### PR TITLE
Set default log level to info, to eliminate chatter from python runner

### DIFF
--- a/app/core/config.py
+++ b/app/core/config.py
@@ -90,7 +90,7 @@ class Settings(BaseSettings):
     # Logging
     LOGGING_PATH: str = "./logs"
     LOGGING_FILENAME: str = "{time:YYYY-MM-DD}.log"
-    LOGGING_LEVEL: str = "debug"
+    LOGGING_LEVEL: str = "info"
     LOGGING_ROTATION: str = "20 days"
     LOGGING_RETENTION: str = "1 months"
     LOGGING_FORMAT: str = (

--- a/app/otbr_manager/otbr_manager.py
+++ b/app/otbr_manager/otbr_manager.py
@@ -142,7 +142,7 @@ class ThreadBorderRouter(metaclass=Singleton):
 
         except (asyncio.exceptions.TimeoutError, ThreadBorderRouterError):
             err_msg = "Border router does not start properly for " + self.__docker_image
-            logger.debug(self.__otbr_docker.logs().decode("utf-8"))
+            logger.warning(self.__otbr_docker.logs().decode("utf-8"))
             logger.error(err_msg)
             self.destroy_device()
             raise ThreadBorderRouterError(err_msg)


### PR DESCRIPTION
This PR will change the default logging level to `info` as the logs get spammed with 1000 of debug lines from the zap xml parsing:

```
DEBUG    | 2023-11-09 19:16:11.606 | matter_idl.zapxml:endElement:75 | ELEMENT END: 'item'
DEBUG    | 2023-11-09 19:16:11.606 | matter_idl.zapxml:startElement:69 | ELEMENT START: 'item' / <xml.sax.xmlreader.AttributesImpl object at 0x7efc75dceef0>
DEBUG    | 2023-11-09 19:16:11.606 | matter_idl.zapxml:endElement:75 | ELEMENT END: 'item'
DEBUG    | 2023-11-09 19:16:11.607 | matter_idl.zapxml:startElement:69 | ELEMENT START: 'item' / <xml.sax.xmlreader.AttributesImpl object at 0x7efc75dceef0>
DEBUG    | 2023-11-09 19:16:11.607 | matter_idl.zapxml:endElement:75 | ELEMENT END: 'item'
DEBUG    | 2023-11-09 19:16:11.607 | matter_idl.zapxml:startElement:69 | ELEMENT START: 'item' / <xml.sax.xmlreader.AttributesImpl object at 0x7efc75dceef0>
DEBUG    | 2023-11-09 19:16:11.607 | matter_idl.zapxml:endElement:75 | ELEMENT END: 'item'
DEBUG    | 2023-11-09 19:16:11.607 | matter_idl.zapxml:startElement:69 | ELEMENT START: 'item' / <xml.sax.xmlreader.AttributesImpl object at 0x7efc75dceef0>
DEBUG    | 2023-11-09 19:16:11.608 | matter_idl.zapxml:endElement:75 | ELEMENT END: 'item'
DEBUG    | 2023-11-09 19:16:11.609 | matter_idl.zapxml:startElement:69 | ELEMENT START: 'item' / <xml.sax.xmlreader.AttributesImpl object at 0x7efc75dceef0>
DEBUG    | 2023-11-09 19:16:11.609 | matter_idl.zapxml:endElement:75 | ELEMENT END: 'item'
DEBUG    | 2023-11-09 19:16:11.609 | matter_idl.zapxml:startElement:69 | ELEMENT START: 'item' / <xml.sax.xmlreader.AttributesImpl object at 0x7efc75dceef0>
DEBUG    | 2023-11-09 19:16:11.611 | matter_idl.zapxml:endElement:75 | ELEMENT END: 'item'
DEBUG    | 2023-11-09 19:16:11.611 | matter_idl.zapxml:startElement:69 | ELEMENT START: 'item' / <xml.sax.xmlreader.AttributesImpl object at 0x7efc75dceef0>
DEBUG    | 2023-11-09 19:16:11.611 | matter_idl.zapxml:endElement:75 | ELEMENT END: 'item'
DEBUG    | 2023-11-09 19:16:11.611 | matter_idl.zapxml:startElement:69 | ELEMENT START: 'item' / <xml.sax.xmlreader.AttributesImpl object at 0x7efc75dceef0>
```