### PR TITLE
Fix python test parsing crash

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
@@ -150,8 +150,10 @@ def __parse_test_case(
     if desc_method:
         try:
             tc_desc = __retrieve_description(desc_method)
-        except:  # noqa E722n
-            pass
+        except Exception as e:
+            logger.error(
+                f"Error while parsing description for {tc_name}, Error:{str(e)}"
+            )
 
     # If the python test does not implement the steps template method,
     # the test case will be presented in UI and the whole test case will be
@@ -160,15 +162,15 @@ def __parse_test_case(
     if steps_method:
         try:
             tc_steps = __retrieve_steps(steps_method)
-        except:  # noqa E722n
-            pass
+        except Exception as e:
+            logger.error(f"Error while parsing steps for {tc_name}, Error:{str(e)}")
 
     pics_method = __get_method_by_name(pics_method_name, methods)
     if pics_method:
         try:
             tc_pics = __retrieve_pics(pics_method)
-        except:  # noqa E722n
-            pass
+        except Exception as e:
+            logger.error(f"Error while parsing PICS for {tc_name}, Error:{str(e)}")
 
     # - PythonTestType.COMMISSIONING: test cases that have a commissioning first step
     # - PythonTestType.NO_COMMISSIONING: test cases that follow the expected template

--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
@@ -148,18 +148,27 @@ def __parse_test_case(
 
     desc_method = __get_method_by_name(desc_method_name, methods)
     if desc_method:
-        tc_desc = __retrieve_description(desc_method)
+        try:
+            tc_desc = __retrieve_description(desc_method)
+        except:  # noqa E722n
+            pass
 
     # If the python test does not implement the steps template method,
     # the test case will be presented in UI and the whole test case will be
     # executed as one step
     steps_method = __get_method_by_name(steps_method_name, methods)
     if steps_method:
-        tc_steps = __retrieve_steps(steps_method)
+        try:
+            tc_steps = __retrieve_steps(steps_method)
+        except:  # noqa E722n
+            pass
 
     pics_method = __get_method_by_name(pics_method_name, methods)
     if pics_method:
-        tc_pics = __retrieve_pics(pics_method)
+        try:
+            tc_pics = __retrieve_pics(pics_method)
+        except:  # noqa E722n
+            pass
 
     # - PythonTestType.COMMISSIONING: test cases that have a commissioning first step
     # - PythonTestType.NO_COMMISSIONING: test cases that follow the expected template


### PR DESCRIPTION
The python test parser is crashing when the SDK SHA is updated. With these changes, any exception that happens while retrieving the test description, steps or PICS are ignored so that the TH's backend does't crash and a warning is logged.

<img width="1794" alt="Screenshot 2024-07-25 at 10 27 50" src="https://github.com/user-attachments/assets/b3bb7c05-f4a5-499b-9614-57000376fe45">