### PR TITLE
[FIX] Reverting the OTBR Start Script

### DIFF
--- a/test_collections/matter/scripts/OTBR/otbr_start.sh
+++ b/test_collections/matter/scripts/OTBR/otbr_start.sh
@@ -18,7 +18,7 @@ TH_SCRIPTS_DIR="$ROOT_DIR/scripts"
 
 DEFAULT_OTBR_INTERFACE="eth0"
 BR_INTERFACE=${1:-$DEFAULT_OTBR_INTERFACE}
-BR_VARIANT="35"
+BR_VARIANT="35" TODO: Receive the BR variant via shell script parameter
 BR_CHANNEL=25 # The Thread communication channel used
 BR_IMAGE_BASE="nrfconnect/otbr"
 BR_IMAGE_TAG="9185bda"

--- a/test_collections/matter/scripts/OTBR/otbr_start.sh
+++ b/test_collections/matter/scripts/OTBR/otbr_start.sh
@@ -1,24 +1,25 @@
 #! /usr/bin/env bash
-
- #
- # Copyright (c) 2023 Project CHIP Authors
- #
- # Licensed under the Apache License, Version 2.0 (the "License");
- # you may not use this file except in compliance with the License.
- # You may obtain a copy of the License at
- #
- # http://www.apache.org/licenses/LICENSE-2.0
- #
- # Unless required by applicable law or agreed to in writing, software
- # distributed under the License is distributed on an "AS IS" BASIS,
- # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- # See the License for the specific language governing permissions and
- # limitations under the License.
+#
+# Copyright (c) 2023 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 ROOT_DIR=$(realpath $(dirname "$0")/../../../../..)
 TH_SCRIPTS_DIR="$ROOT_DIR/scripts"
 
 DEFAULT_OTBR_INTERFACE="eth0"
 BR_INTERFACE=${1:-$DEFAULT_OTBR_INTERFACE}
+BR_VARIANT="35"
+BR_CHANNEL=25 # The Thread communication channel used
 BR_IMAGE_BASE="nrfconnect/otbr"
 BR_IMAGE_TAG="9185bda"
 BR_IMAGE=$BR_IMAGE_BASE":"$BR_IMAGE_TAG
@@ -47,15 +48,11 @@ sudo docker run --privileged -d --network host --name otbr-chip -e NAT64=1 -e DN
 print_script_step "Waiting 10 seconds to give the the docker container enough time to start up..."
 sleep 10
 
-# The configuration values used below are matching the TH's default Thread configuration
-# Please, change the following attributes to create a custom Thread network as desired
-#
-BR_CHANNEL=15 # The Thread communication channel used
 BR_CHANNEL_HEX=$(printf '%02x' $BR_CHANNEL)
-BR_PANID="1234" # The 2-byte Personal Area Network ID is a unique Thread identifier
-BR_EXTPANID="1111111122222222" # The 8-byte Extended Personal Area Network ID is a unique Thread identifier
-BR_NETWORKNAME="DEMO" # The human-readable Network Name is a unique Thread identifier
-BR_IPV6PREFIX="fd11:22::/64" # The Mesh-Local prefix used to reach interfaces in the same network
+BR_PANID="5b${BR_VARIANT}" # The 2-byte Personal Area Network ID is a unique Thread identifier
+BR_EXTPANID="5b${BR_VARIANT}dead5b${BR_VARIANT}beef" # The 8-byte Extended Personal Area Network ID is a unique Thread identifier
+BR_NETWORKNAME="5b${BR_VARIANT}" # The human-readable Network Name is a unique Thread identifier
+BR_IPV6PREFIX="fd11:${BR_VARIANT}::/64" # The Mesh-Local prefix used to reach interfaces in the same network
 BR_NETWORKKEY="00112233445566778899aabbccddeeff" # The Thread authentication key value
 
 BR_PARAMS=(
@@ -89,3 +86,4 @@ print_script_step "Restarting the Raspi avahi to have it in a clean state"
 sudo service avahi-daemon restart
 
 print_end_of_script
+

--- a/test_collections/matter/scripts/OTBR/otbr_start.sh
+++ b/test_collections/matter/scripts/OTBR/otbr_start.sh
@@ -18,7 +18,7 @@ TH_SCRIPTS_DIR="$ROOT_DIR/scripts"
 
 DEFAULT_OTBR_INTERFACE="eth0"
 BR_INTERFACE=${1:-$DEFAULT_OTBR_INTERFACE}
-BR_VARIANT="35" TODO: Receive the BR variant via shell script parameter
+BR_VARIANT="35" # TODO: Receive the BR variant via shell script parameter
 BR_CHANNEL=25 # The Thread communication channel used
 BR_IMAGE_BASE="nrfconnect/otbr"
 BR_IMAGE_TAG="9185bda"

--- a/test_collections/matter/scripts/OTBR/otbr_start.sh
+++ b/test_collections/matter/scripts/OTBR/otbr_start.sh
@@ -16,13 +16,33 @@
 ROOT_DIR=$(realpath $(dirname "$0")/../../../../..)
 TH_SCRIPTS_DIR="$ROOT_DIR/scripts"
 
-DEFAULT_OTBR_INTERFACE="eth0"
-BR_INTERFACE=${1:-$DEFAULT_OTBR_INTERFACE}
-BR_VARIANT="35" # TODO: Receive the BR variant via shell script parameter
+BR_INTERFACE="eth0"
+BR_VARIANT="35"
 BR_CHANNEL=25 # The Thread communication channel used
 BR_IMAGE_BASE="nrfconnect/otbr"
 BR_IMAGE_TAG="9185bda"
 BR_IMAGE=$BR_IMAGE_BASE":"$BR_IMAGE_TAG
+
+while getopts ":i:v:" opt; do
+  case $opt in
+    i)
+      echo "Using BR Interface: $OPTARG" >&2
+      BR_INTERFACE=$OPTARG
+      ;;
+    v)
+      echo "Using BR Variant: $OPTARG" >&2
+      BR_VARIANT=$OPTARG
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+    :)
+      echo "Option -$OPTARG requires an argument." >&2
+      exit 1
+      ;;
+  esac
+done
 
 source "$TH_SCRIPTS_DIR/utils.sh"
 

--- a/test_collections/matter/scripts/OTBR/otbr_start.sh
+++ b/test_collections/matter/scripts/OTBR/otbr_start.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 #
-# Copyright (c) 2023 Project CHIP Authors
+# Copyright (c) 2024 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fixes: https://github.com/project-chip/certification-tool/issues/420

---
Reverting the OTBR start script to use variables.
It seems important for environments with multiples Thread networks that we could easily change the Thread parameters.
So we're reverting the script to use the BR_VARIANT once again so the main thread fields may be changed all at once.

Some comments and a step to stop an already running container will be kept.