### PR TITLE
Fix suite names for custom python tests

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -85,9 +85,7 @@ class PythonTestSuite(TestSuite):
                 "name": name,
                 "python_test_version": python_test_version,
                 "metadata": {
-                    "public_id": name
-                    if python_test_version != "custom"
-                    else name + "-custom",
+                    "public_id": name,
                     "version": "0.0.1",
                     "title": name,
                     "description": name,

--- a/test_collections/matter/sdk_tests/support/python_testing/sdk_python_tests.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/sdk_python_tests.py
@@ -55,25 +55,30 @@ SDK_PYTHON_TEST_FOLDER = SDKTestFolder(
 def _init_test_suites(
     python_test_version: str,
 ) -> dict[SuiteType, PythonSuiteDeclaration]:
+    # Append `custom` text in order to differ from the regular suite name
+    version: str = ""
+    if python_test_version == "custom":
+        version += "-custom"
+
     return {
         SuiteType.MANDATORY: PythonSuiteDeclaration(
-            name="Python Testing Suite - Mandatories",
+            name="Python Testing Suite - Mandatories" + version,
             suite_type=SuiteType.MANDATORY,
             version=python_test_version,
             mandatory=True,
         ),
         SuiteType.COMMISSIONING: PythonSuiteDeclaration(
-            name="Python Testing Suite",
+            name="Python Testing Suite" + version,
             suite_type=SuiteType.COMMISSIONING,
             version=python_test_version,
         ),
         SuiteType.NO_COMMISSIONING: PythonSuiteDeclaration(
-            name="Python Testing Suite - No commissioning",
+            name="Python Testing Suite - No commissioning" + version,
             suite_type=SuiteType.NO_COMMISSIONING,
             version=python_test_version,
         ),
         SuiteType.LEGACY: PythonSuiteDeclaration(
-            name="Python Testing Suite - Old script format",
+            name="Python Testing Suite - Old script format" + version,
             suite_type=SuiteType.LEGACY,
             version=python_test_version,
         ),

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_suite.py
@@ -78,7 +78,7 @@ class YamlTestSuite(TestSuite):
                 "name": name,
                 "yaml_version": yaml_version,
                 "metadata": {
-                    "public_id": name if yaml_version != "custom" else name + "-custom",
+                    "public_id": name,
                     "version": "0.0.1",
                     "title": name,
                     "description": name,


### PR DESCRIPTION
### What changed
Added custom text for custom suite at test selection screen. 

### Related Issue
https://github.com/project-chip/certification-tool/issues/229

### Testing
Custom suite are now being displayed in both test selection and test execution screens.

![Screenshot 2024-11-19 at 09 30 44](https://github.com/user-attachments/assets/26d77730-8800-4ca6-b68f-9c797a5c6731)
![Screenshot 2024-11-19 at 09 30 06](https://github.com/user-attachments/assets/52e718a0-231f-460d-87d6-ac6d7860e130)
