### PR TITLE
Make trace-log configurable

### DIFF
--- a/app/schemas/test_environment_config.py
+++ b/app/schemas/test_environment_config.py
@@ -61,7 +61,8 @@ class DutConfig(BaseModel):
     setup_code: str
     pairing_mode: DutPairingModeEnum
     chip_timeout: Optional[str]
-    chip_use_paa_certs: bool = False
+    chip_use_paa_certs: bool = False    
+    trace_log: bool = True    
 
 
 class TestEnvironmentConfig(BaseModel):

--- a/app/schemas/test_environment_config.py
+++ b/app/schemas/test_environment_config.py
@@ -61,8 +61,8 @@ class DutConfig(BaseModel):
     setup_code: str
     pairing_mode: DutPairingModeEnum
     chip_timeout: Optional[str]
-    chip_use_paa_certs: bool = False    
-    trace_log: bool = True    
+    chip_use_paa_certs: bool = False
+    trace_log: bool = True
 
 
 class TestEnvironmentConfig(BaseModel):

--- a/default_test_environment.config
+++ b/default_test_environment.config
@@ -23,6 +23,7 @@
     "pairing_mode":"onnetwork",
     "setup_code":"20202021",
     "discriminator":"3840",
-    "chip_use_paa_certs":false
+    "chip_use_paa_certs":false,
+    "trace_log":true
   }
 }

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -30,7 +30,7 @@ RUNNER_CLASS_PATH = "/root/python_testing/scripts/sdk/test_harness_client.py"
 EXECUTABLE = "python3"
 
 
-def generate_command_arguments(
+def     generate_command_arguments(
     config: TestEnvironmentConfig, omit_commissioning_method: bool = False
 ) -> list:
     dut_config = config.dut_config
@@ -44,7 +44,8 @@ def generate_command_arguments(
 
     arguments = []
     # Increase log level by adding trace log
-    arguments.append("--trace-to json:log")
+    if dut_config.trace_log:
+        arguments.append("--trace-to json:log")
     # Retrieve arguments from dut_config
     arguments.append(f"--discriminator {dut_config.discriminator}")
     arguments.append(f"--passcode {dut_config.setup_code}")

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -30,7 +30,7 @@ RUNNER_CLASS_PATH = "/root/python_testing/scripts/sdk/test_harness_client.py"
 EXECUTABLE = "python3"
 
 
-def     generate_command_arguments(
+def generate_command_arguments(
     config: TestEnvironmentConfig, omit_commissioning_method: bool = False
 ) -> list:
     dut_config = config.dut_config

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -183,6 +183,7 @@ async def test_generate_command_arguments_no_test_parameter_informed() -> None:
         "--commissioning-method ble-thread",
     ] == arguments
 
+
 @pytest.mark.asyncio
 async def test_generate_command_arguments_trace_log_false_informed() -> None:
     # Mock config
@@ -194,7 +195,7 @@ async def test_generate_command_arguments_trace_log_false_informed() -> None:
         discriminator="456",
         setup_code="8765",
         pairing_mode=DutPairingModeEnum.BLE_THREAD,
-        trace_log=False
+        trace_log=False,
     )
 
     mock_config.dut_config = mock_dut_config

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -183,6 +183,32 @@ async def test_generate_command_arguments_no_test_parameter_informed() -> None:
         "--commissioning-method ble-thread",
     ] == arguments
 
+@pytest.mark.asyncio
+async def test_generate_command_arguments_trace_log_false_informed() -> None:
+    # Mock config
+    mock_config = default_environment_config.copy(deep=True)
+
+    mock_config.test_parameters = None
+
+    mock_dut_config = DutConfig(
+        discriminator="456",
+        setup_code="8765",
+        pairing_mode=DutPairingModeEnum.BLE_THREAD,
+        trace_log=False
+    )
+
+    mock_config.dut_config = mock_dut_config
+
+    arguments = generate_command_arguments(
+        config=mock_config, omit_commissioning_method=False
+    )
+
+    assert [
+        "--discriminator 456",
+        "--passcode 8765",
+        "--commissioning-method ble-thread",
+    ] == arguments
+
 
 @pytest.mark.asyncio
 async def test_generate_command_arguments_omit_comissioning_method() -> None:


### PR DESCRIPTION
The Goal of this PR is to make trace-log configurable for Python Tests.

Related Issue: https://github.com/project-chip/certification-tool/issues/196

This PR does not fix this issue, it's actually a working around since by disabling trace-log the tests listed in the issue passes successfully.