### PR TITLE
Fix custom tests in place of sdk tests

### DIFF
--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -26,6 +26,8 @@ from app.test_engine.test_observer import Observer
 from .test_metadata import TestMetadata
 from .test_step import TestStep
 
+CUSTOM_TEST_IDENTIFIER = "custom"
+
 
 class TestCase(TestObservable):
     """

--- a/test_collections/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_case.py
@@ -135,7 +135,9 @@ class PythonTestCase(TestCase):
                 "python_test": test,
                 "python_test_version": python_test_version,
                 "metadata": {
-                    "public_id": test.name,
+                    "public_id": test.name
+                    if python_test_version != "custom"
+                    else test.name + "-custom",
                     "version": "0.0.1",
                     "title": title,
                     "description": test.description,

--- a/test_collections/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_case.py
@@ -21,6 +21,7 @@ from typing import Any, Generator, Type, TypeVar, cast
 from app.models import TestCaseExecution
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestCase, TestStep
+from app.test_engine.models.test_case import CUSTOM_TEST_IDENTIFIER
 from test_collections.sdk_tests.support.chip_tool.chip_tool import (
     PICS_FILE_PATH,
     ChipTool,
@@ -136,8 +137,8 @@ class PythonTestCase(TestCase):
                 "python_test_version": python_test_version,
                 "metadata": {
                     "public_id": test.name
-                    if python_test_version != "custom"
-                    else test.name + "-custom",
+                    if python_test_version != CUSTOM_TEST_IDENTIFIER
+                    else test.name + "-" + CUSTOM_TEST_IDENTIFIER,
                     "version": "0.0.1",
                     "title": title,
                     "description": test.description,

--- a/test_collections/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/sdk_tests/support/python_testing/models/test_suite.py
@@ -63,7 +63,9 @@ class PythonTestSuite(TestSuite):
                 "name": name,
                 "python_test_version": python_test_version,
                 "metadata": {
-                    "public_id": name,
+                    "public_id": name
+                    if python_test_version != "custom"
+                    else name + "-custom",
                     "version": "0.0.1",
                     "title": name,
                     "description": name,

--- a/test_collections/sdk_tests/support/yaml_tests/models/test_case.py
+++ b/test_collections/sdk_tests/support/yaml_tests/models/test_case.py
@@ -109,7 +109,9 @@ class YamlTestCase(TestCase):
                 "yaml_version": yaml_version,
                 "chip_tool_test_identifier": class_name,
                 "metadata": {
-                    "public_id": identifier,
+                    "public_id": identifier
+                    if yaml_version != "custom"
+                    else identifier + "-custom",
                     "version": "0.0.1",
                     "title": title,
                     "description": test.name,

--- a/test_collections/sdk_tests/support/yaml_tests/models/test_case.py
+++ b/test_collections/sdk_tests/support/yaml_tests/models/test_case.py
@@ -23,9 +23,7 @@ from app.test_engine.models import (
     TestCase,
     TestStep,
 )
-
 from app.test_engine.models.test_case import CUSTOM_TEST_IDENTIFIER
-
 from test_collections.sdk_tests.support.chip_tool.chip_tool import ChipToolTestType
 from test_collections.sdk_tests.support.chip_tool.test_case import (
     ChipToolManualPromptTest,

--- a/test_collections/sdk_tests/support/yaml_tests/models/test_case.py
+++ b/test_collections/sdk_tests/support/yaml_tests/models/test_case.py
@@ -23,6 +23,9 @@ from app.test_engine.models import (
     TestCase,
     TestStep,
 )
+
+from app.test_engine.models.test_case import CUSTOM_TEST_IDENTIFIER
+
 from test_collections.sdk_tests.support.chip_tool.chip_tool import ChipToolTestType
 from test_collections.sdk_tests.support.chip_tool.test_case import (
     ChipToolManualPromptTest,
@@ -110,8 +113,8 @@ class YamlTestCase(TestCase):
                 "chip_tool_test_identifier": class_name,
                 "metadata": {
                     "public_id": identifier
-                    if yaml_version != "custom"
-                    else identifier + "-custom",
+                    if yaml_version != CUSTOM_TEST_IDENTIFIER
+                    else identifier + "-" + CUSTOM_TEST_IDENTIFIER,
                     "version": "0.0.1",
                     "title": title,
                     "description": test.name,

--- a/test_collections/sdk_tests/support/yaml_tests/models/test_suite.py
+++ b/test_collections/sdk_tests/support/yaml_tests/models/test_suite.py
@@ -77,7 +77,7 @@ class YamlTestSuite(TestSuite):
                 "name": name,
                 "yaml_version": yaml_version,
                 "metadata": {
-                    "public_id": name,
+                    "public_id": name if yaml_version != "custom" else name + "-custom",
                     "version": "0.0.1",
                     "title": name,
                     "description": name,


### PR DESCRIPTION
## What changed
Fix custom tests in place of sdk tests

## Related issue
https://github.com/project-chip/certification-tool/issues/133

## Testing
SDK Python Test running (TC-ACE-1.3)
![Screenshot 2023-12-22 at 14 26 10](https://github.com/project-chip/certification-tool-backend/assets/116586593/739708c5-35a5-4f9c-974b-0d87a6766c4d)


Custom Python Test running (TC-ACE-1.3)
![Screenshot 2023-12-22 at 14 25 40](https://github.com/project-chip/certification-tool-backend/assets/116586593/7d613e93-a3f5-46b8-9dac-d64275aea085)

- Unit test passing
<img width="311" alt="Screenshot 2023-12-22 at 14 24 30" src="https://github.com/project-chip/certification-tool-backend/assets/116586593/794965b2-cc69-4a31-92d8-504939889af9">

