### PR TITLE
Fix problem with sdk_tests collection using hardcoded paths

### DIFF
--- a/test_collections/sdk_tests/support/paths.py
+++ b/test_collections/sdk_tests/support/paths.py
@@ -1,0 +1,21 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from pathlib import Path
+
+SUPPORT_PATH = Path(__file__).parent
+SDK_TESTS_ROOT = SUPPORT_PATH.parent
+SDK_CHECKOUT_PATH = SDK_TESTS_ROOT / "sdk_checkout"

--- a/test_collections/sdk_tests/support/yaml_tests/models/yaml_test_folder.py
+++ b/test_collections/sdk_tests/support/yaml_tests/models/yaml_test_folder.py
@@ -15,9 +15,11 @@
 #
 from pathlib import Path
 
+from test_collections.sdk_tests.support.paths import SDK_CHECKOUT_PATH
+
 UNKNOWN_version = "Unknown"
 VERSION_FILE_FILENAME = ".version"
-VERSION_FILE_PATH = Path("/app/backend/test_collections/sdk_tests/sdk_checkout/")
+
 
 class YamlTestFolder:
     """Representing a folder with Test YAML files.
@@ -31,9 +33,9 @@ class YamlTestFolder:
         self.version = self.__version()
 
     def __version(self) -> str:
-        """Read version string from .version file in 
+        """Read version string from .version file in
         /app/backend/test_collections/sdk_tests/sdk_checkout path."""
-        version_file_path = VERSION_FILE_PATH / VERSION_FILE_FILENAME
+        version_file_path = SDK_CHECKOUT_PATH / VERSION_FILE_FILENAME
 
         if not version_file_path.exists():
             return UNKNOWN_version

--- a/test_collections/sdk_tests/support/yaml_tests/sdk_yaml_tests.py
+++ b/test_collections/sdk_tests/support/yaml_tests/sdk_yaml_tests.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 from loguru import logger
 
+from test_collections.sdk_tests.support.paths import SDK_CHECKOUT_PATH
+
 from .models.test_declarations import (
     YamlCaseDeclaration,
     YamlCollectionDeclaration,
@@ -38,11 +40,14 @@ from .models.yaml_test_parser import YamlParserException, parse_yaml_test
 #        - Manual
 ###
 
-SDK_YAML_PATH = Path("/app/backend/test_collections/sdk_tests/sdk_checkout/yaml_tests/yaml/sdk")
+YAML_PATH = SDK_CHECKOUT_PATH / "yaml_tests/yaml"
+SDK_YAML_PATH = YAML_PATH / "sdk"
 SDK_YAML_TEST_FOLDER = YamlTestFolder(path=SDK_YAML_PATH, filename_pattern="Test_TC*")
 
-CUSTOM_YAML_PATH = Path("/app/backend/test_collections/sdk_tests/sdk_checkout/yaml_tests/yaml/custom")
-CUSTOM_YAML_TEST_FOLDER = YamlTestFolder(path=CUSTOM_YAML_PATH, filename_pattern="Test_TC*")
+CUSTOM_YAML_PATH = YAML_PATH / "custom"
+CUSTOM_YAML_TEST_FOLDER = YamlTestFolder(
+    path=CUSTOM_YAML_PATH, filename_pattern="Test_TC*"
+)
 
 
 def _init_test_suites(yaml_version: str) -> dict[SuiteType, YamlSuiteDeclaration]:


### PR DESCRIPTION
Since #10 and #14 was merged, we introduced a problem where the SDK tests only worked when running the backend in developer mode.

Specially, the problem stems from the fact that we used `/app/backed` hardcoded paths:
https://github.com/project-chip/certification-tool-backend/pull/10/files#diff-aea3c8e66d486bcaf287e7c19fa77772d3f40ac9733ee99c465657afda4104d5L41

And that only works in dev mode.

This PR changes this back to using relative paths.