### PR TITLE
Fix project config type

### DIFF
--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -14,11 +14,10 @@
 # limitations under the License.
 #
 from asyncio import CancelledError
-from typing import Any, List, Union, cast
+from typing import Any, List, Union
 
 from app.models import Project, TestCaseExecution
 from app.models.test_enums import TestStateEnum
-from app.schemas.test_environment_config import TestEnvironmentConfig
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models.utils import LogSeparator
 from app.test_engine.test_observable import TestObservable
@@ -48,12 +47,10 @@ class TestCase(TestObservable):
 
     @property
     def test_parameters(self) -> dict[str, Any]:
-        config_dict = cast(dict, self.config)
-
         test_parameters = self.default_test_parameters()
 
-        if config_dict and config_dict.get("test_parameters"):
-            test_parameters |= config_dict.get("test_parameters")  # type: ignore
+        if self.config and self.config.get("test_parameters"):
+            test_parameters |= self.config.get("test_parameters")  # type: ignore
 
         return test_parameters
 
@@ -81,7 +78,7 @@ class TestCase(TestObservable):
         return self.test_case_execution.test_suite_execution.test_run_execution.project
 
     @property
-    def config(self) -> TestEnvironmentConfig:
+    def config(self) -> dict:
         return self.project.config
 
     @property

--- a/app/test_engine/models/test_run.py
+++ b/app/test_engine/models/test_run.py
@@ -18,7 +18,6 @@ from typing import List, Optional
 
 from app.models import Project, TestRunExecution
 from app.models.test_enums import TestStateEnum
-from app.schemas.test_environment_config import TestEnvironmentConfig
 from app.schemas.test_run_log_entry import TestRunLogEntry
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.test_observable import TestObservable
@@ -55,7 +54,7 @@ class TestRun(TestObservable, UserPromptSupport):
         return self.test_run_execution.project
 
     @property
-    def config(self) -> TestEnvironmentConfig:
+    def config(self) -> dict:
         """Convenience getter to access project config."""
         return self.project.config
 

--- a/app/test_engine/models/test_suite.py
+++ b/app/test_engine/models/test_suite.py
@@ -19,7 +19,6 @@ from typing import List, Optional, Type
 from app.models import Project, TestSuiteExecution
 from app.models.test_enums import TestStateEnum
 from app.schemas.pics import PICS
-from app.schemas.test_environment_config import TestEnvironmentConfig
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models.utils import LogSeparator
 from app.test_engine.test_observable import TestObservable
@@ -59,7 +58,7 @@ class TestSuite(TestObservable):
         return self.test_suite_execution.test_run_execution.project
 
     @property
-    def config(self) -> TestEnvironmentConfig:
+    def config(self) -> dict:
         return self.project.config
 
     @property

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -274,7 +274,7 @@ class PythonTestCase(TestCase, UserPromptSupport):
             # project configuration
             # comissioning method is omitted because it's handled by the test suite
             command_arguments = generate_command_arguments(
-                config=TestEnvironmentConfigMatter(**self.config),  # type: ignore
+                config=TestEnvironmentConfigMatter(**self.config),
                 omit_commissioning_method=True,
             )
             command.extend(command_arguments)
@@ -374,9 +374,7 @@ class LegacyPythonTestCase(PythonTestCase):
             case PromptOption.YES:
                 logger.info("User chose prompt option YES")
                 logger.info("Commission DUT")
-                commission_device(
-                    TestEnvironmentConfigMatter(**self.config), logger  # type: ignore
-                )
+                commission_device(TestEnvironmentConfigMatter(**self.config), logger)
 
             case PromptOption.NO:
                 logger.info("User chose prompt option NO")

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -117,9 +117,4 @@ class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
 
         logger.info("Commission DUT")
 
-        if isinstance(self.config, TestEnvironmentConfigMatter):
-            commission_device(self.config, logger)
-        else:
-            commission_device(
-                TestEnvironmentConfigMatter(**self.config), logger  # type: ignore
-            )
+        commission_device(TestEnvironmentConfigMatter(**self.config), logger)

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
@@ -135,7 +135,7 @@ async def test_suite_setup_log_python_version() -> None:
             target="test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
             ".PythonTestSuite.config",
             new_callable=mock.PropertyMock,
-            return_value=default_environment_config,
+            return_value=default_environment_config.__dict__,
         ):
             await suite_instance.setup()
 
@@ -177,7 +177,7 @@ async def test_suite_setup_without_pics() -> None:
             target="test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
             ".PythonTestSuite.config",
             new_callable=mock.PropertyMock,
-            return_value=default_environment_config,
+            return_value=default_environment_config.__dict__,
         ):
             await suite_instance.setup()
 
@@ -219,7 +219,7 @@ async def test_suite_setup_with_pics() -> None:
             target="test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
             ".PythonTestSuite.config",
             new_callable=mock.PropertyMock,
-            return_value=default_environment_config,
+            return_value=default_environment_config.__dict__,
         ):
             await suite_instance.setup()
 
@@ -256,7 +256,7 @@ async def test_commissioning_suite_setup_with_pics() -> None:
         target="test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
         ".PythonTestSuite.config",
         new_callable=mock.PropertyMock,
-        return_value=default_environment_config,
+        return_value=default_environment_config.__dict__,
     ):
         await suite_instance.setup()
 
@@ -292,7 +292,7 @@ async def test_commissioning_suite_setup() -> None:
         target="test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
         ".PythonTestSuite.config",
         new_callable=mock.PropertyMock,
-        return_value=default_environment_config,
+        return_value=default_environment_config.__dict__,
     ):
         await suite_instance.setup()
         python_suite_setup.assert_called_once()

--- a/test_collections/matter/test_environment_config.py
+++ b/test_collections/matter/test_environment_config.py
@@ -73,6 +73,9 @@ class TestEnvironmentConfigMatter(TestEnvironmentConfig):
                     "The dut_config and network configuration are mandatory"
                 )
 
+            if not isinstance(dut_config, dict):
+                dut_config = dut_config.__dict__
+
             # Check if the informed field in dut_config is valid
             for field, _ in dut_config.items():
                 if field not in valid_properties:

--- a/test_collections/tool_unit_tests/test_suite_chip/tctr_chip_log_parsing/tctr_chip_log_parsing.py
+++ b/test_collections/tool_unit_tests/test_suite_chip/tctr_chip_log_parsing/tctr_chip_log_parsing.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from app.default_environment_config import default_environment_config
-from app.schemas.test_environment_config import TestEnvironmentConfig
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestStep
 from test_collections.matter.sdk_tests.support.chip.chip_server import ChipServerType
@@ -38,7 +37,7 @@ class TCTRChipLogParsing(ChipTest):
     # project are not set up. So, override the base class config() to return the
     # default config.
     @property
-    def config(self) -> TestEnvironmentConfig:
+    def config(self) -> dict:
         return default_environment_config.copy(deep=True)  # type: ignore
 
     def create_test_steps(self) -> None:


### PR DESCRIPTION
The test environment config is saved as a dictionary, but the type annotation is using TestEnvironmentConfig.

## Testing

I ran some python tests, that ran with the correct parameters and all unit tests are passing.