### PR TITLE
Fix decommissioning problem in simulated test cases

### DIFF
--- a/app/chip_tool/chip_tool.py
+++ b/app/chip_tool/chip_tool.py
@@ -322,9 +322,10 @@ class ChipTool(metaclass=Singleton):
         return exit_code
 
     async def stop_chip_tool_server(self) -> None:
-        await self.__test_harness_runner.start()
+        await self.start_runner()
         await self.__test_harness_runner._client.send("quit()")
         self.__wait_for_server_exit()
+        self.stop_runner()
         self.__server_started = False
 
     def __get_gateway_ip(self) -> str:
@@ -393,12 +394,15 @@ class ChipTool(metaclass=Singleton):
 
     def destroy_device(self) -> None:
         """Destroy the device container."""
+        self.stop_chip_tool_server()
+
         if self.__chip_tool_container is not None:
             container_manager.destroy(self.__chip_tool_container)
         self.__chip_tool_container = None
 
     async def start_runner(self) -> None:
-        await self.__test_harness_runner.start()
+        if not self.__test_harness_runner.is_connected:
+            await self.__test_harness_runner.start()
 
     async def stop_runner(self) -> None:
         await self.__test_harness_runner.stop()
@@ -470,12 +474,8 @@ class ChipTool(metaclass=Singleton):
         return exit_code
 
     async def send_websocket_command(self, cmd: str) -> Union[str, bytes, bytearray]:
-        response = None
-        try:
-            await self.__test_harness_runner.start()
-            response = await self.__test_harness_runner.execute(cmd)
-        finally:
-            await self.__test_harness_runner.stop()
+        await self.start_runner()
+        response = await self.__test_harness_runner.execute(cmd)
 
         # Log response
         if response:
@@ -523,12 +523,15 @@ class ChipTool(metaclass=Singleton):
         )
         self.__runner_hooks = test_step_interface
         runner_config = TestRunnerConfig(
-            adapter, self.pseudo_clusters, runner_options, test_step_interface
+            adapter,
+            self.pseudo_clusters,
+            runner_options,
+            test_step_interface,
+            auto_start_stop=False,
         )
 
-        web_socket_config = WebSocketRunnerConfig()
-        web_socket_config.server_address = self.__get_gateway_ip()
-        self.__test_harness_runner = WebSocketRunner(config=web_socket_config)
+        await self.start_runner()
+
         return await self.__test_harness_runner.run(
             parser_builder_config, runner_config
         )

--- a/app/chip_tool/test_suite.py
+++ b/app/chip_tool/test_suite.py
@@ -163,12 +163,8 @@ class ChipToolSuite(TestSuite, UserPromptSupport):
             # the test completes. So we need to start it again to
             # perform decommissioning
             elif self.test_type == ChipToolTestType.CHIP_APP:
-                logger.info("Run simulated app instance to perform decommissioning")
-                await self.chip_tool.start_runner()
                 logger.info("Prompt user to perform decommissioning")
                 await self.__prompt_user_to_perform_decommission()
-                logger.info("Stop simulated app instance")
-                await self.chip_tool.stop_runner()
 
         logger.info("Stopping chip-tool container")
         self.chip_tool.destroy_device()

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -115,7 +115,7 @@ class Settings(BaseSettings):
     SDK_DOCKER_IMAGE: str = "connectedhomeip/chip-cert-bins"
     SDK_DOCKER_TAG: str = "f06d9520d02d68076c5accbf839f168cda89c47c"
     # SDK SHA: used to fetch test YAML from SDK.
-    SDK_SHA: str = "f06d9520d02d68076c5accbf839f168cda89c47c"
+    SDK_SHA: str = "4fde331ac902b7349653f069e9da6c933efa1466"
 
     class Config:
         case_sensitive = True


### PR DESCRIPTION
## What changed

- Updated SDK SHA to get the latest runner changes.
- The runner's `start` and `stop` methods are now called one during test suite `setup` and `cleanup`. `stop` is only called after asking the user to decommission.

## Related issue

- https://github.com/project-chip/certification-tool/issues/40

## Testing

Ran one of each SDK YAML test cases and they were all executed as expected. The decommissioning after the simulated test case execution worked.

<img width="2159" alt="Screenshot 2023-11-14 at 14 24 27" src="https://github.com/project-chip/certification-tool-backend/assets/116589288/7e6ace6e-60f8-41de-b48d-002678dee500">

