### PR TITLE
Add validation when getting a content line from uploaded file

### DIFF
--- a/app/test_engine/models/manual_test_case.py
+++ b/app/test_engine/models/manual_test_case.py
@@ -153,10 +153,11 @@ class ManualLogUploadStep(TestStep, UserPromptSupport):
         logger.info("---- Start of Manual Log ----")
         with file.file as f:
             for line in f:
-                if file.content_type == "application/octet-stream":
+                try:
                     logger.info(line.decode("utf-8").strip())
-                else:
-                    logger.info(line.strip())
+                except UnicodeDecodeError:
+                    logger.warning("WARNING: The following line contained invalid UTF-8. Some content was replaced with: �")
+                    logger.info(line.decode("utf-8", errors='replace').strip())
         logger.info("---- End of Manual Log ----")
 
 

--- a/app/test_engine/models/manual_test_case.py
+++ b/app/test_engine/models/manual_test_case.py
@@ -153,7 +153,10 @@ class ManualLogUploadStep(TestStep, UserPromptSupport):
         logger.info("---- Start of Manual Log ----")
         with file.file as f:
             for line in f:
-                logger.info(line.decode("utf-8").strip())
+                if file.content_type == "application/octet-stream":
+                    logger.info(line.decode("utf-8").strip())
+                else:
+                    logger.info(line.strip())
         logger.info("---- End of Manual Log ----")
 
 


### PR DESCRIPTION
### What changed

Add validation when getting a content line from uploaded file in `app/test_engine/models/manual_test_case.py`.
This is necessary because the uploaded file may contain char that are not decodable to utf-8.

### Related Issue
https://github.com/project-chip/certification-tool/issues/49

### Testing
Unit test 100% passed
<img width="473" alt="Screenshot 2023-10-23 at 15 14 44" src="https://github.com/project-chip/certification-tool-backend/assets/116586593/1bf9d7c9-84a3-4048-ae3a-0a951f40a579">

