### PR TITLE
[FIX] TH Repeat Tests Feature With More Iterations

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -167,11 +167,13 @@ def selected_tests_from_execution(run: TestRunExecution) -> TestSelection:
 
     for suite in run.test_suite_executions:
         selected_tests.setdefault(suite.collection_id, {})
-        selected_tests[suite.collection_id][suite.public_id] = {}
+        selected_tests[suite.collection_id].setdefault(suite.public_id, {})
+        suite_dict = selected_tests[suite.collection_id][suite.public_id]
         for case in suite.test_case_executions:
-            selected_tests[suite.collection_id][suite.public_id].update(
-                {case.public_id: 1}
-            )
+            if case.public_id in suite_dict.keys():
+                suite_dict[case.public_id] += 1
+            else:
+                suite_dict.update({case.public_id: 1})
 
     return selected_tests
 


### PR DESCRIPTION
## Description

Fixing the repeat feature for executions that have tests with two or more iterations.
Before this change, if any test from the execution had more iterations, only one iteration was being run.

Now all iterations are being respected in the repeat 
<img width="566" alt="Screenshot 2024-07-19 at 10 32 15" src="https://github.com/user-attachments/assets/22cddac6-8791-4175-a276-6e38852b5528">
<img width="1603" alt="Screenshot 2024-07-19 at 10 16 33" src="https://github.com/user-attachments/assets/346a5cc3-fcb8-49a4-8d59-e2eb4254bb3a">
