### PR TITLE
[FIX] Added support to negated PICS

### DIFF
--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -46,7 +46,6 @@ def applicable_test_cases_list(pics: PICS) -> PICSApplicableTestCases:
     disabled_pics = set([item.number for item in pics.all_disabled_items()])
     all_pics_definitions.update(disabled_pics)
 
-
     applicable_mandatories_tests = __applicable_test_cases(
         test_collections, all_pics_definitions, True
     )

--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -41,13 +41,17 @@ def applicable_test_cases_list(pics: PICS) -> PICSApplicableTestCases:
         return PICSApplicableTestCases(test_cases=applicable_tests)
 
     test_collections = test_script_manager.test_collections
-    enabled_pics = set([item.number for item in pics.all_enabled_items()])
+
+    all_pics_definitions = set([item.number for item in pics.all_enabled_items()])
+    disabled_pics = set([item.number for item in pics.all_disabled_items()])
+    all_pics_definitions.update(disabled_pics)
+
 
     applicable_mandatories_tests = __applicable_test_cases(
-        test_collections, enabled_pics, True
+        test_collections, all_pics_definitions, True
     )
     applicable_remaining_tests = __applicable_test_cases(
-        test_collections, enabled_pics, False
+        test_collections, all_pics_definitions, False
     )
 
     # Add first the mandatories test cases
@@ -61,7 +65,7 @@ def applicable_test_cases_list(pics: PICS) -> PICSApplicableTestCases:
 
 def __applicable_test_cases(
     test_collections: Dict[str, TestCollectionDeclaration],
-    enabled_pics: set[str],
+    pics: set[str],
     mandatory: bool,
 ) -> list:
     applicable_tests: list = []
@@ -74,6 +78,6 @@ def __applicable_test_cases(
                         # Test cases without pics required are always applicable
                         applicable_tests.append(test_case.metadata["title"])
                     elif len(test_case.pics) > 0:
-                        if test_case.pics.issubset(enabled_pics):
+                        if test_case.pics.issubset(pics):
                             applicable_tests.append(test_case.metadata["title"])
     return applicable_tests

--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -44,7 +44,6 @@ def applicable_test_cases_list(pics: PICS) -> PICSApplicableTestCases:
         return PICSApplicableTestCases(test_cases=applicable_tests)
 
     test_collections = test_script_manager.test_collections
-
     enabled_pics = set([item.number for item in pics.all_enabled_items()])
 
     applicable_mandatories_tests = __applicable_test_cases(

--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Dict
+from typing import Dict, Tuple
 
 from loguru import logger
 
@@ -77,21 +77,27 @@ def __applicable_test_cases(
                         # Test cases without pics required are always applicable
                         applicable_tests.append(test_case.metadata["title"])
                     elif len(test_case.pics) > 0:
-                        # Consider only enabled pics for test cases
-                        test_enabled_pics = __retrieve_enabled_pics(test_case)
+                        test_enabled_pics, test_disabled_pics = __retrieve_pics(
+                            test_case
+                        )
 
-                        # test_case
-                        if test_enabled_pics.issubset(enabled_pics):
+                        # Checking if the test case is applicable
+                        if test_enabled_pics.issubset(
+                            enabled_pics
+                        ) and test_disabled_pics.isdisjoint(enabled_pics):
                             applicable_tests.append(test_case.metadata["title"])
     return applicable_tests
 
 
-def __retrieve_enabled_pics(test_case: TestCaseDeclaration) -> set:
-    pics_list: set = set()
+def __retrieve_pics(test_case: TestCaseDeclaration) -> Tuple[set, set]:
+    enabled_pics_list: set = set()
+    disabled_pics_list: set = set()
     for pics in test_case.pics:
         # The '!' char before PICS definition, is how test case flag a PICS as negative
-        # For applicable test cases, we should only consider enabled PICS
-        if not pics.startswith("!"):
-            pics_list.add(pics)
+        if pics.startswith("!"):
+            # Ignore ! char while adding the pics into disabled_pics_list structure
+            disabled_pics_list.add(pics[1:])
+        else:
+            enabled_pics_list.add(pics)
 
-    return pics_list
+    return enabled_pics_list, disabled_pics_list

--- a/app/schemas/pics.py
+++ b/app/schemas/pics.py
@@ -28,17 +28,6 @@ class PICSCluster(BaseModel):
     def enabled_items(self) -> list[PICSItem]:
         return list([item for item in self.items.values() if item.enabled])
 
-    def disabled_items(self) -> list[PICSItem]:
-        # Disabled PICS must be represented as "![PICS_DEFINITION]"
-        # Example: !MCORE.DD.NON_CONCURRENT_CONNECTION
-        disabled_items: list[PICSItem] = []
-        for item in self.items.values():
-            if not item.enabled:
-                item.number = f"!{item.number}"
-                disabled_items.append(item)
-
-        return disabled_items
-
 
 class PICS(BaseModel):
     clusters: dict[str, PICSCluster] = {}
@@ -46,10 +35,6 @@ class PICS(BaseModel):
     def all_enabled_items(self) -> list[PICSItem]:
         # flatten all enabled items for all clusters
         return sum([c.enabled_items() for c in self.clusters.values()], [])
-
-    def all_disabled_items(self) -> list[PICSItem]:
-        # flatten all disabled items for all clusters
-        return sum([c.disabled_items() for c in self.clusters.values()], [])
 
 
 class PICSApplicableTestCases(BaseModel):

--- a/app/schemas/pics.py
+++ b/app/schemas/pics.py
@@ -29,13 +29,15 @@ class PICSCluster(BaseModel):
         return list([item for item in self.items.values() if item.enabled])
 
     def disabled_items(self) -> list[PICSItem]:
-        # Disabled PICS must be represented as "![PICS_DEFINITION]" 
+        # Disabled PICS must be represented as "![PICS_DEFINITION]"
         # Example: !MCORE.DD.NON_CONCURRENT_CONNECTION
-        return [
-            item
-            for item in self.items.values()
-            if not item.enabled and setattr(item, "number", f"!{item.number}") is None
-        ]
+        disabled_items: list[PICSItem] = []
+        for item in self.items.values():
+            if not item.enabled:
+                item.number = f"!{item.number}"
+                disabled_items.append(item)
+
+        return disabled_items
 
 
 class PICS(BaseModel):

--- a/app/schemas/pics.py
+++ b/app/schemas/pics.py
@@ -28,6 +28,15 @@ class PICSCluster(BaseModel):
     def enabled_items(self) -> list[PICSItem]:
         return list([item for item in self.items.values() if item.enabled])
 
+    def disabled_items(self) -> list[PICSItem]:
+        # Disabled PICS must be represented as "![PICS_DEFINITION]" 
+        # Example: !MCORE.DD.NON_CONCURRENT_CONNECTION
+        return [
+            item
+            for item in self.items.values()
+            if not item.enabled and setattr(item, "number", f"!{item.number}") is None
+        ]
+
 
 class PICS(BaseModel):
     clusters: dict[str, PICSCluster] = {}
@@ -35,6 +44,10 @@ class PICS(BaseModel):
     def all_enabled_items(self) -> list[PICSItem]:
         # flatten all enabled items for all clusters
         return sum([c.enabled_items() for c in self.clusters.values()], [])
+
+    def all_disabled_items(self) -> list[PICSItem]:
+        # flatten all disabled items for all clusters
+        return sum([c.disabled_items() for c in self.clusters.values()], [])
 
 
 class PICSApplicableTestCases(BaseModel):


### PR DESCRIPTION
### What Changed
Add support to consider Negative PICS, such as `!MCORE.DT_SW_COMP` as description in image bellow:
<img width="618" alt="352269668-4384683c-af6e-4a6d-8a1c-8f43c4e87aa7-2" src="https://github.com/user-attachments/assets/0952b2f5-7439-4189-b094-3862a86505f5">


### Related Issue
https://github.com/project-chip/certification-tool/issues/320

### Testing
TC with Negative PICS is now being considered.
For example, TC-BIND-2.1, which has the following PICS configuration is now being considered:
`BIND.C: true`
`MCORE.ROLE.CONTROLLER: true`
`MCORE.DT_SW_COMP: false`
<img width="1530" alt="Screenshot 2024-11-25 at 18 09 01" src="https://github.com/user-attachments/assets/eb285827-9fb8-4640-a97d-f7ba9d779d3c">


Unit Testing passing
<img width="246" alt="Screenshot 2024-11-25 at 14 08 43" src="https://github.com/user-attachments/assets/7ea7468e-58c8-4982-a9ea-e17285a7b5de">

