### PR TITLE
Check user prompt answer FAILED for DUT commissioning

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -29,8 +29,8 @@ from test_collections.matter.test_environment_config import (
 )
 
 from ...sdk_container import SDKContainer
-from ...utils import prompt_for_commissioning_mode
-from .utils import commission_device
+from ...utils import PromptOption, prompt_for_commissioning_mode
+from .utils import DUTCommissioningError, commission_device
 
 
 class SuiteType(Enum):
@@ -124,7 +124,14 @@ class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
     async def setup(self) -> None:
         await super().setup()
 
-        await prompt_for_commissioning_mode(self, logger, None, self.cancel)
+        user_response = await prompt_for_commissioning_mode(
+            self, logger, None, self.cancel
+        )
+
+        if user_response == PromptOption.FAIL:
+            raise DUTCommissioningError(
+                "User chose prompt option FAILED for DUT is in Commissioning Mode"
+            )
 
         logger.info("Commission DUT")
 

--- a/test_collections/matter/sdk_tests/support/utils.py
+++ b/test_collections/matter/sdk_tests/support/utils.py
@@ -35,7 +35,7 @@ async def prompt_for_commissioning_mode(
     logger: loguru.Logger,
     on_success: Optional[Callable] = None,
     on_failure: Optional[Callable] = None,
-) -> None:
+) -> PromptOption:
     prompt = "Make sure the DUT is in Commissioning Mode"
     options = {
         "DONE": PromptOption.PASS,
@@ -62,3 +62,4 @@ async def prompt_for_commissioning_mode(
                 f"Received unknown prompt option for \
                         commissioning step: {prompt_response.response}"
             )
+    return prompt_response.response


### PR DESCRIPTION
### What Changed
The goal of this PR is to add a checking when the user select FAILS the DUT commissioning prompt.

### Related Issue
https://github.com/project-chip/certification-tool/issues/464