### PR TITLE
Add support for test not applicable

### DIFF
--- a/app/models/test_enums.py
+++ b/app/models/test_enums.py
@@ -24,5 +24,5 @@ class TestStateEnum(str, Enum):
     PASSED = "passed"  # Test Passed with no issued
     FAILED = "failed"  # Test Failed
     ERROR = "error"  # Test Error due to tool setup or environment
-    NOT_APPLICABLE = "not_applicable"  # TODO: Do we need this for full cert runs?
+    NOT_APPLICABLE = "not_applicable"  # Test is not applicable - e.g. PICS mismatch
     CANCELLED = "cancelled"

--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -282,6 +282,7 @@ class TestCase(TestObservable):
 
     def mark_as_not_applicable(self) -> None:
         self.state = TestStateEnum.NOT_APPLICABLE
+        logger.warning(f"Test Case Not Applicable: {self.metadata['public_id']}")
 
     def next_step(self) -> None:
         if self.current_test_step_index + 1 >= len(self.test_steps):

--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -152,7 +152,7 @@ class TestCase(TestObservable):
         return TestStateEnum.PASSED
 
     def any_steps_with_state(self, state: TestStateEnum) -> bool:
-        return any(ts for ts in self.test_steps if ts.state == state)
+        return any(ts.state == state for ts in self.test_steps)
 
     def completed(self) -> bool:
         return self.state not in [

--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -299,3 +299,34 @@ class TestCase(TestObservable):
 
     async def cleanup(self) -> None:
         raise NotImplementedError  # Must be overridden by subclass
+
+    # def __cancel_remaning_test_steps(self) -> None:
+    #     for step in self.test_steps:
+    #         step.state = TestStateEnum.CANCELLED
+
+    # # def cancel(self) -> None:
+    # #     # Only cancel if test case is not already completed
+    # #     if self.completed():
+    # #         return
+
+    # #     # Cancel remaning test_steps
+    # #     self.__cancel_remaning_test_steps()
+
+    # #     logger.info("Cancel test case")
+    # #     self.mark_as_completed()
+
+    # def __not_applicable_all_test_steps(self) -> None:
+    #     for step in self.test_steps:
+    #         step.state = TestStateEnum.NOT_APPLICABLE
+
+    # def mark_as_not_applicable(self) -> None:
+    #     self.state = TestStateEnum.NOT_APPLICABLE
+
+    #     # Not applicable all test_steps
+    #     self.__not_applicable_all_test_steps()
+
+    #     # if self.completed():
+    #     #     return
+    #     # self.state = self.__compute_state()
+    #     logger.info(f"Test Case Completed[{self.state.name}]: {self.metadata['title']}")
+    #     self.__print_log_separator()

--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -300,33 +300,18 @@ class TestCase(TestObservable):
     async def cleanup(self) -> None:
         raise NotImplementedError  # Must be overridden by subclass
 
-    # def __cancel_remaning_test_steps(self) -> None:
-    #     for step in self.test_steps:
-    #         step.state = TestStateEnum.CANCELLED
+    def __not_applicable_all_test_steps(self) -> None:
+        for step in self.test_steps:
+            step.state = TestStateEnum.NOT_APPLICABLE
 
-    # # def cancel(self) -> None:
-    # #     # Only cancel if test case is not already completed
-    # #     if self.completed():
-    # #         return
+    def mark_as_not_applicable(self) -> None:
+        self.state = TestStateEnum.NOT_APPLICABLE
 
-    # #     # Cancel remaning test_steps
-    # #     self.__cancel_remaning_test_steps()
+        # Not applicable all test_steps
+        self.__not_applicable_all_test_steps()
 
-    # #     logger.info("Cancel test case")
-    # #     self.mark_as_completed()
-
-    # def __not_applicable_all_test_steps(self) -> None:
-    #     for step in self.test_steps:
-    #         step.state = TestStateEnum.NOT_APPLICABLE
-
-    # def mark_as_not_applicable(self) -> None:
-    #     self.state = TestStateEnum.NOT_APPLICABLE
-
-    #     # Not applicable all test_steps
-    #     self.__not_applicable_all_test_steps()
-
-    #     # if self.completed():
-    #     #     return
-    #     # self.state = self.__compute_state()
-    #     logger.info(f"Test Case Completed[{self.state.name}]: {self.metadata['title']}")
-    #     self.__print_log_separator()
+        # if self.completed():
+        #     return
+        # self.state = self.__compute_state()
+        logger.info(f"Test Case Completed[{self.state.name}]: {self.metadata['title']}")
+        self.__print_log_separator()

--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -130,6 +130,11 @@ class TestCase(TestObservable):
         if self.errors is not None and len(self.errors) > 0:
             return TestStateEnum.ERROR
 
+        # Test cases that have already been marked as not applicable should not
+        # change state
+        if self.state == TestStateEnum.NOT_APPLICABLE:
+            return TestStateEnum.NOT_APPLICABLE
+
         # Note: These loops cannot be easily coalesced as we need to iterate through
         # and assign Test Case State in order.
         if self.any_steps_with_state(TestStateEnum.CANCELLED):
@@ -150,7 +155,11 @@ class TestCase(TestObservable):
         return any(ts for ts in self.test_steps if ts.state == state)
 
     def completed(self) -> bool:
-        return self.state not in [TestStateEnum.PENDING, TestStateEnum.EXECUTING]
+        return self.state not in [
+            TestStateEnum.PENDING,
+            TestStateEnum.EXECUTING,
+            TestStateEnum.NOT_APPLICABLE,
+        ]
 
     def __cancel_remaning_test_steps(self) -> None:
         for step in self.test_steps:
@@ -269,6 +278,9 @@ class TestCase(TestObservable):
 
         self.current_test_step.append_failure(message)
 
+    def mark_as_not_applicable(self) -> None:
+        self.state = TestStateEnum.NOT_APPLICABLE
+
     def next_step(self) -> None:
         if self.current_test_step_index + 1 >= len(self.test_steps):
             return
@@ -299,19 +311,3 @@ class TestCase(TestObservable):
 
     async def cleanup(self) -> None:
         raise NotImplementedError  # Must be overridden by subclass
-
-    def __not_applicable_all_test_steps(self) -> None:
-        for step in self.test_steps:
-            step.state = TestStateEnum.NOT_APPLICABLE
-
-    def mark_as_not_applicable(self) -> None:
-        self.state = TestStateEnum.NOT_APPLICABLE
-
-        # Not applicable all test_steps
-        self.__not_applicable_all_test_steps()
-
-        # if self.completed():
-        #     return
-        # self.state = self.__compute_state()
-        logger.info(f"Test Case Completed[{self.state.name}]: {self.metadata['title']}")
-        self.__print_log_separator()

--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -180,7 +180,9 @@ class TestCase(TestObservable):
         if self.completed():
             return
         self.state = self.__compute_state()
-        logger.info(f"Test Case Completed[{self.state.name}]: {self.metadata['title']}")
+        logger.info(
+            f"Test Case Completed [{self.state.name}]: {self.metadata['title']}"
+        )
         self.__print_log_separator()
 
     def mark_as_executing(self) -> None:

--- a/app/test_engine/models/test_run.py
+++ b/app/test_engine/models/test_run.py
@@ -74,17 +74,20 @@ class TestRun(TestObservable, UserPromptSupport):
 
         # Note: These loops cannot be easily coalesced as we need to iterate through
         # and assign Test Suite State in order.
-        if any(ts for ts in self.test_suites if ts.state == TestStateEnum.CANCELLED):
+        if any(ts.state == TestStateEnum.CANCELLED for ts in self.test_suites):
             return TestStateEnum.CANCELLED
 
-        if any(ts for ts in self.test_suites if ts.state == TestStateEnum.ERROR):
+        if any(ts.state == TestStateEnum.ERROR for ts in self.test_suites):
             return TestStateEnum.ERROR
 
-        if any(ts for ts in self.test_suites if ts.state == TestStateEnum.FAILED):
+        if any(ts.state == TestStateEnum.FAILED for ts in self.test_suites):
             return TestStateEnum.FAILED
 
-        if any(ts for ts in self.test_suites if ts.state == TestStateEnum.PENDING):
+        if any(ts.state == TestStateEnum.PENDING for ts in self.test_suites):
             return TestStateEnum.PENDING
+
+        if all(ts.state == TestStateEnum.NOT_APPLICABLE for ts in self.test_suites):
+            return TestStateEnum.NOT_APPLICABLE
 
         return TestStateEnum.PASSED
 

--- a/app/test_engine/models/test_suite.py
+++ b/app/test_engine/models/test_suite.py
@@ -85,17 +85,20 @@ class TestSuite(TestObservable):
 
         # Note: These loops cannot be easily coalesced as we need to iterate through
         # and assign Test Suite State in order.
-        if any(tc for tc in self.test_cases if tc.state == TestStateEnum.CANCELLED):
+        if any(tc.state == TestStateEnum.CANCELLED for tc in self.test_cases):
             return TestStateEnum.CANCELLED
 
-        if any(tc for tc in self.test_cases if tc.state == TestStateEnum.ERROR):
+        if any(tc.state == TestStateEnum.ERROR for tc in self.test_cases):
             return TestStateEnum.ERROR
 
-        if any(tc for tc in self.test_cases if tc.state == TestStateEnum.FAILED):
+        if any(tc.state == TestStateEnum.FAILED for tc in self.test_cases):
             return TestStateEnum.FAILED
 
-        if any(tc for tc in self.test_cases if tc.state == TestStateEnum.PENDING):
+        if any(tc.state == TestStateEnum.PENDING for tc in self.test_cases):
             return TestStateEnum.PENDING
+
+        if all(tc.state == TestStateEnum.NOT_APPLICABLE for tc in self.test_cases):
+            return TestStateEnum.NOT_APPLICABLE
 
         return TestStateEnum.PASSED
 

--- a/app/tests/test_log_utils.py
+++ b/app/tests/test_log_utils.py
@@ -208,7 +208,23 @@ mocked_log: List[TestRunLogEntry] = [
     ),
     TestRunLogEntry(
         level="INFO",
-        timestamp=1684878245.0,
+        timestamp=1684878254.0,
+        message="Test suite 1 case 3 log 0",
+        test_suite_execution_index=1,
+        test_case_execution_index=3,
+        test_step_execution_index=None,
+    ),
+    TestRunLogEntry(
+        level="INFO",
+        timestamp=1684878255.0,
+        message="Test suite 1 case 3 step 0 log 0",
+        test_suite_execution_index=1,
+        test_case_execution_index=3,
+        test_step_execution_index=0,
+    ),
+    TestRunLogEntry(
+        level="INFO",
+        timestamp=1684878265.0,
         message="Test suite 1 log 2",
         test_suite_execution_index=1,
         test_case_execution_index=None,
@@ -216,7 +232,7 @@ mocked_log: List[TestRunLogEntry] = [
     ),
     TestRunLogEntry(
         level="INFO",
-        timestamp=1684878246.0,
+        timestamp=1684878276.0,
         message="General log 3",
         test_suite_execution_index=None,
         test_case_execution_index=None,
@@ -366,6 +382,31 @@ mocked_test_run_execution = schemas.TestRunExecutionWithChildren(
                     ),
                     test_step_executions=[],
                 ),
+                schemas.TestCaseExecution(
+                    state=TestStateEnum.NOT_APPLICABLE,
+                    public_id="TC-Y-1.4",
+                    execution_index=1,
+                    id=5,
+                    test_suite_execution_id=2,
+                    test_case_metadata_id=5,
+                    test_case_metadata=schemas.TestCaseMetadata(
+                        public_id="TC-Y-1.4",
+                        title="[TC-Y-1.4] Title",
+                        description="Fourth test case",
+                        version="1.0",
+                        source_hash="abc123",
+                        id=5,
+                    ),
+                    test_step_executions=[
+                        schemas.TestStepExecution(
+                            state=TestStateEnum.PASSED,
+                            title="First step",
+                            execution_index=0,
+                            id=5,
+                            test_case_execution_id=5,
+                        )
+                    ],
+                ),
             ],
             test_suite_metadata=schemas.TestSuiteMetadata(
                 public_id="Suite1",
@@ -392,11 +433,13 @@ def test_group_test_run_execution_logs() -> None:
     assert len(grouped_logs.suites) == 2
     assert len(grouped_logs.suites["Suite0"]) == 4
     assert len(grouped_logs.suites["Suite1"]) == 3
-    assert len(grouped_logs.cases) == 3
+    assert len(grouped_logs.cases) == 4
     assert len(grouped_logs.cases[TestStateEnum.PASSED]) == 2
     assert len(grouped_logs.cases[TestStateEnum.ERROR]) == 1
     assert len(grouped_logs.cases[TestStateEnum.FAILED]) == 1
+    assert len(grouped_logs.cases[TestStateEnum.NOT_APPLICABLE]) == 1
     assert len(grouped_logs.cases[TestStateEnum.PASSED]["TC-X-1.1"]) == 5
     assert len(grouped_logs.cases[TestStateEnum.PASSED]["TC-Y-1.3"]) == 1
     assert len(grouped_logs.cases[TestStateEnum.ERROR]["TC-Y-1.1"]) == 5
     assert len(grouped_logs.cases[TestStateEnum.FAILED]["TC-Y-1.2"]) == 3
+    assert len(grouped_logs.cases[TestStateEnum.NOT_APPLICABLE]["TC-Y-1.4"]) == 2

--- a/test_collections/matter/config.py
+++ b/test_collections/matter/config.py
@@ -23,9 +23,9 @@ class MatterSettings(BaseSettings):
 
     # SDK Docker Image
     SDK_DOCKER_IMAGE: str = "connectedhomeip/chip-cert-bins"
-    SDK_DOCKER_TAG: str = "5db170117d3afd5b4c815c1c181cc8646779cc5a"
+    SDK_DOCKER_TAG: str = "1cbcc5c81d478e4d24d68ced29c49cedef2043d8"
     # SDK SHA: used to fetch test YAML from SDK.
-    SDK_SHA: str = "5db170117d3afd5b4c815c1c181cc8646779cc5a"
+    SDK_SHA: str = "1cbcc5c81d478e4d24d68ced29c49cedef2043d8"
 
     class Config:
         case_sensitive = True

--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
@@ -141,13 +141,12 @@ class SDKPythonTestRunnerHooks(TestRunnerHooks):
         self.results.put(SDKPythonTestResultStop(duration=duration))
         SDKPythonTestRunnerHooks.finished = True
 
-    def test_start(self, filename: str, name: str, count: int, steps: list[str] = []) -> None:
+    def test_start(
+        self, filename: str, name: str, count: int, steps: list[str] = []
+    ) -> None:
         self.results.put(
             SDKPythonTestResultTestStart(
-                filename=filename,
-                name=name,
-                count=count,
-                steps=steps 
+                filename=filename, name=name, count=count, steps=steps
             )
         )
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
@@ -153,10 +153,7 @@ class SDKPythonTestRunnerHooks(TestRunnerHooks):
 
     def test_stop(self, exception: Exception, duration: int) -> None:
         self.results.put(
-            SDKPythonTestResultTestStop(
-                exception=exception,
-                duration=0, # duration is not being passed as int, NEED TO FIX THIS
-            )
+            SDKPythonTestResultTestStop(exception=exception, duration=duration)
         )
 
     def test_skipped(self, filename: str, name: str) -> None:

--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
@@ -157,7 +157,6 @@ class SDKPythonTestRunnerHooks(TestRunnerHooks):
 
     def test_skipped(self, filename: str, name: str) -> None:
         self.results.put(SDKPythonTestResultTestSkipped(filename=filename, name=name))
-        SDKPythonTestRunnerHooks.finished = True
 
     def step_skipped(self, name: str, expression: str) -> None:
         self.results.put(SDKPythonTestResultStepSkipped(expression=expression))

--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
@@ -26,6 +26,7 @@ class SDKPythonTestResultEnum(str, Enum):
     STOP = "stop"
     TEST_START = "test_start"
     TEST_STOP = "test_stop"
+    TEST_NOT_APPLICABLE = "test_not_applicable"
     STEP_SKIPPED = "step_skipped"
     STEP_START = "step_start"
     STEP_SUCCESS = "step_success"
@@ -63,6 +64,12 @@ class SDKPythonTestResultTestStop(SDKPythonTestResultBase):
     type = SDKPythonTestResultEnum.TEST_STOP
     duration: Optional[str]
     exception: Any
+
+
+class SDKPythonTestResultTestNotApplicable(SDKPythonTestResultBase):
+    type = SDKPythonTestResultEnum.TEST_NOT_APPLICABLE
+    name: Optional[str]
+    expression: Optional[str]
 
 
 class SDKPythonTestResultStepSkipped(SDKPythonTestResultBase):
@@ -149,6 +156,10 @@ class SDKPythonTestRunnerHooks(TestRunnerHooks):
                 duration=duration,
             )
         )
+
+    def test_not_applicable(self, name: str) -> None:
+        self.results.put(SDKPythonTestResultTestNotApplicable(name=name))
+        SDKPythonTestRunnerHooks.finished = True
 
     def step_skipped(self, name: str, expression: str) -> None:
         self.results.put(SDKPythonTestResultStepSkipped(expression=expression))

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -23,6 +23,7 @@ from socket import SocketIO
 from typing import Any, Optional, Type, TypeVar
 
 from app.models import TestCaseExecution
+from app.socket_connection_manager import socket_connection_manager
 from app.test_engine.logger import PYTHON_TEST_LEVEL
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestCase, TestStep
@@ -34,6 +35,7 @@ from app.user_prompt_support.prompt_request import (
 from app.user_prompt_support.user_prompt_support import UserPromptSupport
 from test_collections.matter.test_environment_config import TestEnvironmentConfigMatter
 
+from ...models.matter_test_models import MatterTestStep, MatterTestType
 from ...pics import PICS_FILE_PATH
 from ...sdk_container import SDKContainer
 from ...utils import prompt_for_commissioning_mode
@@ -107,6 +109,14 @@ class PythonTestCase(TestCase, UserPromptSupport):
 
     def test_stop(self, exception: Exception, duration: int) -> None:
         self.test_stop_called = True
+
+    def test_not_applicable(self, name: str) -> None:
+        # TODO - Make all steps skipped
+        # test_case_execution
+        # self.current_test_step.mark_as_not_applicable(f"Test case: {name} skipped")
+        # self.test_case_execution
+        self.mark_as_not_applicable()
+        # self.mark_as_completed()
 
     def step_skipped(self, name: str, expression: str) -> None:
         self.current_test_step.mark_as_not_applicable("Test step skipped")

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -110,7 +110,7 @@ class PythonTestCase(TestCase, UserPromptSupport):
     def test_stop(self, exception: Exception, duration: int) -> None:
         self.test_stop_called = True
 
-    def test_skipped(self, filnename: str, name: str) -> None:
+    def test_skipped(self, filename: str, name: str) -> None:
         # TODO - Make all steps skipped
         # test_case_execution
         # self.current_test_step.mark_as_not_applicable(f"Test case: {name} skipped")

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -104,13 +104,13 @@ class PythonTestCase(TestCase, UserPromptSupport):
         if not self.test_stop_called:
             self.current_test_step.mark_as_completed()
 
-    def test_start(self, filename: str, name: str, count: int) -> None:
+    def test_start(self, filename: str, name: str, count: int, steps: list[str] = []) -> None:
         self.step_over()
 
     def test_stop(self, exception: Exception, duration: int) -> None:
         self.test_stop_called = True
 
-    def test_not_applicable(self, name: str) -> None:
+    def test_skipped(self, filnename: str, name: str) -> None:
         # TODO - Make all steps skipped
         # test_case_execution
         # self.current_test_step.mark_as_not_applicable(f"Test case: {name} skipped")

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -104,8 +104,10 @@ class PythonTestCase(TestCase, UserPromptSupport):
         if not self.test_stop_called:
             self.current_test_step.mark_as_completed()
 
-    def test_start(self, filename: str, name: str, count: int, steps: list[str] = []) -> None:
-        self.step_over()
+    def test_start(
+        self, filename: str, name: str, count: int, steps: list[str] = []
+    ) -> None:
+        pass
 
     def test_stop(self, exception: Exception, duration: int) -> None:
         self.test_stop_called = True
@@ -116,13 +118,12 @@ class PythonTestCase(TestCase, UserPromptSupport):
 
     def step_skipped(self, name: str, expression: str) -> None:
         self.current_test_step.mark_as_not_applicable("Test step skipped")
-        self.step_over()
 
     def step_start(self, name: str) -> None:
-        pass
+        self.step_over()
 
     def step_success(self, logger: Any, logs: str, duration: int, request: Any) -> None:
-        self.step_over()
+        pass
 
     def step_failure(
         self, logger: Any, logs: str, duration: int, request: Any, received: Any
@@ -301,14 +302,7 @@ class PythonTestCase(TestCase, UserPromptSupport):
                 await self.__handle_update(update)
 
             # Step: Show test logs
-
-            # Python tests that don't follow the template only have the 2 default steps
-            # and, at this point, will still be in the first step because of the
-            # step_over method. So we have to explicitly move on to the next step here.
-            # The tests that do follow the template will have additional steps and will
-            # have already been moved to the correct step by the hooks' step methods.
-            if len(self.test_steps) == 2:
-                self.next_step()
+            self.next_step()
 
             logger.info("---- Start of Python test logs ----")
             self.handle_logs_temp()

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -111,12 +111,8 @@ class PythonTestCase(TestCase, UserPromptSupport):
         self.test_stop_called = True
 
     def test_skipped(self, filename: str, name: str) -> None:
-        # TODO - Make all steps skipped
-        # test_case_execution
-        # self.current_test_step.mark_as_not_applicable(f"Test case: {name} skipped")
-        # self.test_case_execution
         self.mark_as_not_applicable()
-        # self.mark_as_completed()
+        self.skip_to_last_step()
 
     def step_skipped(self, name: str, expression: str) -> None:
         self.current_test_step.mark_as_not_applicable("Test step skipped")

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -23,7 +23,6 @@ from socket import SocketIO
 from typing import Any, Optional, Type, TypeVar
 
 from app.models import TestCaseExecution
-from app.socket_connection_manager import socket_connection_manager
 from app.test_engine.logger import PYTHON_TEST_LEVEL
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestCase, TestStep
@@ -35,7 +34,6 @@ from app.user_prompt_support.prompt_request import (
 from app.user_prompt_support.user_prompt_support import UserPromptSupport
 from test_collections.matter.test_environment_config import TestEnvironmentConfigMatter
 
-from ...models.matter_test_models import MatterTestStep, MatterTestType
 from ...pics import PICS_FILE_PATH
 from ...sdk_container import SDKContainer
 from ...utils import prompt_for_commissioning_mode

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -32,10 +32,9 @@ from test_collections.matter.test_environment_config import (
 
 from ...chip.chip_server import ChipServerType
 from ...sdk_container import SDKContainer
+from ...utils import prompt_for_commissioning_mode
 from ...yaml_tests.matter_yaml_runner import MatterYAMLRunner
 from ...yaml_tests.models.chip_test import PromptOption
-from ...utils import prompt_for_commissioning_mode
-
 
 CHIP_APP_PAIRING_CODE = "CHIP:SVR: Manual pairing code:"
 

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -34,6 +34,8 @@ from ...chip.chip_server import ChipServerType
 from ...sdk_container import SDKContainer
 from ...yaml_tests.matter_yaml_runner import MatterYAMLRunner
 from ...yaml_tests.models.chip_test import PromptOption
+from ...utils import prompt_for_commissioning_mode
+
 
 CHIP_APP_PAIRING_CODE = "CHIP:SVR: Manual pairing code:"
 
@@ -85,6 +87,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
         self.__dut_commissioned_successfully = False
         if self.server_type == ChipServerType.CHIP_TOOL:
             logger.info("Commission DUT")
+            await prompt_for_commissioning_mode(self, logger, None, self.cancel)
             await self.__commission_dut_allowing_retries()
         elif self.server_type == ChipServerType.CHIP_APP:
             logger.info("Verify Test suite prerequisites")

--- a/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_case_not_applicable/__init__.py
+++ b/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_case_not_applicable/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Project CHIP Authors
+# Copyright (c) 2024 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,5 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from .test_suite_expected import TestSuiteExpected
-from .test_suite_expected_2 import TestSuiteExpected2
+from .tctr_expected_case_not_applicable import TCTRExpectedCaseNotApplicable

--- a/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_case_not_applicable/tctr_expected_case_not_applicable.py
+++ b/test_collections/tool_unit_tests/test_suite_expected/tctr_expected_case_not_applicable/tctr_expected_case_not_applicable.py
@@ -1,0 +1,47 @@
+#
+# Copyright (c) 2024 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestCase, TestStep
+
+
+class TCTRExpectedCaseNotApplicable(TestCase):
+    metadata = {
+        "public_id": "TCTRExpectedCaseNotApplicable",
+        "version": "1.2.3",
+        "title": "This is Test Case tctr_expected_case_not_applicable",
+        "description": """This Test Case is built to test the test runner,\
+             it is supposed to be marked as not applicable""",
+    }
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [
+            TestStep("Test Step 1"),
+            TestStep("Test Step 2"),
+            TestStep("Test Step 3"),
+        ]
+
+    async def setup(self) -> None:
+        logger.info("This is a test case setup")
+
+    async def execute(self) -> None:
+        for step in self.test_steps:
+            logger.info("Executing something in" + step.name)
+            if step.name == "Test Step 2":
+                self.mark_as_not_applicable()
+                break
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test case cleanup")

--- a/test_collections/tool_unit_tests/test_suite_expected/test_suite_expected_2.py
+++ b/test_collections/tool_unit_tests/test_suite_expected/test_suite_expected_2.py
@@ -13,5 +13,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from .test_suite_expected import TestSuiteExpected
-from .test_suite_expected_2 import TestSuiteExpected2
+from app.test_engine.logger import test_engine_logger as logger
+from app.test_engine.models import TestSuite
+
+
+class TestSuiteExpected2(TestSuite):
+    metadata = {
+        "public_id": "TestSuiteExpected2",
+        "version": "1.2.3",
+        "title": "This is Test Runner Test Suite",
+        "description": "This is Test Runner Test Suite",
+    }
+
+    async def setup(self) -> None:
+        logger.info("This is a test setup")
+
+    async def cleanup(self) -> None:
+        logger.info("This is a test cleanup")


### PR DESCRIPTION
Changes:
- Add support for new hooks method `test_skipped`.
- Update hooks'  method `test_start` to support new parameter.
- Handle state `NOT_APPLICABLE` for test cases, suites and runs.
- Improve logic to move to next step in python tests (at the start of the step instead of the end of the previous one).
- Add prompt to ask the user to make sure that the DUT is in commissioning mode at the start of a YAML chip tool test suite execution.
- Add and update unit tests.

<img width="1643" alt="Screenshot 2024-07-24 at 17 46 48" src="https://github.com/user-attachments/assets/530d0684-f248-4cac-842c-9983bf7e987d">
