### PR TITLE
[FIX] Add workaround code for truncated log

### DIFF
--- a/test_collections/matter/sdk_tests/support/chip/chip_server.py
+++ b/test_collections/matter/sdk_tests/support/chip/chip_server.py
@@ -15,6 +15,7 @@
 #
 from __future__ import annotations
 
+from asyncio import sleep
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -100,6 +101,10 @@ class ChipServer(metaclass=Singleton):
                     self.logger.log(CHIPTOOL_LEVEL, line)
                     return True
                 self.logger.log(CHIPTOOL_LEVEL, line)
+            # TODO - Workaround for truncated log from chip-tool
+            # https://github.com/project-chip/connectedhomeip/issues/34237
+            await sleep(1)
+            return True
         else:
             return False
 


### PR DESCRIPTION
### What changed
The goal of this PR is to workaround the SDK issue that happens while TH reads logs from chip-tool.
The SDK issue impacts YAMLS test execution.
SDK Issue: https://github.com/project-chip/connectedhomeip/issues/34237

##$ Testing
YAML test cases running successfully
<img width="534" alt="Screenshot 2024-07-19 at 13 20 47" src="https://github.com/user-attachments/assets/21569d5e-7409-4c4d-809d-a48ef7178aa2">
