### PR TITLE
[FIX] Handle qr-code parameter

### DIFF
--- a/.version_information
+++ b/.version_information
@@ -1,1 +1,1 @@
-v2.11-beta1+fall2024
+v2.11-beta2+fall2024

--- a/test_collections/matter/config.py
+++ b/test_collections/matter/config.py
@@ -23,9 +23,9 @@ class MatterSettings(BaseSettings):
 
     # SDK Docker Image
     SDK_DOCKER_IMAGE: str = "connectedhomeip/chip-cert-bins"
-    SDK_DOCKER_TAG: str = "1cbcc5c81d478e4d24d68ced29c49cedef2043d8"
+    SDK_DOCKER_TAG: str = "ccd8da9764597a1f48f712c8eb0098f1d3c51b6e"
     # SDK SHA: used to fetch test YAML from SDK.
-    SDK_SHA: str = "1cbcc5c81d478e4d24d68ced29c49cedef2043d8"
+    SDK_SHA: str = "ccd8da9764597a1f48f712c8eb0098f1d3c51b6e"
 
     class Config:
         case_sensitive = True

--- a/test_collections/matter/config.py
+++ b/test_collections/matter/config.py
@@ -23,9 +23,9 @@ class MatterSettings(BaseSettings):
 
     # SDK Docker Image
     SDK_DOCKER_IMAGE: str = "connectedhomeip/chip-cert-bins"
-    SDK_DOCKER_TAG: str = "ccd8da9764597a1f48f712c8eb0098f1d3c51b6e"
+    SDK_DOCKER_TAG: str = "d0d91272068f267cf880f9d56787ca28da885673"
     # SDK SHA: used to fetch test YAML from SDK.
-    SDK_SHA: str = "ccd8da9764597a1f48f712c8eb0098f1d3c51b6e"
+    SDK_SHA: str = "d0d91272068f267cf880f9d56787ca28da885673"
 
     class Config:
         case_sensitive = True

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -52,9 +52,12 @@ def generate_command_arguments(
 
     # Retrieve arguments from test_parameters
     if test_parameters:
-        # If manual-code, discriminator and passcode are provided, the test will think
-        # that we're trying to commission 2 DUTs and it will fail
-        if "manual-code" not in test_parameters.keys():
+        # If manual-code or qr-code and also discriminator and passcode are provided,
+        # the test will think that we're trying to commission 2 DUTs and it will fail
+        if (
+            "manual-code" not in test_parameters.keys()
+            and "qr-code" not in test_parameters.keys()
+        ):
             # Retrieve arguments from dut_config
             arguments.append(f"--discriminator {dut_config.discriminator}")
             arguments.append(f"--passcode {dut_config.setup_code}")

--- a/test_collections/matter/test_environment_config.py
+++ b/test_collections/matter/test_environment_config.py
@@ -65,6 +65,17 @@ class TestEnvironmentConfigMatter(TestEnvironmentConfig):
         valid_properties = list(DutConfig.__annotations__.keys())
 
         if dict_model:
+            # If both qr-code and manual-code are provided the test run execution
+            # will fail
+            if (
+                dict_model.get("test_parameters")
+                and "qr-code" in dict_model.get("test_parameters")
+                and "manual-code" in dict_model.get("test_parameters")
+            ):
+                raise TestEnvironmentConfigMatterError(
+                    "Please inform just one of either: qr-code or manual-code"
+                )
+
             dut_config = dict_model.get("dut_config")
             network = dict_model.get("network")
 

--- a/test_collections/matter/test_environment_config.py
+++ b/test_collections/matter/test_environment_config.py
@@ -65,19 +65,20 @@ class TestEnvironmentConfigMatter(TestEnvironmentConfig):
         valid_properties = list(DutConfig.__annotations__.keys())
 
         if dict_model:
+            dut_config = dict_model.get("dut_config")
+            network = dict_model.get("network")
+            test_parameters = dict_model.get("test_parameters")
+
             # If both qr-code and manual-code are provided the test run execution
             # will fail
             if (
-                dict_model.get("test_parameters")
-                and "qr-code" in dict_model.get("test_parameters")
-                and "manual-code" in dict_model.get("test_parameters")
+                test_parameters
+                and "qr-code" in test_parameters
+                and "manual-code" in test_parameters
             ):
                 raise TestEnvironmentConfigMatterError(
                     "Please inform just one of either: qr-code or manual-code"
                 )
-
-            dut_config = dict_model.get("dut_config")
-            network = dict_model.get("network")
 
             if not dut_config or not network:
                 raise TestEnvironmentConfigMatterError(


### PR DESCRIPTION
### What changed
Add checking when qr-code parameter is informed, so it is not necessary to use discriminator and passcode. 
This implementation follows the manual-code handling. This now will fix the DUT commissioning when qr-code parameter is informed.

### Related Issue
https://github.com/project-chip/certification-tool/issues/358
https://github.com/project-chip/certification-tool/issues/348

### Testing
Unit test passed and TH is now able to commission device
![Screenshot 2024-08-13 at 18 56 27](https://github.com/user-attachments/assets/57e3e88c-1775-4da6-beb2-fd476d6c65d7)
