### PR TITLE
Fix python tests error handling

### DIFF
--- a/test_collections/sdk_tests/support/chip_tool/chip_tool.py
+++ b/test_collections/sdk_tests/support/chip_tool/chip_tool.py
@@ -494,6 +494,19 @@ class ChipTool(metaclass=Singleton):
         exit_code = exec_data.get("ExitCode")
         return exit_code
 
+    def exec_exit_code(self, exec_id: str) -> Optional[int]:
+        if self.__chip_tool_container is None:
+            self.logger.info("No SDK container, cannot get execution exit code")
+            return None
+
+        exec_data = self.__chip_tool_container.client.api.exec_inspect(exec_id)
+
+        if exec_data is None:
+            self.logger.error("Docker didn't return any execution metadata")
+            return None
+
+        return exec_data.get("ExitCode")
+
     async def send_websocket_command(self, cmd: str) -> Union[str, bytes, bytearray]:
         await self.start_runner()
         response = await self.__test_harness_runner.execute(cmd)

--- a/test_collections/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_case.py
@@ -93,15 +93,16 @@ class PythonTestCase(TestCase):
         pass
 
     def step_success(self, logger: Any, logs: str, duration: int, request: Any) -> None:
-        # TODO Handle Logs properly
         self.step_over()
 
     def step_failure(
         self, logger: Any, logs: str, duration: int, request: Any, received: Any
     ) -> None:
-        # TODO Handle Logs properly
         self.mark_step_failure("Python test step failure")
-        self.step_over()
+
+        # Python tests stop when there's a failure. We need to skip the next steps
+        # and execute only the last one, which shows the logs
+        self.skip_to_last_step()
 
     def step_unknown(self) -> None:
         self.__runned += 1
@@ -211,6 +212,11 @@ class PythonTestCase(TestCase):
             self.current_test_step.mark_as_completed()
         finally:
             pass
+
+    def skip_to_last_step(self) -> None:
+        self.current_test_step.mark_as_completed()
+        self.current_test_step_index = len(self.test_steps) - 1
+        self.current_test_step.mark_as_executing()
 
     def __handle_update(self, update: SDKPythonTestResultBase) -> None:
         self.__call_function_from_name(update.type.value, update.params_dict())

--- a/test_collections/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_case.py
@@ -100,9 +100,15 @@ class PythonTestCase(TestCase):
     ) -> None:
         self.mark_step_failure("Python test step failure")
 
-        # Python tests stop when there's a failure. We need to skip the next steps
-        # and execute only the last one, which shows the logs
-        self.skip_to_last_step()
+        # Python tests with only 2 steps are the ones that don't follow the template.
+        # In the case of a test file with multiple test cases, more than one of these
+        # tests can fail and so this method will be called for each of them. These
+        # failures should be reported in the first step and moving to the logs step
+        # should only happen after all test cases are executed.
+        if len(self.test_steps) > 2:
+            # Python tests stop when there's a failure. We need to skip the next steps
+            # and execute only the last one, which shows the logs
+            self.skip_to_last_step()
 
     def step_unknown(self) -> None:
         self.__runned += 1

--- a/test_collections/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_suite.py
@@ -32,6 +32,10 @@ class SuiteType(Enum):
     AUTOMATED = 1
 
 
+class DUTCommissioningError(Exception):
+    pass
+
+
 # Custom Type variable used to annotate the factory methods of classmethod.
 T = TypeVar("T", bound="PythonTestSuite")
 
@@ -103,3 +107,6 @@ class PythonTestSuite(TestSuite):
         )
 
         handle_logs(cast(Generator, exec_result.output), logger)
+
+        if exec_result.exit_code != 0:
+            raise DUTCommissioningError("Failed to commission DUT")

--- a/test_collections/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_suite.py
@@ -108,5 +108,7 @@ class PythonTestSuite(TestSuite):
 
         handle_logs(cast(Generator, exec_result.output), logger)
 
-        if exec_result.exit_code != 0:
+        exit_code = self.chip_tool.exec_exit_code(exec_result.exec_id)
+
+        if exit_code:
             raise DUTCommissioningError("Failed to commission DUT")

--- a/test_collections/sdk_tests/support/tests/python_tests/test_python_test_suite.py
+++ b/test_collections/sdk_tests/support/tests/python_tests/test_python_test_suite.py
@@ -25,6 +25,9 @@ from app.schemas import PICS
 from app.test_engine.logger import test_engine_logger
 from app.tests.utils.test_pics_data import create_random_pics
 from test_collections.sdk_tests.support.chip_tool.chip_tool import ChipTool
+from test_collections.sdk_tests.support.chip_tool.exec_run_in_container import (
+    ExecResultExtended,
+)
 from test_collections.sdk_tests.support.python_testing.models.test_suite import (
     PythonTestSuite,
     SuiteType,
@@ -167,6 +170,7 @@ async def test_commission_device() -> None:
     command_args = ["arg1", "arg2", "arg3"]
     expected_command = [f"{RUNNER_CLASS_PATH} commission"]
     expected_command.extend(command_args)
+    mock_result = ExecResultExtended(0, "log output".encode(), "ID", mock.MagicMock())
 
     suite = PythonTestSuite(TestSuiteExecution())
 
@@ -174,7 +178,7 @@ async def test_commission_device() -> None:
         target="test_collections.sdk_tests.support.python_testing.models.test_suite"
         ".PythonTestSuite.config"
     ), mock.patch.object(
-        target=chip_tool, attribute="send_command"
+        target=chip_tool, attribute="send_command", return_value=mock_result
     ) as mock_send_command, mock.patch(
         target="test_collections.sdk_tests.support.python_testing.models.test_suite"
         ".generate_command_arguments",


### PR DESCRIPTION
## What changed

- Started raising an exception if the commissioning fails in the test suite setup.
- Fixed the steps state after a failure happens during a python test. After the failure the test skips most of the following steps and then executes the last one, to show the logs.

## Testing

- Commissioning error is reported and cancels the test suite execution.
<img width="2160" alt="Screenshot 2023-12-12 at 15 23 25" src="https://github.com/project-chip/certification-tool-backend/assets/116589288/03d1b669-217a-4de9-9987-a8781221d276">

- Test case steps' states after a failure.
<img width="2160" alt="Screenshot 2023-12-12 at 15 14 48" src="https://github.com/project-chip/certification-tool-backend/assets/116589288/da2cb147-a5b1-49a8-a565-100adffd4752">
<img width="2160" alt="Screenshot 2023-12-12 at 15 14 57" src="https://github.com/project-chip/certification-tool-backend/assets/116589288/1119c718-af20-4d96-9826-2246bd62aa66">

- Test case that doesn't follow the template with errors on multiple tests
<img width="2160" alt="Screenshot 2023-12-13 at 08 23 05" src="https://github.com/project-chip/certification-tool-backend/assets/116589288/1cf0489b-139c-4112-ae9b-334c97cf7ca1">
