### PR TITLE
Undo workaround changes for python tests parser

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
@@ -25,13 +25,7 @@ ARG_STEP_DESCRIPTION_INDEX = 1
 KEYWORD_IS_COMISSIONING_INDEX = 0
 
 TC_FUNCTION_PATTERN = re.compile(r"[\S]+_TC_[\S]+")
-# This constant is a temporarily fix for TE2
-# Issue: https://github.com/project-chip/certification-tool/issues/152
-TC_FUNCTION_PATTERN_WORKAROUND = re.compile(r"[\S]+_[\S]+")
 TC_TEST_FUNCTION_PATTERN = re.compile(r"test_(?P<title>TC_[\S]+)")
-# This constant is a temporarily fix for TE2
-# Issue: https://github.com/project-chip/certification-tool/issues/152
-TC_TEST_FUNCTION_PATTERN_WORKAROUND = re.compile(r"test_(?P<title>[\S]+_[0-9]+_[0-9]+)")
 
 
 FunctionDefType = Union[ast.FunctionDef, ast.AsyncFunctionDef]
@@ -110,13 +104,7 @@ def __test_methods(class_def: ast.ClassDef) -> list[FunctionDefType]:
     ]
     for m in methods:
         if isinstance(m.name, str):
-            # THIS IS A WORKAROUND CODE for TE2
-            # Some Python tests written in SDK repo are not following the test method
-            # template, test_TC_[TC_name]
-            # So this code temporarily code to consider other methods signature as a
-            # python test script.
-            # Issue: https://github.com/project-chip/certification-tool/issues/152
-            if re.match(TC_FUNCTION_PATTERN_WORKAROUND, m.name):
+            if re.match(TC_FUNCTION_PATTERN, m.name):
                 all_methods.append(m)
 
     return all_methods
@@ -138,15 +126,6 @@ def __test_case_names(methods: list[FunctionDefType]) -> list[str]:
             if match := re.match(TC_TEST_FUNCTION_PATTERN, m.name):
                 if name := match["title"]:
                     test_names.append(name)
-            # THIS IS A WORKAROUND CODE for TE2
-            # Some Python tests written in SDK repo are not following the test method
-            # template, test_TC_[TC_name]
-            # So this code temporarily code to consider other methods signature as a
-            # python test script.
-            # Issue: https://github.com/project-chip/certification-tool/issues/152
-            elif match := re.match(TC_TEST_FUNCTION_PATTERN_WORKAROUND, m.name):
-                if name := match["title"]:
-                    test_names.append("TC_" + name)
 
     return test_names
 
@@ -191,12 +170,6 @@ def __parse_test_case(
         python_test_type = PythonTestType.COMMISSIONING
     elif desc_method:
         python_test_type = PythonTestType.NO_COMMISSIONING
-
-    # THIS IS A WORKAROUND CODE for TE2
-    # The TC_DGGEN_2_4 test case is not following the test method template
-    if tc_name == "TC_GEN_2_4":
-        tc_name = "TC_DGGEN_2_4"  # spell-checker: disable
-        tc_desc = "TC_DGGEN_2_4"  # spell-checker: disable
 
     return PythonTest(
         name=tc_name,

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -209,22 +209,9 @@ class PythonTestCase(TestCase, UserPromptSupport):
                     f"Missing file path for python test {self.python_test.name}"
                 )
 
-            # THIS IS A WORKAROUND CODE for TE2
-            # Issue: https://github.com/project-chip/certification-tool/issues/152
-            test_name = self.python_test.name
-            if test_name == "TC_DGGEN_2_4":  # spell-checker: disable
-                test_name = "TC_GEN_2_4"
-            elif test_name in [
-                "TC_DT_1_1",
-                "TC_IDM_10_1",
-                "TC_IDM_11_1",
-                "TC_DESC_2_2",
-            ]:
-                test_name = test_name[3:]
-
             command = [
                 f"{RUNNER_CLASS_PATH} {self.python_test.path.stem}"
-                f" {self.python_test.class_name} --tests test_{test_name}"
+                f" {self.python_test.class_name} --tests test_{self.python_test.name}"
             ]
 
             # Generate the command argument by getting the test_parameters from


### PR DESCRIPTION
The Goal of this PR is to undo the changes implemented in this PR: https://github.com/project-chip/certification-tool-backend/pull/61