### PR TITLE
Added checking for valid dut config properties 

### DIFF
--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -28,8 +28,7 @@ from app.pics.pics_parser import PICSParser
 from app.pics_applicable_test_cases import applicable_test_cases_list
 from app.schemas.pics import PICSError
 from app.schemas.project import Project as Proj
-
-# from app.schemas.project import ProjectPICSUpdate
+from app.schemas.test_environment_config import DutConfig
 
 router = APIRouter()
 
@@ -88,13 +87,7 @@ def default_config() -> schemas.TestEnvironmentConfig:
 
 
 def __validate_dut_config(request: Request) -> None:
-    valid_properties = [
-        "discriminator",
-        "setup_code",
-        "pairing_mode",
-        "chip_timeout",
-        "chip_use_paa_certs",
-    ]
+    valid_properties = list(DutConfig.__annotations__.keys())
 
     if "config" in request._json and "dut_config" in request._json["config"]:
         dut_config = request._json["config"]["dut_config"]

--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -96,7 +96,8 @@ def __validate_dut_config(request: Request) -> None:
             if field not in valid_properties:
                 raise HTTPException(
                     status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-                    detail="Dut config section has invalid property informed."
+                    detail="The DUT config section has one or more invalid properties"
+                    " informed."
                     f" The valid properties are: {valid_properties}",
                 )
 

--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -71,7 +71,7 @@ def create_project(
     Returns:
         Project: newly created project record
     """
-    # Validade dut config informed arguments
+    # Validate dut config properties
     __validate_dut_config(request=request)
 
     return crud.project.create(db=db, obj_in=project_in)
@@ -88,23 +88,23 @@ def default_config() -> schemas.TestEnvironmentConfig:
 
 
 def __validate_dut_config(request: Request) -> None:
+    valid_properties = [
+        "discriminator",
+        "setup_code",
+        "pairing_mode",
+        "chip_timeout",
+        "chip_use_paa_certs",
+    ]
+
     if "config" in request._json and "dut_config" in request._json["config"]:
         dut_config = request._json["config"]["dut_config"]
 
-        valid_fields = [
-            "discriminator",
-            "setup_code",
-            "pairing_mode",
-            "chip_timeout",
-            "chip_use_paa_certs",
-        ]
-
         for field, _ in dut_config.items():
-            if field not in valid_fields:
+            if field not in valid_properties:
                 raise HTTPException(
                     status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-                    detail="Dut config has invalid configuration informed."
-                    f" The valid configuration are: {valid_fields}",
+                    detail="Dut config section has invalid property informed."
+                    f" The valid properties are: {valid_properties}",
                 )
 
 
@@ -128,7 +128,7 @@ def update_project(
     Returns:
         Project: updated project record
     """
-    # Validade dut config informed arguments
+    # Validate dut config properties
     __validate_dut_config(request=request)
 
     return crud.project.update(db=db, db_obj=__project(db=db, id=id), obj_in=project_in)

--- a/app/tests/api/api_v1/test_projects.py
+++ b/app/tests/api/api_v1/test_projects.py
@@ -111,7 +111,7 @@ def test_create_project_invalid_dut_config(client: TestClient) -> None:
         response=response,
         expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
         expected_content={
-            "detail": "Dut config has invalid configuration informed. The valid configuration are: ['discriminator', 'setup_code', 'pairing_mode', 'chip_timeout', 'chip_use_paa_certs']"
+            "detail": "Dut config section has invalid property informed. The valid properties are: ['discriminator', 'setup_code', 'pairing_mode', 'chip_timeout', 'chip_use_paa_certs']"
         },
         expected_keys=["detail"],
     )
@@ -210,7 +210,7 @@ def test_update_project_invalid_dut_config(client: TestClient, db: Session) -> N
         response=response,
         expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
         expected_content={
-            "detail": "Dut config has invalid configuration informed. The valid configuration are: ['discriminator', 'setup_code', 'pairing_mode', 'chip_timeout', 'chip_use_paa_certs']"
+            "detail": "Dut config section has invalid property informed. The valid properties are: ['discriminator', 'setup_code', 'pairing_mode', 'chip_timeout', 'chip_use_paa_certs']"
         },
         expected_keys=["detail"],
     )

--- a/app/tests/api/api_v1/test_projects.py
+++ b/app/tests/api/api_v1/test_projects.py
@@ -27,7 +27,7 @@ from app import crud
 from app.core.config import settings
 from app.default_environment_config import default_environment_config
 from app.models.project import Project
-from app.schemas.test_environment_config import DutPairingModeEnum
+from app.schemas.test_environment_config import DutConfig, DutPairingModeEnum
 from app.tests.utils.project import (
     create_random_project,
     create_random_project_archived,
@@ -107,11 +107,13 @@ def test_create_project_invalid_dut_config(client: TestClient) -> None:
         json=invalid_dut_config,
     )
 
+    valid_fields = list(DutConfig.__annotations__.keys())
+
     validate_json_response(
         response=response,
         expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
         expected_content={
-            "detail": "The DUT config section has one or more invalid properties informed. The valid properties are: ['discriminator', 'setup_code', 'pairing_mode', 'chip_timeout', 'chip_use_paa_certs']"
+            f"detail": f"The DUT config section has one or more invalid properties informed. The valid properties are: {valid_fields}"
         },
         expected_keys=["detail"],
     )
@@ -206,11 +208,13 @@ def test_update_project_invalid_dut_config(client: TestClient, db: Session) -> N
         json=invalid_dut_config,
     )
 
+    valid_fields = list(DutConfig.__annotations__.keys())
+
     validate_json_response(
         response=response,
         expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
         expected_content={
-            "detail": "The DUT config section has one or more invalid properties informed. The valid properties are: ['discriminator', 'setup_code', 'pairing_mode', 'chip_timeout', 'chip_use_paa_certs']"
+            "detail": f"The DUT config section has one or more invalid properties informed. The valid properties are: {valid_fields}"
         },
         expected_keys=["detail"],
     )

--- a/app/tests/api/api_v1/test_projects.py
+++ b/app/tests/api/api_v1/test_projects.py
@@ -111,7 +111,7 @@ def test_create_project_invalid_dut_config(client: TestClient) -> None:
         response=response,
         expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
         expected_content={
-            "detail": "Dut config section has invalid property informed. The valid properties are: ['discriminator', 'setup_code', 'pairing_mode', 'chip_timeout', 'chip_use_paa_certs']"
+            "detail": "The DUT config section has one or more invalid properties informed. The valid properties are: ['discriminator', 'setup_code', 'pairing_mode', 'chip_timeout', 'chip_use_paa_certs']"
         },
         expected_keys=["detail"],
     )
@@ -210,7 +210,7 @@ def test_update_project_invalid_dut_config(client: TestClient, db: Session) -> N
         response=response,
         expected_status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
         expected_content={
-            "detail": "Dut config section has invalid property informed. The valid properties are: ['discriminator', 'setup_code', 'pairing_mode', 'chip_timeout', 'chip_use_paa_certs']"
+            "detail": "The DUT config section has one or more invalid properties informed. The valid properties are: ['discriminator', 'setup_code', 'pairing_mode', 'chip_timeout', 'chip_use_paa_certs']"
         },
         expected_keys=["detail"],
     )


### PR DESCRIPTION
## What changed

- The goal of this PR is perform a validation for the valid dut config properties when creating or updating a project.
Before this PR, if the user inputs an invalid dut config property, the UI shows a false positive message stating the change was performed successfully but in the end the change does not happened.

## Related issue
https://github.com/project-chip/certification-tool/issues/119

## Testing
- Development testing using an invalid property inside dut_config
![Screenshot 2024-01-11 at 16 04 15](https://github.com/project-chip/certification-tool-backend/assets/116586593/eda1c2ad-a13a-411c-9857-26f2717fa65e)

![Screenshot 2024-01-11 at 16 05 33](https://github.com/project-chip/certification-tool-backend/assets/116586593/5bff83a8-143b-481d-9178-247cdd7955bb)


- Unit test added and passed
<img width="357" alt="Screenshot 2024-01-11 at 16 02 52" src="https://github.com/project-chip/certification-tool-backend/assets/116586593/729707ca-90ef-4889-9249-7fd98da70173">
factoring
