### PR TITLE
[FIX] Update SDK Hooks With New Parameter

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
@@ -57,6 +57,7 @@ class SDKPythonTestResultTestStart(SDKPythonTestResultBase):
     filename: Optional[str]
     name: Optional[str]
     count: Optional[int]
+    steps: Optional[list[str]]
 
 
 class SDKPythonTestResultTestStop(SDKPythonTestResultBase):
@@ -133,12 +134,12 @@ class SDKPythonTestRunnerHooks(TestRunnerHooks):
         self.results.put(SDKPythonTestResultStop(duration=duration))
         SDKPythonTestRunnerHooks.finished = True
 
-    def test_start(self, filename: str, name: str, count: int) -> None:
+    def test_start(
+        self, filename: str, name: str, count: int, steps: list[str] = []
+    ) -> None:
         self.results.put(
             SDKPythonTestResultTestStart(
-                filename=filename,
-                name=name,
-                count=count,
+                filename=filename, name=name, count=count, steps=steps
             )
         )
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -102,7 +102,9 @@ class PythonTestCase(TestCase, UserPromptSupport):
         if not self.test_stop_called:
             self.current_test_step.mark_as_completed()
 
-    def test_start(self, filename: str, name: str, count: int) -> None:
+    def test_start(
+        self, filename: str, name: str, count: int, steps: list[str] = []
+    ) -> None:
         self.step_over()
 
     def test_stop(self, exception: Exception, duration: int) -> None:

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_test.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_test.py
@@ -105,7 +105,9 @@ class ChipTest(TestCase, UserPromptSupport, TestRunnerHooks, TestParserHooks):
     def stop(self, duration: int) -> None:
         pass
 
-    def test_start(self, filename: str, name: str, count: int) -> None:
+    def test_start(
+        self, filename: str, name: str, count: int, steps: list[str] = []
+    ) -> None:
         # This is necessary in order to synchronize model and runner steps
         # since there is step execute outside runner context
         self.next_step()


### PR DESCRIPTION
Update the SDK start hooks and related methods with the steps parameter from the latest SDK version

With this current version of SDK, **Python Tests** fails receiving an extra unexpected parameter `steps`:
<img width="1625" alt="Screenshot 2024-07-24 at 15 14 16" src="https://github.com/user-attachments/assets/1fbb8bb1-1b6f-4769-baf2-ab250fad0391">

This change adds the `steps` parameter correcting this problem:
<img width="1625" alt="Screenshot 2024-07-24 at 15 00 06" src="https://github.com/user-attachments/assets/c453bdca-c1c4-4600-a9d7-9ceb8e6d0ad8">
