### PR TITLE
Add support for manual operations in SDK Python Tests

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
@@ -32,6 +32,7 @@ class SDKPythonTestResultEnum(str, Enum):
     STEP_FAILURE = "step_failure"
     STEP_UNKNOWN = "step_unknown"
     STEP_MANUAL = "step_manual"
+    SHOW_PROMPT = "show_prompt"
 
 
 class SDKPythonTestResultBase(BaseModel):
@@ -98,6 +99,13 @@ class SDKPythonTestResultStepUnknown(SDKPythonTestResultBase):
 
 class SDKPythonTestResultStepManual(SDKPythonTestResultBase):
     type = SDKPythonTestResultEnum.STEP_MANUAL
+
+
+class SDKPythonTestResultShowPrompt(SDKPythonTestResultBase):
+    type = SDKPythonTestResultEnum.SHOW_PROMPT
+    msg: str
+    placeholder: Optional[str]
+    default_value: Optional[str]
 
 
 class SDKPythonTestRunnerHooks(TestRunnerHooks):
@@ -176,6 +184,18 @@ class SDKPythonTestRunnerHooks(TestRunnerHooks):
 
     def step_manual(self) -> None:
         self.results.put(SDKPythonTestResultStepManual())
+
+    def show_prompt(
+        self,
+        msg: str,
+        placeholder: Optional[str] = None,
+        default_value: Optional[str] = None,
+    ) -> None:
+        self.results.put(
+            SDKPythonTestResultShowPrompt(
+                msg=msg, placeholder=placeholder, default_value=default_value
+            )
+        )
 
     def step_start_list(self) -> None:
         pass

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_test.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_test.py
@@ -15,7 +15,7 @@
 #
 import asyncio
 from enum import Enum, IntEnum
-from typing import Any
+from typing import Any, Optional
 
 # Websocket Test imports:
 from matter_chip_tool_adapter.decoder import MatterLog
@@ -180,6 +180,14 @@ class ChipTest(TestCase, UserPromptSupport, TestRunnerHooks, TestParserHooks):
         except asyncio.TimeoutError:
             self.current_test_step.append_failure("Prompt timed out.")
         self.next_step()
+
+    def show_prompt(
+        self,
+        msg: str,
+        placeholder: Optional[str] = None,
+        default_value: Optional[str] = None,
+    ) -> None:
+        pass
 
     # Other methods
 


### PR DESCRIPTION
## What changed

- Added support for manual operations in SDK Python Tests.

## Related issue

- https://github.com/project-chip/certification-tool/issues/163

## Example

<img width="2160" alt="Screenshot 2024-02-23 at 17 55 11" src="https://github.com/project-chip/certification-tool-backend/assets/116589288/f795f106-5ded-4197-8c32-9071e581f33f">
<img width="2160" alt="Screenshot 2024-02-23 at 17 55 08" src="https://github.com/project-chip/certification-tool-backend/assets/116589288/f76cc828-2406-4862-9f55-94b4830193bc">
