### PR TITLE
Reword python test legacy collection

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/sdk_python_tests.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/sdk_python_tests.py
@@ -64,7 +64,7 @@ def _init_test_suites(
             version=python_test_version,
         ),
         SuiteType.LEGACY: PythonSuiteDeclaration(
-            name="Python Testing Suite - Legacy",
+            name="Python Testing Suite - Old script format",
             suite_type=SuiteType.LEGACY,
             version=python_test_version,
         ),


### PR DESCRIPTION
### What changed
Reword python test legacy collection

### Related Issue
https://github.com/project-chip/certification-tool/issues/216

### Testing
Python test legacy collection reword in UI
![Screenshot 2024-04-05 at 09 36 38](https://github.com/project-chip/certification-tool-backend/assets/116586593/f2293227-bf37-4165-a939-120f2c8c832e)


Unit testing passing
<img width="418" alt="Screenshot 2024-04-05 at 09 35 59" src="https://github.com/project-chip/certification-tool-backend/assets/116586593/033730ba-79da-4c35-b94f-8abaa0f70e23">
