### PR TITLE
[FIX] Handle Python test execution runtime errors

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
@@ -53,16 +53,22 @@ def main() -> None:
 
 
 def run_test(script_path: str, class_name: str, config: MatterTestConfig) -> None:
-    # For a script_path like 'custom/TC_XYZ' the module is 'custom.TC_XYZ'
-    module = importlib.import_module(script_path.replace("/", "."))
-    TestClassReference = getattr(module, class_name)
-
     BaseManager.register(TestRunnerHooks.__name__)
     manager = BaseManager(address=("0.0.0.0", 50000), authkey=b"abc")
     manager.connect()
     test_runner_hooks = manager.TestRunnerHooks()  # shared object proxy # type: ignore
 
-    run_tests(TestClassReference, config, test_runner_hooks)
+    try:
+        # For a script_path like 'custom/TC_XYZ' the module is 'custom.TC_XYZ'
+        module = importlib.import_module(script_path.replace("/", "."))
+        TestClassReference = getattr(module, class_name)
+
+        run_tests(TestClassReference, config, test_runner_hooks)
+    except Exception as e:
+        test_runner_hooks.step_failure(
+            logger=None, logs=str(e), duration=0, request=None, received=None
+        )
+        test_runner_hooks.stop(duration=0)
 
 
 def commission(config: MatterTestConfig) -> None:

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -126,7 +126,11 @@ class PythonTestCase(TestCase, UserPromptSupport):
     def step_failure(
         self, logger: Any, logs: str, duration: int, request: Any, received: Any
     ) -> None:
-        self.mark_step_failure("Python test step failure")
+        failure_msg = "Python test step failure"
+        if logs:
+            failure_msg = f"Python test step failure: {logs}"
+
+        self.mark_step_failure(failure_msg)
 
         # Python tests with only 2 steps are the ones that don't follow the template.
         # In the case of a test file with multiple test cases, more than one of these


### PR DESCRIPTION
### What changed
The goal of this PR is to avoid test execution hangs if a runtime error occurs.


### Related Issue
https://github.com/project-chip/matter-test-scripts/issues/365

### Testing
Execution does not Hangs when runtime error happens
<img width="1398" alt="Screenshot 2024-09-13 at 15 30 00" src="https://github.com/user-attachments/assets/7ebbf543-314c-4df3-8279-1bce0f44791f">

