### PR TITLE
Enforced exit code 0 in prestart.sh

### DIFF
--- a/gunicorn/start.sh
+++ b/gunicorn/start.sh
@@ -59,4 +59,5 @@ else
 fi
 
 # Start Gunicorn
+echo "Starting Gunicorn: gunicorn -k \"$WORKER_CLASS\" -c \"$GUNICORN_CONF\" \"$APP_MODULE\""
 exec gunicorn -k "$WORKER_CLASS" -c "$GUNICORN_CONF" "$APP_MODULE"

--- a/prestart.sh
+++ b/prestart.sh
@@ -31,3 +31,6 @@ do
     # Only run prestart.sh if present/
     [ -x $prestart ] && $prestart
 done
+
+echo "Prestart Complete"
+exit 0


### PR DESCRIPTION
This PR will fix the problem below, by ensuring that `prestart.sh` return a zero exit code on successful completion.

**Problem:**

`prestart.sh` will attempt to run `test_collection/<collection_name>/prestart.sh` if that script exists.

This is done by:

```bash
# Run Prestart scripts in test collections
for dir in ./test_collections/*
do
    prestart=$dir/prestart.sh
    # Only run prestart.sh if present/
    [ -x $prestart ] && $prestart
done
```

However, if the script doesn't exist. `[ -x $prestart ]`  will return a non-zero value.
As this is the last step in `prestart.sh` the exit code of `prestart.sh` will be the non-zero value if the last iteration in the for-loop is for a test_collection that doesn't have a prestart script.

This will stop the start.sh to not start the `gunicorn` server.