### PR TITLE
Create migration scripts due to python legacy suite was renamed

### DIFF
--- a/alembic/versions/9df8004ad9bb_migrate_python_test_legacy_suite_.py
+++ b/alembic/versions/9df8004ad9bb_migrate_python_test_legacy_suite_.py
@@ -1,0 +1,38 @@
+"""Migrate python test legacy suite executions
+
+Revision ID: 9df8004ad9bb
+Revises: 96ee37627a48
+Create Date: 2024-04-24 17:26:26.770729
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "9df8004ad9bb"
+down_revision = "96ee37627a48"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Update Python Testing Suite - Legacy suite referece 
+    # to Python Testing Suite - Old script format
+    op.execute(
+        "Update testsuiteexecution set public_id='Python Testing Suite - Old script format' where public_id='Python Testing Suite - Legacy'"
+    )
+    op.execute(
+        "Update testsuitemetadata set public_id='Python Testing Suite - Old script format', title='Python Testing Suite - Old script format', description='Python Testing Suite - Old script format' where public_id='Python Testing Suite - Legacy'"
+    )
+
+
+def downgrade():
+    # Update Python Testing Suite - Old script format suite reference 
+    # to Python Testing Suite - Legacy
+    op.execute(
+        "Update testsuiteexecution set public_id='Python Testing Suite - Legacy' where public_id='Python Testing Suite - Old script format'"
+    )
+    op.execute(
+        "Update testsuitemetadata set public_id='Python Testing Suite - Legacy', title='Python Testing Suite - Legacy', description='Python Testing Suite - Legacy' where public_id='Python Testing Suite - Old script format'"
+    )

--- a/alembic/versions/9df8004ad9bb_migrate_python_test_legacy_suite_.py
+++ b/alembic/versions/9df8004ad9bb_migrate_python_test_legacy_suite_.py
@@ -6,7 +6,6 @@ Create Date: 2024-04-24 17:26:26.770729
 
 """
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
@@ -17,22 +16,34 @@ depends_on = None
 
 
 def upgrade():
-    # Update Python Testing Suite - Legacy suite referece 
+    # Update Python Testing Suite - Legacy suite reference
     # to Python Testing Suite - Old script format
     op.execute(
-        "Update testsuiteexecution set public_id='Python Testing Suite - Old script format' where public_id='Python Testing Suite - Legacy'"
+        "Update testsuiteexecution "
+        "set public_id='Python Testing Suite - Old script format' "
+        "where public_id='Python Testing Suite - Legacy'"
     )
     op.execute(
-        "Update testsuitemetadata set public_id='Python Testing Suite - Old script format', title='Python Testing Suite - Old script format', description='Python Testing Suite - Old script format' where public_id='Python Testing Suite - Legacy'"
+        "Update testsuitemetadata "
+        "set public_id='Python Testing Suite - Old script format', "
+        "title='Python Testing Suite - Old script format', "
+        "description='Python Testing Suite - Old script format' "
+        "where public_id='Python Testing Suite - Legacy'"
     )
 
 
 def downgrade():
-    # Update Python Testing Suite - Old script format suite reference 
+    # Update Python Testing Suite - Old script format suite reference
     # to Python Testing Suite - Legacy
     op.execute(
-        "Update testsuiteexecution set public_id='Python Testing Suite - Legacy' where public_id='Python Testing Suite - Old script format'"
+        "Update testsuiteexecution "
+        "set public_id='Python Testing Suite - Legacy' "
+        "where public_id='Python Testing Suite - Old script format'"
     )
     op.execute(
-        "Update testsuitemetadata set public_id='Python Testing Suite - Legacy', title='Python Testing Suite - Legacy', description='Python Testing Suite - Legacy' where public_id='Python Testing Suite - Old script format'"
+        "Update testsuitemetadata "
+        "set public_id='Python Testing Suite - Legacy', "
+        "title='Python Testing Suite - Legacy', "
+        "description='Python Testing Suite - Legacy' "
+        "where public_id='Python Testing Suite - Old script format'"
     )

--- a/app/crud/crud_project.py
+++ b/app/crud/crud_project.py
@@ -81,7 +81,7 @@ class CRUDProject(
         if obj_in.config is None or len(obj_in.config) == 0:
             obj_in.config = default_environment_config.__dict__
             json_obj_in = jsonable_encoder(obj_in)
-        # Try to instanciate the program class in order to validate the input data
+        # Try to instantiate the program class in order to validate the input data
         if program_class:
             program_class(**json_obj_in["config"])
 
@@ -111,7 +111,7 @@ class CRUDProject(
             if field in update_data:
                 setattr(db_obj, field, update_data[field])
 
-        # Try to instanciate the program class in order to validate the input data
+        # Try to instantiate the program class in order to validate the input data
         if program_class:
             program_class(**jsonable_encoder(db_obj)["config"])
 

--- a/cspell.json
+++ b/cspell.json
@@ -98,7 +98,7 @@
     "ignorePaths": [
         "logs",
         "test_collections/matter/python_tests/onboarding_payload_test_suite/",
-        "app/otbr_manager/avahi/avahi-daemon.conf",
+        "test_collections/matter/sdk_tests/support/otbr_manager/avahi/avahi-daemon.conf",
         "*.ini",
         "*.toml",
         "docker-compose*",

--- a/cspell.json
+++ b/cspell.json
@@ -98,7 +98,8 @@
     "ignorePaths": [
         "logs",
         "test_collections/matter/python_tests/onboarding_payload_test_suite/",
-        "test_collections/matter/sdk_tests/support/otbr_manager/avahi/avahi-daemon.conf",
+        "test_collections/matter/sdk_tests/support/otbr_manager/avahi",
+        "test_collections/matter/scripts/OTBR",
         "*.ini",
         "*.toml",
         "docker-compose*",

--- a/cspell.json
+++ b/cspell.json
@@ -98,8 +98,7 @@
     "ignorePaths": [
         "logs",
         "test_collections/matter/python_tests/onboarding_payload_test_suite/",
-        "test_collections/matter/sdk_tests/support/otbr_manager/avahi",
-        "test_collections/matter/scripts/OTBR",
+        "app/otbr_manager/avahi/avahi-daemon.conf",
         "*.ini",
         "*.toml",
         "docker-compose*",

--- a/test_collections/matter/sdk_tests/support/tests/matter/test_test_environment_config.py
+++ b/test_collections/matter/sdk_tests/support/tests/matter/test_test_environment_config.py
@@ -26,7 +26,7 @@ from test_collections.matter.sdk_tests.support.tests.utils.utils import (
 from test_collections.matter.test_environment_config import TestEnvironmentConfigMatter
 
 
-def test_create_config_matter_with_valid_config_suceess() -> None:
+def test_create_config_matter_with_valid_config_success() -> None:
     config_matter = TestEnvironmentConfigMatter(**default_matter_config)
 
     assert config_matter is not None

--- a/test_collections/matter/test_environment_config.py
+++ b/test_collections/matter/test_environment_config.py
@@ -69,7 +69,7 @@ class TestEnvironmentConfigMatter(TestEnvironmentConfig):
 
             if not dut_config or not network:
                 raise TestEnvironmentConfigMatterError(
-                    "The dut_config and network configuration are mandatories"
+                    "The dut_config and network configuration are mandatory"
                 )
 
             # Check if the informed field in dut_config is valid


### PR DESCRIPTION
### What changed
The Goal of this PR is to provide a migration scripts since `Python Testing Suite - Legacy` python suite was renamed to `Python Testing Suite - Old`.

### Related Issue
https://github.com/project-chip/certification-tool/issues/256