### PR TITLE
Fix decommissioning problem for simulated test cases

### DIFF
--- a/app/chip_tool/chip_tool.py
+++ b/app/chip_tool/chip_tool.py
@@ -394,6 +394,12 @@ class ChipTool(metaclass=Singleton):
             container_manager.destroy(self.__chip_tool_container)
         self.__chip_tool_container = None
 
+    async def start_runner(self) -> None:
+        await self.__test_harness_runner.start()
+
+    async def stop_runner(self) -> None:
+        await self.__test_harness_runner.stop()
+
     def send_command(
         self,
         command: Union[str, list],

--- a/app/chip_tool/test_suite.py
+++ b/app/chip_tool/test_suite.py
@@ -159,9 +159,16 @@ class ChipToolSuite(TestSuite, UserPromptSupport):
                 logger.info("Unpairing chip_tool from device")
                 await self.chip_tool.unpair()
             # Need a better way to trigger unpair for chip-app.
+            # Currently the runner is being stopped automatically once
+            # the test completes. So we need to start it again to
+            # perform decommissioning
             elif self.test_type == ChipToolTestType.CHIP_APP:
+                logger.info("Run simulated app instance to perform decommissioning")
+                await self.chip_tool.start_runner()
                 logger.info("Prompt user to perform decommissioning")
                 await self.__prompt_user_to_perform_decommission()
+                logger.info("Stop simulated app instance")
+                await self.chip_tool.stop_runner()
 
         logger.info("Stopping chip-tool container")
         self.chip_tool.destroy_device()


### PR DESCRIPTION
A fix for the following issue:
- https://github.com/project-chip/certification-tool/issues/40

Maybe a permanent solution should involve changes in the runner so that it doesn't stop automatically at every test run. In that case we wouldn't need to start and stop it every time we need to commission or decommission a device, we'd start it at the beginning of a test suite execution and stop it at the cleanup.
Since changes in the runner usually takes longer, we can have this temporary solution for TH now and then migrate to another solution involving the runner changes later.