### PR TITLE
Separate SDK Python tests in 3 suites and support running multiple suites/collections in one run

### DIFF
--- a/test_collections/sdk_tests/support/models/matter_test_models.py
+++ b/test_collections/sdk_tests/support/models/matter_test_models.py
@@ -38,6 +38,7 @@ class MatterTestStep(BaseModel):
     command: Optional[str]
     disabled: bool = False
     arguments: Optional[dict[str, Any]]
+    is_commissioning: bool = False
 
 
 class MatterTest(BaseModel):

--- a/test_collections/sdk_tests/support/python_testing/models/python_test_models.py
+++ b/test_collections/sdk_tests/support/python_testing/models/python_test_models.py
@@ -24,6 +24,10 @@ from ...models.matter_test_models import MatterTest, MatterTestType
 
 
 class PythonTestType(Enum):
+    # - PythonTestType.COMMISSIONING: test cases that have a commissioning first step
+    # - PythonTestType.NO_COMMISSIONING: test cases that follow the expected template
+    #   but don't have a commissioning first step
+    # - PythonTestType.LEGACY: test cases that don't follow the expected template
     COMMISSIONING = 1
     NO_COMMISSIONING = 2
     LEGACY = 3

--- a/test_collections/sdk_tests/support/python_testing/models/python_test_models.py
+++ b/test_collections/sdk_tests/support/python_testing/models/python_test_models.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from enum import Enum
 from typing import Any
 
 from ...models.matter_test_models import MatterTest, MatterTestType
@@ -22,9 +23,16 @@ from ...models.matter_test_models import MatterTest, MatterTestType
 ###
 
 
+class PythonTestType(Enum):
+    COMMISSIONING = 1
+    NO_COMMISSIONING = 2
+    LEGACY = 3
+
+
 class PythonTest(MatterTest):
     description: str
     class_name: str
+    python_type: PythonTestType
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/test_collections/sdk_tests/support/python_testing/models/python_test_models.py
+++ b/test_collections/sdk_tests/support/python_testing/models/python_test_models.py
@@ -32,7 +32,7 @@ class PythonTestType(Enum):
 class PythonTest(MatterTest):
     description: str
     class_name: str
-    python_type: PythonTestType
+    python_test_type: PythonTestType
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)

--- a/test_collections/sdk_tests/support/python_testing/models/python_test_parser.py
+++ b/test_collections/sdk_tests/support/python_testing/models/python_test_parser.py
@@ -23,7 +23,7 @@ from test_collections.sdk_tests.support.models.matter_test_models import (
     MatterTestType,
 )
 
-from .python_test_models import PythonTest
+from .python_test_models import PythonTest, PythonTestType
 
 ARG_STEP_DESCRIPTION_INDEX = 1
 KEYWORD_IS_COMISSIONING_INDEX = 0
@@ -163,6 +163,18 @@ def __parse_test_case(
     if pics_method:
         tc_pics = __retrieve_pics(pics_method)
 
+    # - PythonTestType.COMMISSIONING: test cases that have a commissioning first step
+    # - PythonTestType.NO_COMMISSIONING: test cases that follow the expected template
+    #   but don't have a commissioning first step
+    # - PythonTestType.LEGACY: test cases that don't follow the expected template
+    # We use the desc_[test_name] method as an indicator that the test case follows the
+    # expected template
+    python_type = PythonTestType.LEGACY
+    if len(tc_steps) > 0 and tc_steps[0].is_commissioning:
+        python_type = PythonTestType.COMMISSIONING
+    elif desc_method:
+        python_type = PythonTestType.NO_COMMISSIONING
+
     return PythonTest(
         name=tc_name,
         description=tc_desc,
@@ -172,6 +184,7 @@ def __parse_test_case(
         path=path,
         type=MatterTestType.AUTOMATED,
         class_name=class_name,
+        python_type=python_type,
     )
 
 

--- a/test_collections/sdk_tests/support/python_testing/models/python_test_parser.py
+++ b/test_collections/sdk_tests/support/python_testing/models/python_test_parser.py
@@ -169,11 +169,11 @@ def __parse_test_case(
     # - PythonTestType.LEGACY: test cases that don't follow the expected template
     # We use the desc_[test_name] method as an indicator that the test case follows the
     # expected template
-    python_type = PythonTestType.LEGACY
+    python_test_type = PythonTestType.LEGACY
     if len(tc_steps) > 0 and tc_steps[0].is_commissioning:
-        python_type = PythonTestType.COMMISSIONING
+        python_test_type = PythonTestType.COMMISSIONING
     elif desc_method:
-        python_type = PythonTestType.NO_COMMISSIONING
+        python_test_type = PythonTestType.NO_COMMISSIONING
 
     return PythonTest(
         name=tc_name,
@@ -184,7 +184,7 @@ def __parse_test_case(
         path=path,
         type=MatterTestType.AUTOMATED,
         class_name=class_name,
-        python_type=python_type,
+        python_test_type=python_test_type,
     )
 
 

--- a/test_collections/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_case.py
@@ -15,18 +15,22 @@
 #
 import re
 from asyncio import sleep
+from enum import IntEnum
 from multiprocessing.managers import BaseManager
 from typing import Any, Generator, Type, TypeVar, cast
 
 from app.models import TestCaseExecution
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestCase, TestStep
+from app.user_prompt_support.prompt_request import OptionsSelectPromptRequest
+from app.user_prompt_support.user_prompt_support import UserPromptSupport
 from test_collections.sdk_tests.support.chip_tool.chip_tool import (
     PICS_FILE_PATH,
     ChipTool,
 )
+from test_collections.sdk_tests.support.utils import prompt_for_commissioning_mode
 
-from .python_test_models import PythonTest
+from .python_test_models import PythonTest, PythonTestType
 from .python_testing_hooks_proxy import (
     SDKPythonTestResultBase,
     SDKPythonTestRunnerHooks,
@@ -34,9 +38,16 @@ from .python_testing_hooks_proxy import (
 from .utils import (
     EXECUTABLE,
     RUNNER_CLASS_PATH,
+    commission_device,
     generate_command_arguments,
     handle_logs,
 )
+
+
+class PromptOption(IntEnum):
+    YES = 1
+    NO = 2
+
 
 # Custom type variable used to annotate the factory method in PythonTestCase.
 T = TypeVar("T", bound="PythonTestCase")
@@ -46,7 +57,7 @@ class PythonTestCaseError(Exception):
     pass
 
 
-class PythonTestCase(TestCase):
+class PythonTestCase(TestCase, UserPromptSupport):
     """Base class for all Python Test based test cases.
 
     This class provides a class factory that will dynamically declare a new sub-class
@@ -124,6 +135,22 @@ class PythonTestCase(TestCase):
 
     @classmethod
     def class_factory(cls, test: PythonTest, python_test_version: str) -> Type[T]:
+        """Dynamically declares a subclass based on the type of Python test."""
+        case_class: Type[PythonTestCase]
+
+        if test.python_type == PythonTestType.NO_COMMISSIONING:
+            case_class = NoCommissioningPythonTestCase
+        elif test.python_type == PythonTestType.LEGACY:
+            case_class = LegacyPythonTestCase
+        else:  # Commissioning
+            case_class = PythonTestCase
+
+        return case_class.__class_factory(
+            test=test, python_test_version=python_test_version
+        )
+
+    @classmethod
+    def __class_factory(cls, test: PythonTest, python_test_version: str) -> Type[T]:
         """class factory method for PythonTestCase."""
         title = cls.__title(test.name)
         class_name = cls.__class_name(test.name)
@@ -253,3 +280,47 @@ class PythonTestCase(TestCase):
             python_test_step = TestStep(step.label)
             self.test_steps.append(python_test_step)
         self.test_steps.append(TestStep("Show test logs"))
+
+
+class NoCommissioningPythonTestCase(PythonTestCase):
+    async def setup(self) -> None:
+        await super().setup()
+        await prompt_for_commissioning_mode(self, logger, None, self.cancel)
+
+
+class LegacyPythonTestCase(PythonTestCase):
+    async def setup(self) -> None:
+        await super().setup()
+        await prompt_for_commissioning_mode(self, logger, None, self.cancel)
+        await self.prompt_about_commissioning()
+
+    async def prompt_about_commissioning(self) -> None:
+        """Prompt the user to ask about commissioning
+
+        Raises:
+            ValueError: Prompt response is unexpected
+        """
+
+        prompt = "Should the DUT be commissioned to run this test case?"
+        options = {
+            "YES": PromptOption.YES,
+            "NO": PromptOption.NO,
+        }
+        prompt_request = OptionsSelectPromptRequest(prompt=prompt, options=options)
+        logger.info(f'User prompt: "{prompt}"')
+        prompt_response = await self.send_prompt_request(prompt_request)
+
+        match prompt_response.response:
+            case PromptOption.YES:
+                logger.info("User chose prompt option YES")
+                logger.info("Commission DUT")
+                commission_device(self.config, logger)
+
+            case PromptOption.NO:
+                logger.info("User chose prompt option NO")
+
+            case _:
+                raise ValueError(
+                    f"Received unknown prompt option for \
+                        commissioning step: {prompt_response.response}"
+                )

--- a/test_collections/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_case.py
@@ -138,9 +138,9 @@ class PythonTestCase(TestCase, UserPromptSupport):
         """Dynamically declares a subclass based on the type of Python test."""
         case_class: Type[PythonTestCase]
 
-        if test.python_type == PythonTestType.NO_COMMISSIONING:
+        if test.python_test_type == PythonTestType.NO_COMMISSIONING:
             case_class = NoCommissioningPythonTestCase
-        elif test.python_type == PythonTestType.LEGACY:
+        elif test.python_test_type == PythonTestType.LEGACY:
             case_class = LegacyPythonTestCase
         else:  # Commissioning
             case_class = PythonTestCase

--- a/test_collections/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_suite.py
@@ -14,26 +14,22 @@
 # limitations under the License.
 #
 from enum import Enum
-from typing import Generator, Type, TypeVar, cast
+from typing import Type, TypeVar
 
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestSuite
+from app.user_prompt_support.user_prompt_support import UserPromptSupport
 from test_collections.sdk_tests.support.chip_tool import ChipTool
-
-from .utils import (
-    EXECUTABLE,
-    RUNNER_CLASS_PATH,
-    generate_command_arguments,
-    handle_logs,
+from test_collections.sdk_tests.support.python_testing.models.utils import (
+    commission_device,
 )
+from test_collections.sdk_tests.support.utils import prompt_for_commissioning_mode
 
 
 class SuiteType(Enum):
-    AUTOMATED = 1
-
-
-class DUTCommissioningError(Exception):
-    pass
+    COMMISSIONING = 1
+    NO_COMMISSIONING = 2
+    LEGACY = 3
 
 
 # Custom Type variable used to annotate the factory methods of classmethod.
@@ -56,6 +52,21 @@ class PythonTestSuite(TestSuite):
         cls, suite_type: SuiteType, name: str, python_test_version: str
     ) -> Type[T]:
         """Dynamically declares a subclass based on the type of test suite."""
+        suite_class: Type[PythonTestSuite]
+
+        if suite_type == SuiteType.COMMISSIONING:
+            suite_class = CommissioningPythonTestSuite
+        else:
+            suite_class = PythonTestSuite
+
+        return suite_class.__class_factory(
+            name=name, python_test_version=python_test_version
+        )
+
+    @classmethod
+    def __class_factory(cls, name: str, python_test_version: str) -> Type[T]:
+        """Common class factory method for all subclasses of PythonTestSuite."""
+
         return type(
             name,
             (cls,),
@@ -85,30 +96,18 @@ class PythonTestSuite(TestSuite):
         else:
             self.chip_tool.reset_pics_state()
 
-        logger.info("Commission DUT")
-        self.commission_device()
-
     async def cleanup(self) -> None:
         logger.info("Suite Cleanup")
 
         logger.info("Stopping SDK container")
         await self.chip_tool.destroy_device()
 
-    def commission_device(self) -> None:
-        command = [f"{RUNNER_CLASS_PATH} commission"]
-        command_arguments = generate_command_arguments(config=self.config)
-        command.extend(command_arguments)
 
-        exec_result = self.chip_tool.send_command(
-            command,
-            prefix=EXECUTABLE,
-            is_stream=True,
-            is_socket=False,
-        )
+class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
+    async def setup(self) -> None:
+        await super().setup()
 
-        handle_logs(cast(Generator, exec_result.output), logger)
+        await prompt_for_commissioning_mode(self, logger, None, self.cancel)
 
-        exit_code = self.chip_tool.exec_exit_code(exec_result.exec_id)
-
-        if exit_code:
-            raise DUTCommissioningError("Failed to commission DUT")
+        logger.info("Commission DUT")
+        commission_device(self.config, logger)

--- a/test_collections/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/sdk_tests/support/python_testing/models/utils.py
@@ -16,12 +16,13 @@
 
 from __future__ import annotations
 
-from typing import Generator
+from typing import Generator, cast
 
 import loguru
 
 from app.schemas.test_environment_config import TestEnvironmentConfig
 from app.test_engine.logger import PYTHON_TEST_LEVEL
+from test_collections.sdk_tests.support.chip_tool import ChipTool
 
 # Command line params
 RUNNER_CLASS_PATH = "/root/python_testing/test_harness_client.py"
@@ -62,3 +63,32 @@ def handle_logs(log_generator: Generator, logger: loguru.Logger) -> None:
         log_lines = decoded_log.splitlines()
         for line in log_lines:
             logger.log(PYTHON_TEST_LEVEL, line)
+
+
+class DUTCommissioningError(Exception):
+    pass
+
+
+def commission_device(
+    config: TestEnvironmentConfig,
+    logger: loguru.Logger,
+) -> None:
+    chip_tool = ChipTool()
+
+    command = [f"{RUNNER_CLASS_PATH} commission"]
+    command_arguments = generate_command_arguments(config)
+    command.extend(command_arguments)
+
+    exec_result = chip_tool.send_command(
+        command,
+        prefix=EXECUTABLE,
+        is_stream=True,
+        is_socket=False,
+    )
+
+    handle_logs(cast(Generator, exec_result.output), logger)
+
+    exit_code = chip_tool.exec_exit_code(exec_result.exec_id)
+
+    if exit_code:
+        raise DUTCommissioningError("Failed to commission DUT")

--- a/test_collections/sdk_tests/support/python_testing/sdk_python_tests.py
+++ b/test_collections/sdk_tests/support/python_testing/sdk_python_tests.py
@@ -96,7 +96,7 @@ def _parse_all_sdk_python_tests(
         )
 
         for test_case in test_cases:
-            python_test_type = test_case.class_ref.python_test.python_type
+            python_test_type = test_case.class_ref.python_test.python_test_type
             if python_test_type == PythonTestType.COMMISSIONING:
                 suites[SuiteType.COMMISSIONING].add_test_case(test_case)
             elif python_test_type == PythonTestType.NO_COMMISSIONING:

--- a/test_collections/sdk_tests/support/python_testing/sdk_python_tests.py
+++ b/test_collections/sdk_tests/support/python_testing/sdk_python_tests.py
@@ -19,6 +19,7 @@ from typing import Optional
 from test_collections.sdk_tests.support.models.sdk_test_folder import SDKTestFolder
 from test_collections.sdk_tests.support.paths import SDK_CHECKOUT_PATH
 
+from .models.python_test_models import PythonTestType
 from .models.python_test_parser import parse_python_script
 from .models.test_declarations import (
     PythonCaseDeclaration,
@@ -53,9 +54,19 @@ def _init_test_suites(
     python_test_version: str,
 ) -> dict[SuiteType, PythonSuiteDeclaration]:
     return {
-        SuiteType.AUTOMATED: PythonSuiteDeclaration(
+        SuiteType.COMMISSIONING: PythonSuiteDeclaration(
             name="Python Testing Suite",
-            suite_type=SuiteType.AUTOMATED,
+            suite_type=SuiteType.COMMISSIONING,
+            version=python_test_version,
+        ),
+        SuiteType.NO_COMMISSIONING: PythonSuiteDeclaration(
+            name="Python Testing Suite - No commissioning",
+            suite_type=SuiteType.NO_COMMISSIONING,
+            version=python_test_version,
+        ),
+        SuiteType.LEGACY: PythonSuiteDeclaration(
+            name="Python Testing Suite - Legacy",
+            suite_type=SuiteType.LEGACY,
             version=python_test_version,
         ),
     }
@@ -85,7 +96,13 @@ def _parse_all_sdk_python_tests(
         )
 
         for test_case in test_cases:
-            suites[SuiteType.AUTOMATED].add_test_case(test_case)
+            python_test_type = test_case.class_ref.python_test.python_type
+            if python_test_type == PythonTestType.COMMISSIONING:
+                suites[SuiteType.COMMISSIONING].add_test_case(test_case)
+            elif python_test_type == PythonTestType.NO_COMMISSIONING:
+                suites[SuiteType.NO_COMMISSIONING].add_test_case(test_case)
+            else:
+                suites[SuiteType.LEGACY].add_test_case(test_case)
 
     return list(suites.values())
 

--- a/test_collections/sdk_tests/support/tests/python_tests/test_python_test_case.py
+++ b/test_collections/sdk_tests/support/tests/python_tests/test_python_test_case.py
@@ -47,7 +47,7 @@ def python_test_instance(
     type: MatterTestType = MatterTestType.AUTOMATED,
     path: Optional[Path] = None,
     class_name: str = "TC_Test_Python",
-    python_type: PythonTestType = PythonTestType.COMMISSIONING,
+    python_test_type: PythonTestType = PythonTestType.COMMISSIONING,
 ) -> PythonTest:
     return PythonTest(
         name=name,
@@ -58,7 +58,7 @@ def python_test_instance(
         path=path,
         description=description,
         class_name=class_name,
-        python_type=python_type,
+        python_test_type=python_test_type,
     )
 
 

--- a/test_collections/sdk_tests/support/tests/python_tests/test_python_test_case.py
+++ b/test_collections/sdk_tests/support/tests/python_tests/test_python_test_case.py
@@ -31,6 +31,7 @@ from test_collections.sdk_tests.support.models.matter_test_models import (
 from test_collections.sdk_tests.support.python_testing.models import PythonTestCase
 from test_collections.sdk_tests.support.python_testing.models.python_test_models import (
     PythonTest,
+    PythonTestType,
 )
 
 
@@ -46,6 +47,7 @@ def python_test_instance(
     type: MatterTestType = MatterTestType.AUTOMATED,
     path: Optional[Path] = None,
     class_name: str = "TC_Test_Python",
+    python_type: PythonTestType = PythonTestType.COMMISSIONING,
 ) -> PythonTest:
     return PythonTest(
         name=name,
@@ -56,11 +58,12 @@ def python_test_instance(
         path=path,
         description=description,
         class_name=class_name,
+        python_type=python_type,
     )
 
 
 def test_python_test_name() -> None:
-    """Test that test name is set as description in metadata."""
+    """Test that test name is set as title in metadata."""
     name = "Another Test Name"
     description = "Another Test Name Description"
     test = python_test_instance(name=name, description=description)
@@ -138,10 +141,7 @@ def test_class_factory_test_class_name() -> None:
 
 @pytest.mark.asyncio
 async def test_python_version_logging() -> None:
-    """Test that all Python tests will log Python test version to test_engine_logger.
-
-    Note that since `chip-tool` is not setup, we except the TestError raised.
-    """
+    """Test that all Python tests will log Python test version to test_engine_logger."""
     for type in list(MatterTestType):
         test = python_test_instance(type=type)
         test_python_version = "PythonVersionTest"
@@ -153,10 +153,7 @@ async def test_python_version_logging() -> None:
         with mock.patch.object(
             target=test_engine_logger, attribute="info"
         ) as logger_info:
-            try:
-                await instance.setup()
-            except TestError:
-                pass
+            await instance.setup()
             logger_info.assert_called()
             logger_info.assert_any_call("Test Setup")
 
@@ -192,15 +189,3 @@ def test_multiple_steps_for_python_tests() -> None:
             s for s in instance.test_steps if s.name == test_step.label
         ]
         assert len(steps_from_python) == no_steps
-
-
-@pytest.mark.asyncio
-async def test_setup_super_error_handling() -> None:
-    # ignore requirement to create_tests on init
-    with mock.patch(
-        "test_collections.sdk_tests.support.python_testing.models.test_case.PythonTestCase.create_test_steps"
-    ) as _:
-        test = PythonTestCase(TestCaseExecution())
-        test.python_test_version = "some version"
-        # Assert this doesn't raise an exception
-        await test.setup()

--- a/test_collections/sdk_tests/support/tests/python_tests/test_python_test_declarations.py
+++ b/test_collections/sdk_tests/support/tests/python_tests/test_python_test_declarations.py
@@ -54,7 +54,7 @@ def test_python_case_declaration() -> None:
         config={},
         steps=[],
         class_name="TC_TestTest",
-        python_type=PythonTestType.COMMISSIONING,
+        python_test_type=PythonTestType.COMMISSIONING,
     )
     version = "SomeVersionStr"
     with mock.patch(

--- a/test_collections/sdk_tests/support/tests/python_tests/test_python_test_declarations.py
+++ b/test_collections/sdk_tests/support/tests/python_tests/test_python_test_declarations.py
@@ -19,6 +19,7 @@ from unittest import mock
 
 from test_collections.sdk_tests.support.python_testing.models.python_test_models import (
     PythonTest,
+    PythonTestType,
 )
 from test_collections.sdk_tests.support.python_testing.models.test_declarations import (
     PythonCaseDeclaration,
@@ -31,7 +32,7 @@ from test_collections.sdk_tests.support.python_testing.models.test_suite import 
 
 def test_python_suite_declaration() -> None:
     name = "TestName"
-    type = SuiteType.AUTOMATED
+    type = SuiteType.COMMISSIONING
     version = "SomeVersionStr"
 
     with mock.patch(
@@ -53,6 +54,7 @@ def test_python_case_declaration() -> None:
         config={},
         steps=[],
         class_name="TC_TestTest",
+        python_type=PythonTestType.COMMISSIONING,
     )
     version = "SomeVersionStr"
     with mock.patch(

--- a/test_collections/sdk_tests/support/tests/python_tests/test_sdk_python_collection.py
+++ b/test_collections/sdk_tests/support/tests/python_tests/test_sdk_python_collection.py
@@ -48,7 +48,7 @@ def test_sdk_python_test_collection(
     python_test_collection: PythonCollectionDeclaration,
 ) -> None:
     assert python_test_collection.name == "SDK Python Tests"
-    assert len(python_test_collection.test_suites.keys()) == 1
+    assert len(python_test_collection.test_suites.keys()) == 3
     assert python_test_collection.python_test_version == "unit-test-python-version"
 
 

--- a/test_collections/sdk_tests/support/utils.py
+++ b/test_collections/sdk_tests/support/utils.py
@@ -1,0 +1,64 @@
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import annotations
+
+from enum import IntEnum
+from typing import Callable, Optional
+
+import loguru
+
+from app.user_prompt_support.prompt_request import OptionsSelectPromptRequest
+from app.user_prompt_support.user_prompt_support import UserPromptSupport
+
+
+class PromptOption(IntEnum):
+    PASS = 1
+    FAIL = 2
+
+
+async def prompt_for_commissioning_mode(
+    prompt_support: UserPromptSupport,
+    logger: loguru.Logger,
+    on_success: Optional[Callable] = None,
+    on_failure: Optional[Callable] = None,
+) -> None:
+    prompt = "Make sure the DUT is in Commissioning Mode"
+    options = {
+        "DONE": PromptOption.PASS,
+        "FAILED": PromptOption.FAIL,
+    }
+    prompt_request = OptionsSelectPromptRequest(prompt=prompt, options=options)
+
+    logger.info(f'User prompt: "{prompt}"')
+    prompt_response = await prompt_support.send_prompt_request(prompt_request)
+
+    match prompt_response.response:
+        case PromptOption.PASS:
+            logger.info("User chose prompt option DONE")
+            if on_success:
+                on_success()
+
+        case PromptOption.FAIL:
+            logger.info("User chose prompt option FAILED")
+            if on_failure:
+                on_failure()
+
+        case _:
+            raise ValueError(
+                f"Received unknown prompt option for \
+                        commissioning step: {prompt_response.response}"
+            )


### PR DESCRIPTION
## What changed

- Separated the SDK Python tests in 3 suites:
   - Python Testing Suite: test cases that follow the template and need commissioning.
   - Python Testing Suite - No commissioning: test cases that follow the template and don't need commissioning.
   - Python Testing Suite - Legacy: test cases that don't follow the template so we don't know if they need commissioning or not.
- This change allows for running tests from different suites and collections in a single test run.

## New prompts

- "Make sure the DUT is in Commissioning Mode"
   - Shown at:
      - Setup for the "Python Testing Suite" suite.
      - Setup for each test case of the "Python Testing Suite - No commissioning" and the "Python Testing Suite - Legacy" suites.
<img width="2160" alt="Screenshot 2023-12-19 at 14 31 26" src="https://github.com/project-chip/certification-tool-backend/assets/116589288/1b31e643-1eee-4cb2-9a85-a8cafe768948">

- "Should the DUT be commissioned to run this test case?"
   - Shown at:
      - Setup for each test case of the "Python Testing Suite - Legacy" suite.
<img width="2160" alt="Screenshot 2023-12-19 at 14 32 55" src="https://github.com/project-chip/certification-tool-backend/assets/116589288/9f8650cd-5c01-4f48-99a1-4f9b0472ebbe">

## Additional screenshots

- Tests from different test suites and collections running in the same execution:
<img width="2160" alt="Screenshot 2023-12-21 at 15 15 19" src="https://github.com/project-chip/certification-tool-backend/assets/116589288/3e4690db-ad47-4659-8e07-4c2528e6f4a1">
