### PR TITLE
Removed checking for valid arguments for python tests execution

### DIFF
--- a/default_test_environment.config
+++ b/default_test_environment.config
@@ -23,7 +23,6 @@
     "pairing_mode":"onnetwork",
     "setup_code":"20202021",
     "discriminator":"3840",
-    "endpoint_id":"0",
     "chip_tool_use_paa_certs":false
   }
 }

--- a/test_collections/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/sdk_tests/support/python_testing/models/utils.py
@@ -22,7 +22,6 @@ import loguru
 
 from app.schemas.test_environment_config import TestEnvironmentConfig
 from app.test_engine.logger import PYTHON_TEST_LEVEL
-from app.test_engine.logger import test_engine_logger as logger
 
 # Command line params
 RUNNER_CLASS_PATH = "/root/python_testing/test_harness_client.py"
@@ -32,31 +31,6 @@ EXECUTABLE = "python3"
 def generate_command_arguments(
     config: TestEnvironmentConfig, omit_commissioning_method: bool = False
 ) -> list:
-    # All valid arguments for python test
-    valid_args = [
-        "ble_interface_id",
-        "commissioning_method",
-        "controller_node_id",
-        "discriminator",
-        "endpoint",
-        "logs_path",
-        "PICS",
-        "paa_trust_store_path",
-        "timeout",
-        "trace_to",
-        "int_arg",
-        "float_arg",
-        "string_arg",
-        "json_arg",
-        "hex_arg",
-        "bool_arg",
-        "storage_path",
-        "passcode",
-        "dut_node_id",
-        "qr_code",
-        "manual_code",
-    ]
-
     dut_config = config.dut_config
     test_parameters = config.test_parameters
 
@@ -76,13 +50,8 @@ def generate_command_arguments(
     # Retrieve arguments from test_parameters
     if test_parameters:
         for name, value in test_parameters.items():
-            if name in valid_args:
-                if str(value) != "":
-                    arguments.append(f"--{name.replace('_','-')} {str(value)}")
-                else:
-                    arguments.append(f"--{name.replace('_','-')} " "")
-            else:
-                logger.warning(f"Argument {name} is not valid")
+            arg_value = str(value) if str(value) != "" else " "
+            arguments.append(f"--{name} {str(arg_value)}")
 
     return arguments
 

--- a/test_collections/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/sdk_tests/support/python_testing/models/utils.py
@@ -50,8 +50,7 @@ def generate_command_arguments(
     # Retrieve arguments from test_parameters
     if test_parameters:
         for name, value in test_parameters.items():
-            arg_value = str(value) if str(value) != "" else ""
-            arguments.append(f"--{name} {str(arg_value)}")
+            arguments.append(f"--{name} {str(value)}")
 
     return arguments
 

--- a/test_collections/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/sdk_tests/support/python_testing/models/utils.py
@@ -50,7 +50,8 @@ def generate_command_arguments(
     # Retrieve arguments from test_parameters
     if test_parameters:
         for name, value in test_parameters.items():
-            arguments.append(f"--{name} {str(value)}")
+            arg_value = str(value) if value is not None else ""
+            arguments.append(f"--{name} {arg_value}")
 
     return arguments
 

--- a/test_collections/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/sdk_tests/support/python_testing/models/utils.py
@@ -50,7 +50,7 @@ def generate_command_arguments(
     # Retrieve arguments from test_parameters
     if test_parameters:
         for name, value in test_parameters.items():
-            arg_value = str(value) if str(value) != "" else " "
+            arg_value = str(value) if str(value) != "" else ""
             arguments.append(f"--{name} {str(arg_value)}")
 
     return arguments

--- a/test_collections/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/sdk_tests/support/tests/python_tests/test_utils.py
@@ -27,6 +27,8 @@ async def test_generate_command_arguments_on_network() -> None:
     # Mock config
     mock_config = default_environment_config.copy(deep=True)
 
+    # Using attributes with both - and _ word separators in test_parameters
+    # Both must be considered as python test arguments the way it was configured
     mock_config.test_parameters = {
         "paa-trust-store-path": "/paa-root-certs",
         "storage_path": "/root/admin_storage.json",

--- a/test_collections/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/sdk_tests/support/tests/python_tests/test_utils.py
@@ -28,7 +28,7 @@ async def test_generate_command_arguments_on_network() -> None:
     mock_config = default_environment_config.copy(deep=True)
 
     mock_config.test_parameters = {
-        "paa_trust_store_path": "/paa-root-certs",
+        "paa-trust-store-path": "/paa-root-certs",
         "storage_path": "/root/admin_storage.json",
     }
 
@@ -49,7 +49,7 @@ async def test_generate_command_arguments_on_network() -> None:
         "--passcode 1234",
         "--commissioning-method on-network",
         "--paa-trust-store-path /paa-root-certs",
-        "--storage-path /root/admin_storage.json",
+        "--storage_path /root/admin_storage.json",
     ] == arguments
 
 
@@ -59,7 +59,7 @@ async def test_generate_command_arguments_ble_wifi() -> None:
     mock_config = default_environment_config.copy(deep=True)
 
     mock_config.test_parameters = {
-        "paa_trust_store_path": "/paa-root-certs",
+        "paa-trust-store-path": "/paa-root-certs",
         "storage_path": "/root/admin_storage.json",
     }
 
@@ -80,7 +80,7 @@ async def test_generate_command_arguments_ble_wifi() -> None:
         "--passcode 357",
         "--commissioning-method ble-wifi",
         "--paa-trust-store-path /paa-root-certs",
-        "--storage-path /root/admin_storage.json",
+        "--storage_path /root/admin_storage.json",
     ] == arguments
 
 
@@ -90,7 +90,7 @@ async def test_generate_command_arguments_ble_thread() -> None:
     mock_config = default_environment_config.copy(deep=True)
 
     mock_config.test_parameters = {
-        "paa_trust_store_path": "/paa-root-certs",
+        "paa-trust-store-path": "/paa-root-certs",
         "storage_path": "/root/admin_storage.json",
     }
 
@@ -110,7 +110,7 @@ async def test_generate_command_arguments_ble_thread() -> None:
         "--passcode 8765",
         "--commissioning-method ble-thread",
         "--paa-trust-store-path /paa-root-certs",
-        "--storage-path /root/admin_storage.json",
+        "--storage_path /root/admin_storage.json",
     ] == arguments
 
 

--- a/test_collections/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/sdk_tests/support/tests/python_tests/test_utils.py
@@ -23,6 +23,33 @@ from test_collections.sdk_tests.support.python_testing.models.utils import (
 
 
 @pytest.mark.asyncio
+async def test_generate_command_arguments_with_null_value_attribute() -> None:
+    # Mock config
+    mock_config = default_environment_config.copy(deep=True)
+
+    mock_config.test_parameters = {"test-argument": None}
+
+    mock_dut_config = DutConfig(
+        discriminator="123",
+        setup_code="1234",
+        pairing_mode=DutPairingModeEnum.ON_NETWORK,
+    )
+
+    mock_config.dut_config = mock_dut_config
+
+    arguments = generate_command_arguments(
+        config=mock_config, omit_commissioning_method=False
+    )
+
+    assert [
+        "--discriminator 123",
+        "--passcode 1234",
+        "--commissioning-method on-network",
+        "--test-argument ",
+    ] == arguments
+
+
+@pytest.mark.asyncio
 async def test_generate_command_arguments_on_network() -> None:
     # Mock config
     mock_config = default_environment_config.copy(deep=True)


### PR DESCRIPTION
## What changed
- Removed the checking for valid arguments when running python tests. We intend to remove any dependency regarding python arguments between TH and SDK. If any parameter in Python test were added in SDK we would have to update the valid args list in TH backend code.

- Removed `endpoint_id` attribute in `default_test_environment.config` because this parameter is no longer defined in the pydantic model and must be defined in test_parameter when necessary.
## Testing

- The way the arguments is defined in Project Config it will be used while running Python tests.

![Screenshot 2023-12-13 at 10 44 54](https://github.com/project-chip/certification-tool-backend/assets/116586593/0cde0d94-5558-4bcb-a5fb-af400e680f4b)

![Screenshot 2023-12-13 at 11 11 01](https://github.com/project-chip/certification-tool-backend/assets/116586593/2d2ad4a3-f306-4e74-a3ea-c9db5b4ae79b)

- Unit Testing updated and running
<img width="530" alt="Screenshot 2023-12-13 at 10 56 19" src="https://github.com/project-chip/certification-tool-backend/assets/116586593/a110d076-3c9b-4ad8-808a-5c4eadda917a">
