### PR TITLE
[FIX] Intermittent Tests Start Error With No Information

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -17,7 +17,6 @@ import re
 from asyncio import sleep
 from enum import IntEnum
 from inspect import iscoroutinefunction
-from multiprocessing.managers import BaseManager
 from pathlib import Path
 from socket import SocketIO
 from typing import Any, Optional, Type, TypeVar
@@ -38,10 +37,7 @@ from ...pics import PICS_FILE_PATH
 from ...sdk_container import SDKContainer
 from ...utils import prompt_for_commissioning_mode
 from .python_test_models import PythonTest, PythonTestType
-from .python_testing_hooks_proxy import (
-    SDKPythonTestResultBase,
-    SDKPythonTestRunnerHooks,
-)
+from .python_testing_hooks_proxy import SDKPythonTestResultBase
 from .utils import (
     EXECUTABLE,
     RUNNER_CLASS_PATH,
@@ -261,10 +257,7 @@ class PythonTestCase(TestCase, UserPromptSupport):
         try:
             logger.info("Running Python Test: " + self.python_test.name)
 
-            BaseManager.register("TestRunnerHooks", SDKPythonTestRunnerHooks)
-            manager = BaseManager(address=("0.0.0.0", 50000), authkey=b"abc")
-            manager.start()
-            test_runner_hooks = manager.TestRunnerHooks()  # type: ignore
+            test_runner_hooks = self.sdk_container.manager.TestRunnerHooks()  # type: ignore
 
             if not self.python_test.path:
                 raise PythonTestCaseError(

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -257,7 +257,8 @@ class PythonTestCase(TestCase, UserPromptSupport):
         try:
             logger.info("Running Python Test: " + self.python_test.name)
 
-            test_runner_hooks = self.sdk_container.manager.TestRunnerHooks()  # type: ignore
+            manager = self.sdk_container.manager
+            test_runner_hooks = manager.TestRunnerHooks()  # type: ignore
 
             if not self.python_test.path:
                 raise PythonTestCaseError(

--- a/test_collections/matter/sdk_tests/support/sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/sdk_container.py
@@ -153,6 +153,13 @@ class SDKContainer(metaclass=Singleton):
             )
             container_manager.destroy(existing_container)
 
+    def __create_manager(self) -> BaseManager:
+        BaseManager.register("TestRunnerHooks", SDKPythonTestRunnerHooks)
+        manager = BaseManager(address=("0.0.0.0", 50000), authkey=b"abc")
+        manager.start()
+
+        return manager
+
     def is_running(self) -> bool:
         if self.__container is None:
             return False
@@ -179,9 +186,8 @@ class SDKContainer(metaclass=Singleton):
             self.image_tag, self.run_parameters
         )
 
-        BaseManager.register("TestRunnerHooks", SDKPythonTestRunnerHooks)
-        self.manager = BaseManager(address=("0.0.0.0", 50000), authkey=b"abc")
-        self.manager.start()
+        # Create the BaseManager for multiprocess data share
+        self.manager = self.__create_manager()
 
         self.logger.info(
             f"{self.container_name} container started"

--- a/test_collections/matter/sdk_tests/support/sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/sdk_container.py
@@ -15,6 +15,7 @@
 #
 from __future__ import annotations
 
+from multiprocessing.managers import BaseManager
 from pathlib import Path
 from typing import Optional, Union
 
@@ -29,6 +30,7 @@ from test_collections.matter.config import matter_settings
 
 from .exec_run_in_container import ExecResultExtended, exec_run_in_container
 from .pics import set_pics_command
+from .python_testing.models.python_testing_hooks_proxy import SDKPythonTestRunnerHooks
 
 # Trace mount
 LOCAL_LOGS_PATH = Path("/var/tmp")
@@ -136,6 +138,7 @@ class SDKContainer(metaclass=Singleton):
 
         self.__pics_file_created = False
         self.logger = logger
+        self.manager: BaseManager | None = None
 
     @property
     def pics_file_created(self) -> bool:
@@ -175,6 +178,10 @@ class SDKContainer(metaclass=Singleton):
         self.__container = await container_manager.create_container(
             self.image_tag, self.run_parameters
         )
+
+        BaseManager.register("TestRunnerHooks", SDKPythonTestRunnerHooks)
+        self.manager = BaseManager(address=("0.0.0.0", 50000), authkey=b"abc")
+        self.manager.start()
 
         self.logger.info(
             f"{self.container_name} container started"

--- a/test_collections/matter/sdk_tests/support/tests/test_sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/tests/test_sdk_container.py
@@ -77,6 +77,10 @@ async def test_destroy_container_running() -> None:
     with mock.patch.object(
         target=sdk_container, attribute="is_running", return_value=False
     ), mock.patch.object(
+        target=sdk_container,
+        attribute="_SDKContainer__create_manager",
+        return_value=None,
+    ), mock.patch.object(
         target=container_manager, attribute="get_container", return_value=None
     ), mock.patch.object(
         target=container_manager, attribute="destroy"
@@ -113,6 +117,10 @@ async def test_destroy_container_once() -> None:
     with mock.patch.object(
         target=sdk_container, attribute="is_running", return_value=False
     ), mock.patch.object(
+        target=sdk_container,
+        attribute="_SDKContainer__create_manager",
+        return_value=None,
+    ), mock.patch.object(
         target=container_manager, attribute="get_container", return_value=None
     ), mock.patch.object(
         target=container_manager, attribute="destroy"
@@ -147,6 +155,10 @@ async def test_send_command_default_prefix() -> None:
 
     with mock.patch.object(
         target=sdk_container, attribute="is_running", return_value=False
+    ), mock.patch.object(
+        target=sdk_container,
+        attribute="_SDKContainer__create_manager",
+        return_value=None,
     ), mock.patch.object(
         target=container_manager, attribute="get_container", return_value=None
     ), mock.patch.object(
@@ -188,6 +200,10 @@ async def test_send_command_custom_prefix() -> None:
 
     with mock.patch.object(
         target=sdk_container, attribute="is_running", return_value=False
+    ), mock.patch.object(
+        target=sdk_container,
+        attribute="_SDKContainer__create_manager",
+        return_value=None,
     ), mock.patch.object(
         target=container_manager, attribute="get_container", return_value=None
     ), mock.patch.object(


### PR DESCRIPTION
Fixes: https://github.com/project-chip/certification-tool/issues/450

## Description
There's an intermittent problem when running many tests that the logs don't show any information on why the error occurred, as we can see in the image below:
<img width="822" alt="Screenshot 2024-10-21 at 15 41 08" src="https://github.com/user-attachments/assets/58d1cb1f-2287-4e2d-a716-3f14868503df">

After trying to reproduce while debugging, the error was isolated and points out to be Python's `BaseManager` that failed to connect since the address was already used:
<img width="1189" alt="Screenshot 2024-10-15 at 16 33 27" src="https://github.com/user-attachments/assets/61608783-db6e-4d95-a0fd-6619e8ffc686">

## Solution
It was noted afterwards that the TH was currently creating the `BaseManager` (object to share data between processes) every time a Python Test is started. Thus, resulting sometimes in this error when was creating a new manager.

The proposed solution moved the manager creation to the initialization of the SDK Container, occurring only once for test run. When a Python Test starts now it will only access the manager previously created within the container.

> [!Note]
> Since it's an intermittent problem there's always a chance of coincidence, but this solution was anyway extensively tested for a couple of days and the problem didn't happen again.