### PR TITLE
Update update-sample-apps script to copy apps from a new origin

### DIFF
--- a/test_collections/matter/scripts/update-sample-apps.sh
+++ b/test_collections/matter/scripts/update-sample-apps.sh
@@ -39,8 +39,7 @@ else
 fi
 
 print_script_step "Updating Sample APPs"
-# TODO: update SDK image to place the apps in a specific folder and then copy that entire folder
-sudo docker run -t -v ~/apps:/apps $SDK_DOCKER_IMAGE bash -c "rm -v /apps/*; cp -v chip-* /apps/; cp -v thermostat-app /apps/; cp -v lit-icd-app /apps/;cp -v fabric-* /apps/; cp -v matter-network-manager-app /apps/"
+sudo docker run -t -v ~/apps:/apps $SDK_DOCKER_IMAGE bash -c "rm -v /apps/*; cp -v apps/* /apps/"
 echo "Setting Sample APPs ownership"
 sudo chown -R `whoami` ~/apps
 


### PR DESCRIPTION
### What changed
The goal of this PR is to update the origin folder from SKA apps. All SDK apps are now located at /apps folders.

### Related Issue
https://github.com/project-chip/certification-tool/issues/403

**Important:**
Do NOT merge this PR until this PR be merged: https://github.com/project-chip/connectedhomeip/pull/35700