### PR TITLE
Fix chip test cleanup hanging problem

### DIFF
--- a/app/chip_tool/chip_tool.py
+++ b/app/chip_tool/chip_tool.py
@@ -395,8 +395,6 @@ class ChipTool(metaclass=Singleton):
 
     async def destroy_device(self) -> None:
         """Destroy the device container."""
-        await self.stop_chip_tool_server()
-
         if self.__chip_tool_container is not None:
             container_manager.destroy(self.__chip_tool_container)
         self.__chip_tool_container = None


### PR DESCRIPTION
## Issue

The chip server is not stopping and TH is hanging while waiting for the process to exit.


## Comment

This line had been added recently and I'm reverting it for now, since destroying the container will stop the server anyway. Later, I'll update the stop method to do it in another way that I've found that works.

## Testing

I've run a `CHIP_TOOL` and a `CHIP_APP` test and they both finished the cleanup without hanging.