### PR TITLE
Removed exit 0, as it exits the parent script

### DIFF
--- a/prestart.sh
+++ b/prestart.sh
@@ -32,5 +32,5 @@ do
     [ -x $prestart ] && $prestart
 done
 
+# We echo "complete" to ensure this scripts last command has exit code 0.
 echo "Prestart Complete"
-exit 0


### PR DESCRIPTION
Turned out #26 didn't actually work as the `exit 0` caused the parent script to exit due to this.