### PR TITLE
Use manual-code or discriminator and password, never all of them

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -60,7 +60,9 @@
         "unpairing",
         "wlan",
         "yamls",
-        "yamltests"
+        "yamltests",
+        "wifipaf",
+        "WIFIPAF"
     ],
     "ignoreWords": [
         "bdist",

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -52,8 +52,8 @@ def generate_command_arguments(
 
     # Retrieve arguments from test_parameters
     if test_parameters:
-        # If manual-code, discriminator and passcode are provided, the test will think that
-        # we're trying to commission 2 DUTs and it will fail
+        # If manual-code, discriminator and passcode are provided, the test will think
+        # that we're trying to commission 2 DUTs and it will fail
         if "manual-code" not in test_parameters.keys():
             # Retrieve arguments from dut_config
             arguments.append(f"--discriminator {dut_config.discriminator}")

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -46,9 +46,14 @@ def generate_command_arguments(
     # Increase log level by adding trace log
     if dut_config.trace_log:
         arguments.append("--trace-to json:log")
-    # Retrieve arguments from dut_config
-    arguments.append(f"--discriminator {dut_config.discriminator}")
-    arguments.append(f"--passcode {dut_config.setup_code}")
+
+    # If manual-code, discriminator and passcode are provided, the test will think that
+    # we're trying to commission 2 DUTs and it will fail
+    if "manual-code" not in test_parameters.keys():
+        # Retrieve arguments from dut_config
+        arguments.append(f"--discriminator {dut_config.discriminator}")
+        arguments.append(f"--passcode {dut_config.setup_code}")
+
     if not omit_commissioning_method:
         arguments.append(f"--commissioning-method {pairing_mode}")
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -47,21 +47,25 @@ def generate_command_arguments(
     if dut_config.trace_log:
         arguments.append("--trace-to json:log")
 
-    # If manual-code, discriminator and passcode are provided, the test will think that
-    # we're trying to commission 2 DUTs and it will fail
-    if "manual-code" not in test_parameters.keys():
-        # Retrieve arguments from dut_config
-        arguments.append(f"--discriminator {dut_config.discriminator}")
-        arguments.append(f"--passcode {dut_config.setup_code}")
-
     if not omit_commissioning_method:
         arguments.append(f"--commissioning-method {pairing_mode}")
 
     # Retrieve arguments from test_parameters
     if test_parameters:
+        # If manual-code, discriminator and passcode are provided, the test will think that
+        # we're trying to commission 2 DUTs and it will fail
+        if "manual-code" not in test_parameters.keys():
+            # Retrieve arguments from dut_config
+            arguments.append(f"--discriminator {dut_config.discriminator}")
+            arguments.append(f"--passcode {dut_config.setup_code}")
+
         for name, value in test_parameters.items():
             arg_value = str(value) if value is not None else ""
             arguments.append(f"--{name} {arg_value}")
+    else:
+        # Retrieve arguments from dut_config
+        arguments.append(f"--discriminator {dut_config.discriminator}")
+        arguments.append(f"--passcode {dut_config.setup_code}")
 
     return arguments
 

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -56,9 +56,9 @@ async def test_generate_command_arguments_with_null_value_attribute() -> None:
 
     assert [
         "--trace-to json:log",
+        "--commissioning-method on-network",
         "--discriminator 123",
         "--passcode 1234",
-        "--commissioning-method on-network",
         "--test-argument ",
     ] == arguments
 
@@ -89,9 +89,9 @@ async def test_generate_command_arguments_on_network() -> None:
 
     assert [
         "--trace-to json:log",
+        "--commissioning-method on-network",
         "--discriminator 123",
         "--passcode 1234",
-        "--commissioning-method on-network",
         "--paa-trust-store-path /paa-root-certs",
         "--storage_path /root/admin_storage.json",
     ] == arguments
@@ -121,9 +121,9 @@ async def test_generate_command_arguments_ble_wifi() -> None:
 
     assert [
         "--trace-to json:log",
+        "--commissioning-method ble-wifi",
         "--discriminator 147",
         "--passcode 357",
-        "--commissioning-method ble-wifi",
         "--paa-trust-store-path /paa-root-certs",
         "--storage_path /root/admin_storage.json",
     ] == arguments
@@ -152,9 +152,9 @@ async def test_generate_command_arguments_ble_thread() -> None:
     )
     assert [
         "--trace-to json:log",
+        "--commissioning-method ble-thread",
         "--discriminator 456",
         "--passcode 8765",
-        "--commissioning-method ble-thread",
         "--paa-trust-store-path /paa-root-certs",
         "--storage_path /root/admin_storage.json",
     ] == arguments
@@ -181,9 +181,9 @@ async def test_generate_command_arguments_no_test_parameter_informed() -> None:
 
     assert [
         "--trace-to json:log",
+        "--commissioning-method ble-thread",
         "--discriminator 456",
         "--passcode 8765",
-        "--commissioning-method ble-thread",
     ] == arguments
 
 
@@ -208,9 +208,9 @@ async def test_generate_command_arguments_trace_log_false_informed() -> None:
     )
 
     assert [
+        "--commissioning-method ble-thread",
         "--discriminator 456",
         "--passcode 8765",
-        "--commissioning-method ble-thread",
     ] == arguments
 
 

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -115,7 +115,10 @@ class ChipSuite(TestSuite, UserPromptSupport):
             self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.BLE_THREAD
         ):
             pair_result = await self.__pair_with_dut_ble_thread()
-        elif self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.WIFIPAF_WIFI:
+        elif (
+            self.config_matter.dut_config.pairing_mode
+            is DutPairingModeEnum.WIFIPAF_WIFI
+        ):
             pair_result = await self.__pair_with_dut_wifipaf_wifi()
         else:
             raise DUTCommissioningError("Unsupported DUT pairing mode")


### PR DESCRIPTION
Fix issue with commissioning when setting manual-code parameter