### PR TITLE
[Feature] Updating Step Start Hook to Receive Endpoint

### DIFF
--- a/app/test_engine/models/manual_test_case.py
+++ b/app/test_engine/models/manual_test_case.py
@@ -193,7 +193,7 @@ class ManualTestCase(TestCase, UserPromptSupport):
             if isinstance(step, ManualVerificationTestStep):
                 await step.prompt_verification_step()
             else:
-                logger.error(f"Unsupported test test {step.__class__}")
+                logger.error(f"Unsupported test step {step.__class__}")
             self.next_step()
 
         if isinstance(self.current_test_step, ManualLogUploadStep):

--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -293,6 +293,7 @@ class TestCase(TestObservable):
 
         # update current step
         self.current_test_step_index += 1
+
         self.current_test_step.mark_as_executing()
 
     def __print_log_separator(self) -> None:

--- a/app/test_engine/models/test_case.py
+++ b/app/test_engine/models/test_case.py
@@ -293,7 +293,6 @@ class TestCase(TestObservable):
 
         # update current step
         self.current_test_step_index += 1
-
         self.current_test_step.mark_as_executing()
 
     def __print_log_separator(self) -> None:

--- a/app/test_engine/models/test_step.py
+++ b/app/test_engine/models/test_step.py
@@ -29,11 +29,17 @@ class TestStep(TestObservable):
 
     __test__ = False  # Needed to indicate to PyTest that this is not a "test"
 
-    def __init__(self, name: str, state: TestStateEnum = TestStateEnum.PENDING) -> None:
+    def __init__(
+        self,
+        name: str,
+        endpoint: int | None = None,
+        state: TestStateEnum = TestStateEnum.PENDING,
+    ) -> None:
         super().__init__()
         self.errors: List[str] = []
         self.failures: List[str] = []
         self.name = name
+        self.endpoint = endpoint
         self.__state = state
         self.test_step_execution: Optional[TestStepExecution] = None
 
@@ -90,7 +96,12 @@ class TestStep(TestObservable):
         else:
             self.state = TestStateEnum.PASSED
 
-        logger.info(f"Test Step Completed [{self.state.name}]: {self.name}")
+        endpoint_info = (
+            f" for endpoint {self.endpoint}" if self.endpoint is not None else ""
+        )
+        logger.info(
+            f"Test Step Completed [{self.state.name}]: {self.name}{endpoint_info}"
+        )
         self.__print_log_separator()
 
     def __print_log_separator(self) -> None:

--- a/app/test_engine/test_ui_observer.py
+++ b/app/test_engine/test_ui_observer.py
@@ -119,6 +119,7 @@ class TestUIObserver(Observer):
                 "test_suite_execution_index": test_suite_execution.execution_index,
                 "test_case_execution_index": test_case_execution.execution_index,
                 "test_step_execution_index": test_step_execution.execution_index,
+                "endpoint": observable.endpoint,
                 "state": observable.state,
                 "errors": observable.errors,
                 "failures": observable.failures,

--- a/app/tests/test_engine/test_ui_observer.py
+++ b/app/tests/test_engine/test_ui_observer.py
@@ -147,7 +147,7 @@ def __expected_test_case_dict(index: int, suite_index: int) -> Dict[str, Any]:
 
 
 def __expected_test_step_dict(
-    index: int, case_index: int, suite_index: int
+    index: int, case_index: int, suite_index: int, endpoint: int | None = None
 ) -> Dict[str, Any]:
     return {
         MessageKeysEnum.TYPE: MessageTypeEnum.TEST_UPDATE,
@@ -157,6 +157,7 @@ def __expected_test_step_dict(
                 "test_suite_execution_index": suite_index,
                 "test_case_execution_index": case_index,
                 "test_step_execution_index": index,
+                "endpoint": endpoint,
                 "state": TestStateEnum.EXECUTING,
                 "errors": [],
                 "failures": [],

--- a/test_collections/matter/sdk_tests/support/models/matter_test_models.py
+++ b/test_collections/matter/sdk_tests/support/models/matter_test_models.py
@@ -33,6 +33,10 @@ class MatterTestType(Enum):
 
 class MatterTestStep(BaseModel):
     label: str
+    # Pydantic will fail parsing YAML files since they are using endpoints as variables
+    # instead of numbers only.
+    # So endpoint has to be a String as well to pass the file parsing.
+    endpoint: Optional[int | str] = None
     PICS: Optional[str] = None
     verification: Optional[str] = None
     command: Optional[str]

--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
@@ -288,17 +288,19 @@ def __retrieve_steps(method: FunctionDefType) -> List[MatterTestStep]:
 
             step_name = step.args[ARG_STEP_DESCRIPTION_INDEX].value
             parsed_step_name = step_name
+            python_steps.append(
+                MatterTestStep(
+                    label=parsed_step_name,
+                    command=None,
+                    arguments=None,
+                    is_commissioning=arg_is_commissioning,
+                )
+            )
         except Exception as e:
             logger.warning(
                 f"Failed parsing step name from {method.name}, Error:{str(e)}"
             )
             parsed_step_name = "UNABLE TO PARSE TEST STEP NAME"
-
-        python_steps.append(
-            MatterTestStep(
-                label=parsed_step_name, is_commissioning=arg_is_commissioning
-            )
-        )
 
     return python_steps
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
@@ -44,17 +44,17 @@ class SDKPythonTestResultBase(BaseModel):
 
 
 class SDKPythonTestResultStart(SDKPythonTestResultBase):
-    type = SDKPythonTestResultEnum.START
+    type: SDKPythonTestResultEnum = SDKPythonTestResultEnum.START
     count: int
 
 
 class SDKPythonTestResultStop(SDKPythonTestResultBase):
-    type = SDKPythonTestResultEnum.STOP
+    type: SDKPythonTestResultEnum = SDKPythonTestResultEnum.STOP
     duration: int
 
 
 class SDKPythonTestResultTestStart(SDKPythonTestResultBase):
-    type = SDKPythonTestResultEnum.TEST_START
+    type: SDKPythonTestResultEnum = SDKPythonTestResultEnum.TEST_START
     filename: Optional[str]
     name: Optional[str]
     count: Optional[int]
@@ -62,30 +62,31 @@ class SDKPythonTestResultTestStart(SDKPythonTestResultBase):
 
 
 class SDKPythonTestResultTestStop(SDKPythonTestResultBase):
-    type = SDKPythonTestResultEnum.TEST_STOP
+    type: SDKPythonTestResultEnum = SDKPythonTestResultEnum.TEST_STOP
     duration: Optional[int]
     exception: Any
 
 
 class SDKPythonTestResultTestSkipped(SDKPythonTestResultBase):
-    type = SDKPythonTestResultEnum.TEST_SKIPPED
+    type: SDKPythonTestResultEnum = SDKPythonTestResultEnum.TEST_SKIPPED
     filename: Optional[str]
     name: Optional[str]
 
 
 class SDKPythonTestResultStepSkipped(SDKPythonTestResultBase):
-    type = SDKPythonTestResultEnum.STEP_SKIPPED
+    type: SDKPythonTestResultEnum = SDKPythonTestResultEnum.STEP_SKIPPED
     name: Optional[str]
     expression: Optional[str]
 
 
 class SDKPythonTestResultStepStart(SDKPythonTestResultBase):
-    type = SDKPythonTestResultEnum.STEP_START
+    type: SDKPythonTestResultEnum = SDKPythonTestResultEnum.STEP_START
     name: Optional[str]
+    endpoint: Optional[int]
 
 
 class SDKPythonTestResultStepSuccess(SDKPythonTestResultBase):
-    type = SDKPythonTestResultEnum.STEP_SUCCESS
+    type: SDKPythonTestResultEnum = SDKPythonTestResultEnum.STEP_SUCCESS
     logger: Any
     logs: Any
     duration: int
@@ -93,7 +94,7 @@ class SDKPythonTestResultStepSuccess(SDKPythonTestResultBase):
 
 
 class SDKPythonTestResultStepFailure(SDKPythonTestResultBase):
-    type = SDKPythonTestResultEnum.STEP_FAILURE
+    type: SDKPythonTestResultEnum = SDKPythonTestResultEnum.STEP_FAILURE
     logger: Any
     logs: Any
     duration: int
@@ -102,15 +103,15 @@ class SDKPythonTestResultStepFailure(SDKPythonTestResultBase):
 
 
 class SDKPythonTestResultStepUnknown(SDKPythonTestResultBase):
-    type = SDKPythonTestResultEnum.STEP_UNKNOWN
+    type: SDKPythonTestResultEnum = SDKPythonTestResultEnum.STEP_UNKNOWN
 
 
 class SDKPythonTestResultStepManual(SDKPythonTestResultBase):
-    type = SDKPythonTestResultEnum.STEP_MANUAL
+    type: SDKPythonTestResultEnum = SDKPythonTestResultEnum.STEP_MANUAL
 
 
 class SDKPythonTestResultShowPrompt(SDKPythonTestResultBase):
-    type = SDKPythonTestResultEnum.SHOW_PROMPT
+    type: SDKPythonTestResultEnum = SDKPythonTestResultEnum.SHOW_PROMPT
     msg: str
     placeholder: Optional[str]
     default_value: Optional[str]
@@ -159,10 +160,12 @@ class SDKPythonTestRunnerHooks(TestRunnerHooks):
         self.results.put(SDKPythonTestResultTestSkipped(filename=filename, name=name))
 
     def step_skipped(self, name: str, expression: str) -> None:
-        self.results.put(SDKPythonTestResultStepSkipped(expression=expression))
+        self.results.put(
+            SDKPythonTestResultStepSkipped(name=None, expression=expression)
+        )
 
-    def step_start(self, name: str) -> None:
-        self.results.put(SDKPythonTestResultStepStart(name=name))
+    def step_start(self, name: str, endpoint: Optional[int] = None) -> None:
+        self.results.put(SDKPythonTestResultStepStart(name=name, endpoint=endpoint))
 
     def step_success(self, logger: Any, logs: Any, duration: int, request: Any) -> None:
         self.results.put(
@@ -198,6 +201,7 @@ class SDKPythonTestRunnerHooks(TestRunnerHooks):
         msg: str,
         placeholder: Optional[str] = None,
         default_value: Optional[str] = None,
+        endpoint_id: Optional[int] = None,
     ) -> None:
         self.results.put(
             SDKPythonTestResultShowPrompt(

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -118,8 +118,9 @@ class PythonTestCase(TestCase, UserPromptSupport):
         else:
             self.current_test_step.mark_as_not_applicable(skiped_msg)
 
-    def step_start(self, name: str) -> None:
+    def step_start(self, name: str, endpoint: int | None = None) -> None:
         self.step_over()
+        self.current_test_step.endpoint = endpoint
 
     def step_success(self, logger: Any, logs: str, duration: int, request: Any) -> None:
         pass

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
@@ -170,7 +170,8 @@ class YamlTestCase(TestCase):
             )
             return
 
-        step = TestStep(yaml_step.label)
+        endpoint = yaml_step.endpoint if isinstance(yaml_step.endpoint, int) else None
+        step = TestStep(yaml_step.label, endpoint=endpoint)
         if yaml_step.command == "UserPrompt":
             step = ManualVerificationTestStep(
                 name=yaml_step.label,


### PR DESCRIPTION
Solves: https://github.com/project-chip/certification-tool/issues/367
SDK Dependency PR: ~https://github.com/project-chip/connectedhomeip/pull/35662~ (The SDK PR entered out of sync with this backend PR causing problems TH. The change was then reverted on the SDK's side and a new PR should be created to pair with this one)

> [!WARNING]  
> **The frontend changes and images shown here are not official and for experimental purpose only.**
> **Also, the SDK dependency PR should merge in sync with this PR**

## Description
Updating the Step Start hooks and the related code to use the provided optional endpoint information from SDK. Also, logs were updated to show the endpoint, if it exists.
This change depends on the SDK's PR, mentioned above, that sends the endpoint information by including it on TC Step Start method parameters.

Please, mind this current solution will not store the endpoint information in the DB and it will not be retrieved for the UI after loading old executions. Anyway, the logs still points the endpoint on the step completion lines. 

## Use Case Example:
> [!WARNING]  
> **The frontend changes and images shown here are not official and for experimental purpose only.**
> **Also, the SDK dependency PR should merge in sync with this PR**
 
The images below show a possible usage of the new endpoint information passed to the frontend using the SDK and Backend changes:

<img width="1724" alt="Screenshot 2024-09-19 at 10 00 46" src="https://github.com/user-attachments/assets/c8b75819-6644-4905-a0d9-38c2fe34178f">
<p align="center">The TC ACE 1.3 example</p>

<img width="1725" alt="Screenshot 2024-09-19 at 10 02 19" src="https://github.com/user-attachments/assets/2f1233f9-646e-4750-8079-e5bddeb592a5">
<p align="center">The TC BOOLCFG 2.1 example</p>