### PR TITLE
Implement project config test_parameter allow non default test parameters

### DIFF
--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -52,10 +52,7 @@ class TestCase(TestObservable):
         test_parameters = self.default_test_parameters()
 
         if config_dict and config_dict.get("test_parameters"):
-            test_parameters |= config_dict.get(  # type: ignore
-                "test_parameters"
-            )
-
+            test_parameters |= config_dict.get("test_parameters")  # type: ignore
 
         return test_parameters
 

--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -52,9 +52,9 @@ class TestCase(TestObservable):
         default_test_parameters = self.default_test_parameters()
 
         if config_dict and config_dict.get("test_parameters"):
-            test_parameters = default_test_parameters | config_dict.get(
+            test_parameters = default_test_parameters | config_dict.get(  # type: ignore
                 "test_parameters"
-            )  # type: ignore
+            )
         else:
             test_parameters = default_test_parameters
 

--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -49,14 +49,13 @@ class TestCase(TestObservable):
     def test_parameters(self) -> dict[str, Any]:
         config_dict = cast(dict, self.config)
 
-        default_test_parameters = self.default_test_parameters()
+        test_parameters = self.default_test_parameters()
 
         if config_dict and config_dict.get("test_parameters"):
-            test_parameters = default_test_parameters | config_dict.get(  # type: ignore
+            test_parameters |= config_dict.get(  # type: ignore
                 "test_parameters"
             )
-        else:
-            test_parameters = default_test_parameters
+
 
         return test_parameters
 

--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -49,20 +49,16 @@ class TestCase(TestObservable):
     def test_parameters(self) -> dict[str, Any]:
         config_dict = cast(dict, self.config)
 
-        if not config_dict or config_dict.get("test_parameters") is None:
-            return self.default_test_parameters()
-        else:
-            test_parameters = config_dict.get("test_parameters")
-            all_test_parameters = (
-                self.default_test_parameters() | test_parameters  # type: ignore
-            )
+        default_test_parameters = self.default_test_parameters()
 
-        # filter test_parameters to only contain relevant test_parameters from
-        # default_test_parameters
-        return {
-            name: all_test_parameters[name]
-            for name in self.default_test_parameters().keys()
-        }
+        if config_dict and config_dict.get("test_parameters"):
+            test_parameters = default_test_parameters | config_dict.get(
+                "test_parameters"
+            )  # type: ignore
+        else:
+            test_parameters = default_test_parameters
+
+        return test_parameters
 
     def __init__(self, test_case_execution: TestCaseExecution):
         super().__init__()

--- a/app/tests/test_engine/test_test_case.py
+++ b/app/tests/test_engine/test_test_case.py
@@ -95,12 +95,12 @@ def test_test_case_test_params_merged() -> None:
             == DEFAULT_TEST_PARAMETERS[TEST_PARAMETER_NAME_2]
         )
 
-        # Assert parameter 3 is NOT present as it is not in default test parameters
-        assert TEST_PARAMETER_NAME_3 not in case.test_parameters
+        # Assert parameter 3 is present even it is not in default test parameters
+        assert TEST_PARAMETER_NAME_3 in case.test_parameters
 
 
 def test_test_case_no_test_parameters() -> None:
-    """Test that a TestCase without default test parameters will not have runtime test
+    """Test that a TestCase without default test parameters will have runtime test
     parameters.
     """
     mock_config = default_environment_config.copy(deep=True)  # type: ignore
@@ -118,7 +118,8 @@ def test_test_case_no_test_parameters() -> None:
         case = NoDefaultTestParamsTestCase(
             test_case_execution=MagicMock(spec=TestCaseExecution)
         )
-        assert case.test_parameters == {}
+        assert case.test_parameters[TEST_PARAMETER_NAME_1] == 11
+        assert case.test_parameters[TEST_PARAMETER_NAME_3] == 333
 
 
 def test_test_case_cancel_test_case() -> None:

--- a/app/tests/test_engine/test_test_case.py
+++ b/app/tests/test_engine/test_test_case.py
@@ -95,7 +95,7 @@ def test_test_case_test_params_merged() -> None:
             == DEFAULT_TEST_PARAMETERS[TEST_PARAMETER_NAME_2]
         )
 
-        # Assert parameter 3 is present even it is not in default test parameters
+        # Assert parameter 3 is present even if it is not in default test parameters
         assert TEST_PARAMETER_NAME_3 in case.test_parameters
 
 


### PR DESCRIPTION
### What changed
TH was not considering test_parameter if they are not defined in default_test_parameter.  The goal of this PR is to allow the add test_parameter other than the default_test_parameter defined in test cases.