### PR TITLE
Support multi-test scripts

### DIFF
--- a/test_collections/sdk_tests/support/python_testing/models/python_test_models.py
+++ b/test_collections/sdk_tests/support/python_testing/models/python_test_models.py
@@ -24,6 +24,7 @@ from ...models.matter_test_models import MatterTest, MatterTestType
 
 class PythonTest(MatterTest):
     description: str
+    class_name: str
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/test_collections/sdk_tests/support/python_testing/models/python_test_parser.py
+++ b/test_collections/sdk_tests/support/python_testing/models/python_test_parser.py
@@ -58,13 +58,13 @@ def parse_python_script(path: Path) -> list[PythonTest]:
 
     test_classes = __test_classes(parsed_python_file)
 
+    test_cases: list[PythonTest] = []
     for c in test_classes:
         test_methods = __test_methods(c)
         test_names = __test_case_names(test_methods)
 
-        test_cases: list[PythonTest] = []
         for test_name in test_names:
-            test_cases.append(__parse_test_case(test_name, test_methods, path))
+            test_cases.append(__parse_test_case(test_name, test_methods, c.name, path))
 
     return test_cases
 
@@ -135,7 +135,7 @@ def __test_case_names(methods: list[FunctionDefType]) -> list[str]:
 
 
 def __parse_test_case(
-    tc_name: str, methods: list[FunctionDefType], path: Path
+    tc_name: str, methods: list[FunctionDefType], class_name: str, path: Path
 ) -> PythonTest:
     # Currently config is not configured in Python Testing
     tc_config: dict = {}
@@ -171,6 +171,7 @@ def __parse_test_case(
         PICS=tc_pics,
         path=path,
         type=MatterTestType.AUTOMATED,
+        class_name=class_name,
     )
 
 

--- a/test_collections/sdk_tests/support/python_testing/models/python_test_parser.py
+++ b/test_collections/sdk_tests/support/python_testing/models/python_test_parser.py
@@ -43,7 +43,7 @@ def parse_python_script(path: Path) -> list[PythonTest]:
     This method will search the file for classes that inherit from MatterBaseTest and
     then look for methods with the following patterns to extract the needed information:
      * test_[test_name] - (required) This method contains the test logic
-     * desc_[test_name] - (optional) This method should return a string with the test
+     * desc_[test_name] - (required) This method should return a string with the test
         description
      * pics_[test_name] - (optional) This method should return a list of strings with
         the PICS required for the test case

--- a/test_collections/sdk_tests/support/python_testing/models/python_test_parser.py
+++ b/test_collections/sdk_tests/support/python_testing/models/python_test_parser.py
@@ -90,7 +90,7 @@ def __test_classes(module: ast.Module) -> list[ast.ClassDef]:
 
 
 def __test_methods(class_def: ast.ClassDef) -> list[FunctionDefType]:
-    """Find methods in the given class that match the pattern "[\S]+_TC_[\S]+".
+    """Find methods in the given class that match the pattern "[\\S]+_TC_[\\S]+".
     These are the methods that are relevant to the parsing.
 
     Args:
@@ -115,7 +115,7 @@ def __test_methods(class_def: ast.ClassDef) -> list[FunctionDefType]:
 
 
 def __test_case_names(methods: list[FunctionDefType]) -> list[str]:
-    """Extract test case names from methods that match the pattern "test_TC_[\S]+".
+    """Extract test case names from methods that match the pattern "test_TC_[\\S]+".
 
     Args:
         methods (list[FunctionDefType]): List of methods to search from.

--- a/test_collections/sdk_tests/support/python_testing/models/python_test_parser.py
+++ b/test_collections/sdk_tests/support/python_testing/models/python_test_parser.py
@@ -14,8 +14,9 @@
 # limitations under the License.
 #
 import ast
+import re
 from pathlib import Path
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from test_collections.sdk_tests.support.models.matter_test_models import (
     MatterTestStep,
@@ -28,42 +29,113 @@ ARG_STEP_DESCRIPTION_INDEX = 1
 KEYWORD_IS_COMISSIONING_INDEX = 0
 BODY_INDEX = 0
 
+TC_FUNCTION_PATTERN = re.compile(r"[\S]+_TC_[\S]+")
+TC_TEST_FUNCTION_PATTERN = re.compile(r"test_(?P<title>TC_[\S]+)")
 
-class PythonParserException(Exception):
-    """Raised when an error occurs during the parser of python file."""
+FunctionDefType = Union[ast.FunctionDef, ast.AsyncFunctionDef]
 
 
-def parse_python_test(path: Path) -> PythonTest:
-    """Parse a single Python test file into PythonTest model.
+def parse_python_script(path: Path) -> list[PythonTest]:
+    """Parse a python file into a list of PythonTest models.
 
-    This will also annotate parsed python test with it's path and test type.
+    This will also annotate parsed python tests with their file path and test type.
 
-    It's expected that the python script files has a class with the same file name,
-    and also the following methods:
-     * desc_[class_name] - This method should return a str with the test description
-     * pics_[class_name] - This method should return a list with the PICS required
-        for the test case
-     * steps_[class_name] - This method should return a list with the step description
-     * test_[class_name] -  This method contains the test logic
+    This method will search the file for classes that inherit from MatterBaseTest and
+    then look for methods with the following patterns to extract the needed information:
+     * test_[test_name] - (required) This method contains the test logic
+     * desc_[test_name] - (optional) This method should return a string with the test
+        description
+     * pics_[test_name] - (optional) This method should return a list of strings with
+        the PICS required for the test case
+     * steps_[test_name] - (optional) This method should return a list with the steps'
+        descriptions
 
-    Example: file TC_ACE_1_3.py must have the methods desc_TC_ACE_1_3, pics_TC_ACE_1_3,
-        steps_TC_ACE_1_3 and test_TC_ACE_1_3.
+    Example: file TC_ACE_1_3.py has the methods test_TC_ACE_1_3, desc_TC_ACE_1_3,
+        pics_TC_ACE_1_3 and steps_TC_ACE_1_3.
     """
     with open(path, "r") as python_file:
         parsed_python_file = ast.parse(python_file.read())
-        classes = [c for c in parsed_python_file.body if isinstance(c, ast.ClassDef)]
 
-    tc_name = path.name.split(".")[0]
-    try:
-        class_ = next(c for c in classes if tc_name in c.name)
-    except StopIteration as si:  # Raised when `next` doesn't find a matching method
-        raise PythonParserException(f"{path} must have a class named {tc_name}") from si
+    test_classes = __test_classes(parsed_python_file)
 
-    return __parse_test_case_from_class(class_=class_, path=path, tc_name=tc_name)
+    for c in test_classes:
+        test_methods = __test_methods(c)
+        test_names = __test_case_names(test_methods)
+
+        test_cases: list[PythonTest] = []
+        for test_name in test_names:
+            test_cases.append(__parse_test_case(test_name, test_methods, path))
+
+    return test_cases
 
 
-def __parse_test_case_from_class(
-    class_: ast.ClassDef, path: Path, tc_name: str
+def __test_classes(module: ast.Module) -> list[ast.ClassDef]:
+    """Find classes that inherit from MatterBaseTest.
+
+    Args:
+        module (ast.Module): Python module.
+
+    Returns:
+        list[ast.ClassDef]: List of classes from the given module that inherit from
+        MatterBaseTest.
+    """
+    return [
+        c
+        for c in module.body
+        if isinstance(c, ast.ClassDef)
+        and any(
+            b for b in c.bases if isinstance(b, ast.Name) and b.id == "MatterBaseTest"
+        )
+    ]
+
+
+def __test_methods(class_def: ast.ClassDef) -> list[FunctionDefType]:
+    """Find methods in the given class that match the pattern "[\S]+_TC_[\S]+".
+    These are the methods that are relevant to the parsing.
+
+    Args:
+        classes (ast.ClassDef): Class where the methods will be searched for.
+
+    Returns:
+        list[FunctionDefType]: List of methods that are relevant to the parsing.
+    """
+    all_methods: list[FunctionDefType] = []
+
+    methods = [
+        m
+        for m in class_def.body
+        if isinstance(m, ast.FunctionDef) or isinstance(m, ast.AsyncFunctionDef)
+    ]
+    for m in methods:
+        if isinstance(m.name, str):
+            if re.match(TC_FUNCTION_PATTERN, m.name):
+                all_methods.append(m)
+
+    return all_methods
+
+
+def __test_case_names(methods: list[FunctionDefType]) -> list[str]:
+    """Extract test case names from methods that match the pattern "test_TC_[\S]+".
+
+    Args:
+        methods (list[FunctionDefType]): List of methods to search from.
+
+    Returns:
+        list[str]: List of test case names.
+    """
+    test_names: list[str] = []
+
+    for m in methods:
+        if isinstance(m.name, str):
+            if match := re.match(TC_TEST_FUNCTION_PATTERN, m.name):
+                if name := match["title"]:
+                    test_names.append(name)
+
+    return test_names
+
+
+def __parse_test_case(
+    tc_name: str, methods: list[FunctionDefType], path: Path
 ) -> PythonTest:
     # Currently config is not configured in Python Testing
     tc_config: dict = {}
@@ -71,8 +143,6 @@ def __parse_test_case_from_class(
     desc_method_name = "desc_" + tc_name
     steps_method_name = "steps_" + tc_name
     pics_method_name = "pics_" + tc_name
-
-    methods = [m for m in class_.body if isinstance(m, ast.FunctionDef)]
 
     tc_desc = tc_name
     tc_steps = []
@@ -105,12 +175,12 @@ def __parse_test_case_from_class(
 
 
 def __get_method_by_name(
-    name: str, methods: list[ast.FunctionDef]
-) -> Optional[ast.FunctionDef]:
+    name: str, methods: list[FunctionDefType]
+) -> Optional[FunctionDefType]:
     return next((m for m in methods if name in m.name), None)
 
 
-def __retrieve_steps(method: ast.FunctionDef) -> List[MatterTestStep]:
+def __retrieve_steps(method: FunctionDefType) -> List[MatterTestStep]:
     python_steps: List[MatterTestStep] = []
     for step in method.body[BODY_INDEX].value.elts:  # type: ignore
         step_name = step.args[ARG_STEP_DESCRIPTION_INDEX].value
@@ -130,7 +200,7 @@ def __retrieve_steps(method: ast.FunctionDef) -> List[MatterTestStep]:
     return python_steps
 
 
-def __retrieve_pics(method: ast.FunctionDef) -> list:
+def __retrieve_pics(method: FunctionDefType) -> list:
     python_steps: list = []
     for step in method.body[BODY_INDEX].value.elts:  # type: ignore
         python_steps.append(step.value)

--- a/test_collections/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
+++ b/test_collections/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
@@ -43,12 +43,12 @@ def main() -> None:
     if sys.argv[1] == "commission":
         commission(config)
     else:
-        run_test(script_name=sys.argv[1], config=config)
+        run_test(script_name=sys.argv[1], class_name=sys.argv[2], config=config)
 
 
-def run_test(script_name: str, config: MatterTestConfig) -> None:
+def run_test(script_name: str, class_name: str, config: MatterTestConfig) -> None:
     module = importlib.import_module(script_name)
-    TestClassReference = getattr(module, script_name)
+    TestClassReference = getattr(module, class_name)
 
     BaseManager.register(TestRunnerHooks.__name__)
     manager = BaseManager(address=("0.0.0.0", 50000), authkey=b"abc")

--- a/test_collections/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
+++ b/test_collections/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
@@ -43,12 +43,12 @@ def main() -> None:
     if sys.argv[1] == "commission":
         commission(config)
     else:
-        run_test(test_name=sys.argv[1], config=config)
+        run_test(script_name=sys.argv[1], config=config)
 
 
-def run_test(test_name: str, config: MatterTestConfig) -> None:
-    module = importlib.import_module(test_name)
-    TestClassReference = getattr(module, test_name)
+def run_test(script_name: str, config: MatterTestConfig) -> None:
+    module = importlib.import_module(script_name)
+    TestClassReference = getattr(module, script_name)
 
     BaseManager.register(TestRunnerHooks.__name__)
     manager = BaseManager(address=("0.0.0.0", 50000), authkey=b"abc")

--- a/test_collections/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_case.py
@@ -150,7 +150,7 @@ class PythonTestCase(TestCase):
 
     @staticmethod
     def __title(identifier: str) -> str:
-        """Retrieve the test title in format TC_ABC_1_2"""
+        """Retrieve the test title in format TC-ABC-1.2"""
         title: str = ""
         elements = identifier.split("_")
 
@@ -182,8 +182,8 @@ class PythonTestCase(TestCase):
                 )
 
             command = [
-                f"{RUNNER_CLASS_PATH} {self.python_test.path.stem} --tests"
-                f" test_{self.python_test.name}"
+                f"{RUNNER_CLASS_PATH} {self.python_test.path.stem}"
+                f" {self.python_test.class_name} --tests test_{self.python_test.name}"
             ]
 
             # Generate the command argument by getting the test_parameters from

--- a/test_collections/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_case.py
@@ -42,6 +42,10 @@ from .utils import (
 T = TypeVar("T", bound="PythonTestCase")
 
 
+class PythonTestCaseError(Exception):
+    pass
+
+
 class PythonTestCase(TestCase):
     """Base class for all Python Test based test cases.
 
@@ -172,7 +176,15 @@ class PythonTestCase(TestCase):
             manager.start()
             test_runner_hooks = manager.TestRunnerHooks()  # type: ignore
 
-            command = [f"{RUNNER_CLASS_PATH} {self.python_test.name}"]
+            if not self.python_test.path:
+                raise PythonTestCaseError(
+                    f"Missing file path for python test {self.python_test.name}"
+                )
+
+            command = [
+                f"{RUNNER_CLASS_PATH} {self.python_test.path.stem} --tests"
+                f" test_{self.python_test.name}"
+            ]
 
             # Generate the command argument by getting the test_parameters from
             # project configuration

--- a/test_collections/sdk_tests/support/python_testing/sdk_python_tests.py
+++ b/test_collections/sdk_tests/support/python_testing/sdk_python_tests.py
@@ -15,12 +15,10 @@
 #
 from pathlib import Path
 
-from loguru import logger
-
 from test_collections.sdk_tests.support.models.sdk_test_folder import SDKTestFolder
 from test_collections.sdk_tests.support.paths import SDK_CHECKOUT_PATH
 
-from .models.python_test_parser import PythonParserException, parse_python_test
+from .models.python_test_parser import parse_python_script
 from .models.test_declarations import (
     PythonCaseDeclaration,
     PythonCollectionDeclaration,
@@ -56,13 +54,15 @@ def _init_test_suites(
     }
 
 
-def _parse_python_test_to_test_case_declaration(
+def _parse_python_script_to_test_case_declarations(
     python_test_path: Path, python_test_version: str
-) -> PythonCaseDeclaration:
-    python_test = parse_python_test(python_test_path)
-    return PythonCaseDeclaration(
-        test=python_test, python_test_version=python_test_version
-    )
+) -> list[PythonCaseDeclaration]:
+    python_tests = parse_python_script(python_test_path)
+
+    return [
+        PythonCaseDeclaration(test=python_test, python_test_version=python_test_version)
+        for python_test in python_tests
+    ]
 
 
 def _parse_all_sdk_python_tests(
@@ -72,19 +72,13 @@ def _parse_all_sdk_python_tests(
     suites = _init_test_suites(python_test_version)
 
     for python_test_file in python_test_files:
-        try:
-            test_case = _parse_python_test_to_test_case_declaration(
-                python_test_path=python_test_file,
-                python_test_version=python_test_version,
-            )
+        test_cases = _parse_python_script_to_test_case_declarations(
+            python_test_path=python_test_file,
+            python_test_version=python_test_version,
+        )
 
+        for test_case in test_cases:
             suites[SuiteType.AUTOMATED].add_test_case(test_case)
-        except PythonParserException as e:
-            # If an exception was raised during parse process, the python file will be
-            # ignored and the loop will continue with the next file
-            logger.error(
-                f"Error while parsing Python File: {python_test_file} \nError:{e}"
-            )
 
     return list(suites.values())
 

--- a/test_collections/sdk_tests/support/tests/python_tests/test_python_parser.py
+++ b/test_collections/sdk_tests/support/tests/python_tests/test_python_parser.py
@@ -44,7 +44,7 @@ class TC_Sample(MatterBaseTest):
 
 """
 
-sample_multi_tests_python_file_content = """
+sample_multi_tests_single_class_python_file_content = """
 class TC_CommonSample(MatterBaseTest):
 
     def steps_TC_Sample_1_1(self) -> list[TestStep]:
@@ -62,6 +62,36 @@ class TC_CommonSample(MatterBaseTest):
         print("Test execution")
 
     def test_TC_Sample_1_2(self):
+        print("Test execution")
+
+"""
+
+sample_multi_tests_multi_classes_python_file_content = """
+class TC_CommonSample(MatterBaseTest):
+
+    def steps_TC_Sample_1_1(self) -> list[TestStep]:
+        steps = [
+            TestStep(1, "Commissioning, already done", is_commissioning=True),
+            TestStep(2, "Second step"),
+            TestStep(3, "Third step"),
+        ]
+        return steps
+
+    def test_TC_ABC_1_1(self):
+        print("Test execution")
+
+    def test_TC_Sample_1_1(self):
+        print("Test execution")
+
+    def test_TC_Sample_1_2(self):
+        print("Test execution")
+
+class TC_CommonSample_2(MatterBaseTest):
+
+    def test_TC_ABC_1_2(self):
+        print("Test execution")
+
+    def test_TC_DEF_1_3(self):
         print("Test execution")
 
 """
@@ -89,7 +119,7 @@ def test_single_test_python_file_parser() -> None:
     assert len(tests[0].PICS) is 1
 
 
-def test_multi_tests_python_file_parser() -> None:
+def test_multi_tests_single_class_python_file_parser() -> None:
     file_path = Path("/test/TC_Sample.py")
 
     # We mock builtin `open` method to read sample python file content,
@@ -97,7 +127,9 @@ def test_multi_tests_python_file_parser() -> None:
     with mock.patch(
         "test_collections.sdk_tests.support.python_testing.models.python_test_parser."
         "open",
-        new=mock.mock_open(read_data=sample_multi_tests_python_file_content),
+        new=mock.mock_open(
+            read_data=sample_multi_tests_single_class_python_file_content
+        ),
     ) as file_open:
         tests = parse_python_script(file_path)
 
@@ -109,3 +141,29 @@ def test_multi_tests_python_file_parser() -> None:
     assert "TC_ABC_1_1" in test_names
     assert "TC_Sample_1_1" in test_names
     assert "TC_Sample_1_2" in test_names
+
+
+def test_multi_tests_multi_classes_python_file_parser() -> None:
+    file_path = Path("/test/TC_Sample.py")
+
+    # We mock builtin `open` method to read sample python file content,
+    # to avoid having to load a real file.
+    with mock.patch(
+        "test_collections.sdk_tests.support.python_testing.models.python_test_parser."
+        "open",
+        new=mock.mock_open(
+            read_data=sample_multi_tests_multi_classes_python_file_content
+        ),
+    ) as file_open:
+        tests = parse_python_script(file_path)
+
+    file_open.assert_called_once_with(file_path, "r")
+
+    assert len(tests) is 5
+    assert all(test.path == file_path for test in tests)
+    test_names = [test.name for test in tests]
+    assert "TC_ABC_1_1" in test_names
+    assert "TC_Sample_1_1" in test_names
+    assert "TC_Sample_1_2" in test_names
+    assert "TC_ABC_1_2" in test_names
+    assert "TC_DEF_1_3" in test_names

--- a/test_collections/sdk_tests/support/tests/python_tests/test_python_test_case.py
+++ b/test_collections/sdk_tests/support/tests/python_tests/test_python_test_case.py
@@ -45,6 +45,7 @@ def python_test_instance(
     steps: list[MatterTestStep] = [],
     type: MatterTestType = MatterTestType.AUTOMATED,
     path: Optional[Path] = None,
+    class_name: str = "TC_Test_Python",
 ) -> PythonTest:
     return PythonTest(
         name=name,
@@ -54,6 +55,7 @@ def python_test_instance(
         type=type,
         path=path,
         description=description,
+        class_name=class_name,
     )
 
 

--- a/test_collections/sdk_tests/support/tests/python_tests/test_python_test_declarations.py
+++ b/test_collections/sdk_tests/support/tests/python_tests/test_python_test_declarations.py
@@ -48,7 +48,11 @@ def test_python_suite_declaration() -> None:
 
 def test_python_case_declaration() -> None:
     test = PythonTest(
-        name="TestTest", description="TestTest description", config={}, steps=[]
+        name="TestTest",
+        description="TestTest description",
+        config={},
+        steps=[],
+        class_name="TC_TestTest",
     )
     version = "SomeVersionStr"
     with mock.patch(


### PR DESCRIPTION
## What changed

- Modified the python tests parser to separate each test case from a single python script. They are now shown individually in the UI and can be run separately.

## Testing

- I modified a python script to follow the template and provide the test steps for the tests contained in the file.
<img width="2048" alt="Screenshot 2023-12-19 at 08 38 26" src="https://github.com/project-chip/certification-tool-backend/assets/116589288/54b2359d-6b05-411c-a4c7-bd1c40114e61">

- I ran the test cases in debug mode and manually performed a factory reset between each test execution to be able to pass most of these tests (a fix for this will be developed soon).
<img width="2160" alt="Screenshot 2023-12-19 at 09 49 50" src="https://github.com/project-chip/certification-tool-backend/assets/116589288/c9ef9177-ac46-49e7-90c0-ba7185c816ce">
