### PR TITLE
Cancel test execution if one of the mandatory test cases fail on certification mode

### DIFF
--- a/alembic/versions/e2c185af1226_pics_v2_support.py
+++ b/alembic/versions/e2c185af1226_pics_v2_support.py
@@ -52,15 +52,11 @@ def upgrade():
     )
     op.alter_column(
         "testsuitemetadata",
-        sa.Column(
-            "mandatory", existing_type=sa.Boolean(), nullable=False, default=False
-        ),
+        sa.Column("mandatory", nullable=False, default=False),
     )
     op.alter_column(
         "testcasemetadata",
-        sa.Column(
-            "mandatory", existing_type=sa.Boolean(), nullable=False, default=False
-        ),
+        sa.Column("mandatory", nullable=False, default=False),
     )
     # ### end Alembic commands ###
 

--- a/app/test_engine/models/test_run.py
+++ b/app/test_engine/models/test_run.py
@@ -125,9 +125,7 @@ class TestRun(TestObservable):
                 self.test_run_execution.certification_mode
                 and test_suite.mandatory
                 and any(
-                    tc
-                    for tc in test_suite.test_cases
-                    if tc.state != TestStateEnum.PASSED
+                    tc.state != TestStateEnum.PASSED for tc in test_suite.test_cases
                 )
             ):
                 print("Abort execution")

--- a/app/test_engine/models/test_run.py
+++ b/app/test_engine/models/test_run.py
@@ -120,6 +120,21 @@ class TestRun(TestObservable):
             self.current_test_suite = test_suite
             await test_suite.run()
 
+            # Check if mandatory suite failed
+            if (
+                self.test_run_execution.certification_mode
+                and test_suite.mandatory
+                and any(
+                    tc
+                    for tc in test_suite.test_cases
+                    if tc.state != TestStateEnum.PASSED
+                )
+            ):
+                print("Abort execution")
+                self.__cancel_remaining_tests()
+                self.cancel()
+                break
+
     def cancel(self) -> None:
         """This will abort executuion of the current test suite, and mark all remaining
         tests as cancelled."""

--- a/app/test_engine/models/test_run.py
+++ b/app/test_engine/models/test_run.py
@@ -138,9 +138,8 @@ class TestRun(TestObservable, UserPromptSupport):
 
     async def __display_mandatory_test_failure_prompt(self) -> None:
         prompt = (
-            "At least one of the mandatory test cases have failed during a "
-            "test run execution in certification mode.\nAs a consequence, the remaining"
-            " tests have been cancelled."
+            "At least one of the mandatory test cases failed while running in "
+            "certification mode.\nAs a consequence, the remaining tests were cancelled."
         )
         options = {"OK": 1}
         prompt_request = OptionsSelectPromptRequest(prompt=prompt, options=options)

--- a/app/test_engine/models/test_suite.py
+++ b/app/test_engine/models/test_suite.py
@@ -40,16 +40,14 @@ class TestSuite(TestObservable):
 
     available_test_cases: List[Type[TestCase]] = []
 
-    def __init__(
-        self, test_suite_execution: TestSuiteExecution, mandatory: bool = False
-    ):
+    def __init__(self, test_suite_execution: TestSuiteExecution):
         super().__init__()
         self.test_suite_execution: TestSuiteExecution = test_suite_execution
         self.current_test_case: Optional[TestCase] = None
         self.test_cases: List[TestCase] = []
         self.__state = TestStateEnum.PENDING
         self.errors: List[str] = []
-        self.mandatory: bool = mandatory
+        self.mandatory: bool = test_suite_execution.mandatory
 
     @property
     def project(self) -> Project:

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -168,7 +168,10 @@ class PythonTestCase(TestCase, UserPromptSupport):
 
         if test.python_test_type == PythonTestType.NO_COMMISSIONING:
             case_class = NoCommissioningPythonTestCase
-        elif test.python_test_type == PythonTestType.LEGACY:
+        elif (
+            test.python_test_type == PythonTestType.LEGACY
+            or test.python_test_type == PythonTestType.MANDATORY
+        ):
             case_class = LegacyPythonTestCase
         else:  # Commissioning
             case_class = PythonTestCase

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_suite.py
@@ -61,9 +61,9 @@ class YamlTestSuite(TestSuite):
         if suite_type == SuiteType.MANUAL:
             suite_class = ManualYamlTestSuite
         elif suite_type == SuiteType.SIMULATED:
-            suite_class = SimulatedYamlTestSuite  # type: ignore
+            suite_class = SimulatedYamlTestSuite
         elif suite_type == SuiteType.AUTOMATED:
-            suite_class = ChipYamlTestSuite  # type: ignore
+            suite_class = ChipYamlTestSuite
 
         return suite_class.__class_factory(name=name, yaml_version=yaml_version)
 


### PR DESCRIPTION
Part of the PICS v2 implementation.

- Cancel test execution if one of the mandatory test cases fail on certification mode.
- Display a prompt explaining this cancellation to the user.
- Ask the user if the DUT should be commissioned at the start of each mandatory test case.

<img width="1809" alt="Screenshot 2024-07-23 at 14 30 39" src="https://github.com/user-attachments/assets/74eaff8b-b8e1-411d-aa61-2189c4c14a98">
