### PR TITLE
[FIX] Handle ERROR and FAILED step states

### DIFF
--- a/app/test_engine/models/test_step.py
+++ b/app/test_engine/models/test_step.py
@@ -48,11 +48,13 @@ class TestStep(TestObservable):
             self.notify()
 
     def record_error(self, msg: str) -> None:
+        self.state = TestStateEnum.ERROR
         self.errors.append(msg)
         logger.error(f"Test Step Error: {msg}")
         self.notify()
 
     def append_failure(self, msg: str) -> None:
+        self.state = TestStateEnum.FAILED
         logger.warning(f"Test Failure: {msg}")
         self.failures.append(msg)
 


### PR DESCRIPTION
### What changed
Changed in the code where to assign step status FAILED and ERROR. 
There is a scenario that for a single step it was receiving 2 calls from the hooks (`test_skipped` and `step_failure`) and the TH was reporting, at the end of the execution, a wrong test state and run state.

### Related Issue
https://github.com/project-chip/certification-tool/issues/355

### Testing
Unit test passed and TH Fails test case when a step Fails.
![Screenshot 2024-08-22 at 15 32 14](https://github.com/user-attachments/assets/37241c63-2d0e-4e36-a470-aa0bd59a9223)


