### PR TITLE
fix python test step parser

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -12,6 +12,7 @@
         "baudrate",
         "behaviour",
         "bothify",
+        "buildx",
         "chip",
         "commissionee",
         "connectedhomeip",


### PR DESCRIPTION
- Adding default string when failed to parse the test step name 

![image](https://github.com/project-chip/certification-tool-backend/assets/116589806/7b4d617a-c89f-4fa6-aa73-c943188c2618)
