### PR TITLE
Show python logs at the end of the test execution

### DIFF
--- a/test_collections/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_case.py
@@ -61,7 +61,7 @@ class PythonTestCase(TestCase):
         self.__runned = 0
         self.test_stop_called = False
 
-    # Move to the next step if the test case has additional steps appart from the 2
+    # Move to the next step if the test case has additional steps apart from the 2
     # deafult ones
     def step_over(self) -> None:
         # Python tests that don't follow the template only have the default steps "Start

--- a/test_collections/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_case.py
@@ -62,10 +62,10 @@ class PythonTestCase(TestCase):
         self.test_stop_called = False
 
     def next_step(self) -> None:
-        # Python tests that don't follow the template only have the default step "Start
-        # Python test", but inside the file there can be more than one test case, so the
-        # hooks steps methods will continue to be called
-        if len(self.test_steps) == 1:
+        # Python tests that don't follow the template only have the default steps "Start
+        # Python test" and "Show test logs", but inside the file there can be more than
+        # one test case, so the hooks steps methods will continue to be called
+        if len(self.test_steps) == 2:
             return
 
         super().next_step()
@@ -194,7 +194,8 @@ class PythonTestCase(TestCase):
                 self.__handle_update(update)
 
             # Step: Show test logs
-            self.next_step()
+            # Skip the override because here it should always go to the next step
+            super().next_step()
             logger.info("---- Start of Python test logs ----")
             handle_logs(cast(Generator, exec_result.output), logger)
             logger.info("---- End of Python test logs ----")


### PR DESCRIPTION
## What changed

- Added a test step for all SDK python tests to show the test case logs. We don't get the logs step by step, we only have it as a whole. That's why we're showing it complete at the end of the execution.

## Testing

<img width="2160" alt="Screenshot 2023-12-11 at 15 18 24" src="https://github.com/project-chip/certification-tool-backend/assets/116589288/6a5119f3-542e-49d1-b0e8-b1f4a9169b4b">
