### PR TITLE
[Feature] Implement support to export project config

### DIFF
--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import json
 from http import HTTPStatus
 from typing import List, Sequence, Union
 

--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import json
 from http import HTTPStatus
 from typing import List, Sequence, Union
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse
+from pydantic import ValidationError, parse_obj_as
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 
@@ -364,3 +366,34 @@ def export_project_config(
         jsonable_encoder(project),
         **options,
     )
+
+
+@router.post("/import", response_model=schemas.Project)
+def importproject_config(
+    *,
+    db: Session = Depends(get_db),
+    import_file: UploadFile = File(...),
+) -> models.Project:
+    """
+    Imports a test run execution to the the given project_id.
+    """
+
+    file_content = import_file.file.read().decode("utf-8")
+    file_dict = json.loads(file_content)
+
+    try:
+        exported_project: schemas.ProjectCreate = parse_obj_as(
+            schemas.ProjectCreate, file_dict
+        )
+    except ValidationError as error:
+        raise HTTPException(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY, detail=str(error)
+        )
+
+    try:
+        return crud.project.create(db=db, obj_in=exported_project)
+    except TestEnvironmentConfigError as e:
+        raise HTTPException(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            detail=str(e),
+        )

--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -350,9 +350,9 @@ def export_project_config(
         HTTPException: if no project exists for provided project id
 
     Returns:
-        Project: project The project by the informed project id
+        JSONResponse: json representation of the project with the informed project id
     """
-    # Retreive project by project_id using schemas.ProjectCreate schema
+    # Retrieve project by project_id using schemas.ProjectCreate schema
     project = schemas.ProjectCreate(**__project(db=db, id=id).__dict__)
 
     options: dict = {"media_type": "application/json"}

--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -332,7 +332,7 @@ def __persist_pics_update(db: Session, project: Project) -> Project:
     return project
 
 
-@router.get("/{id}/project_config", response_model=schemas.Project)
+@router.get("/{id}/export", response_model=schemas.ProjectCreate)
 def export_project_config(
     *,
     db: Session = Depends(get_db),
@@ -350,11 +350,12 @@ def export_project_config(
     Returns:
         Project: project The project by the informed project id
     """
-    project = __project(db=db, id=id)
+    # Retreive project by project_id using schemas.ProjectCreate schema
+    project = schemas.ProjectCreate(**__project(db=db, id=id).__dict__)
 
     options: dict = {"media_type": "application/json"}
     if download:
-        filename = f"{project.name}-project-config.txt"
+        filename = f"{project.name}-project-config.json"
         options["headers"] = {
             "Content-Disposition": f'attachment; filename="{filename}"'
         }

--- a/app/tests/api/api_v1/test_projects.py
+++ b/app/tests/api/api_v1/test_projects.py
@@ -24,10 +24,9 @@ from fastapi.testclient import TestClient
 from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
-from app import crud
+from app import crud, models, schemas
 from app.core.config import settings
 from app.default_environment_config import default_environment_config
-from app.models.project import Project
 from app.tests.utils.project import (
     create_random_project,
     create_random_project_archived,
@@ -151,7 +150,7 @@ def test_read_project(client: TestClient, db: Session) -> None:
 def test_read_multiple_project(client: TestClient, db: Session) -> None:
     project1 = create_random_project(db, config={})
     project2 = create_random_project(db, config={})
-    limit = db.scalar(select(func.count(Project.id))) or 0
+    limit = db.scalar(select(func.count(models.Project.id))) or 0
     response = client.get(
         f"{settings.API_V1_STR}/projects?limit={limit}",
     )
@@ -164,7 +163,7 @@ def test_read_multiple_project(client: TestClient, db: Session) -> None:
 
 def test_read_multiple_project_by_archived(client: TestClient, db: Session) -> None:
     archived = create_random_project_archived(db, config={})
-    limit = db.scalar(select(func.count(Project.id))) or 0
+    limit = db.scalar(select(func.count(models.Project.id))) or 0
 
     response = client.get(
         f"{settings.API_V1_STR}/projects?limit={limit}",
@@ -375,13 +374,14 @@ def test_applicable_test_cases_empty_pics(client: TestClient, db: Session) -> No
 
 def test_project_config(client: TestClient, db: Session) -> None:
     project = create_random_project_with_pics(db=db, config={})
+    project_create_schema = schemas.ProjectCreate(**project.__dict__)
     # retrieve the project config
     response = client.get(
-        f"{settings.API_V1_STR}/projects/{project.id}/project_config",
+        f"{settings.API_V1_STR}/projects/{project.id}/export",
     )
 
     validate_json_response(
         response=response,
         expected_status_code=HTTPStatus.OK,
-        expected_content=jsonable_encoder(project),
+        expected_content=jsonable_encoder(project_create_schema),
     )

--- a/app/tests/api/api_v1/test_projects.py
+++ b/app/tests/api/api_v1/test_projects.py
@@ -383,5 +383,5 @@ def test_project_config(client: TestClient, db: Session) -> None:
     validate_json_response(
         response=response,
         expected_status_code=HTTPStatus.OK,
-        expected_content=jsonable_encoder(project),  # type: ignore
+        expected_content=jsonable_encoder(project),
     )

--- a/app/tests/api/api_v1/test_projects.py
+++ b/app/tests/api/api_v1/test_projects.py
@@ -371,3 +371,17 @@ def test_applicable_test_cases_empty_pics(client: TestClient, db: Session) -> No
     # the project is created with empty pics
     # expected value: applicable_test_cases == 0
     assert len(content["test_cases"]) == 0
+
+
+def test_project_config(client: TestClient, db: Session) -> None:
+    project = create_random_project_with_pics(db=db, config={})
+    # retrieve the project config
+    response = client.get(
+        f"{settings.API_V1_STR}/projects/{project.id}/project_config",
+    )
+
+    validate_json_response(
+        response=response,
+        expected_status_code=HTTPStatus.OK,
+        expected_content=jsonable_encoder(project),  # type: ignore
+    )


### PR DESCRIPTION
### What Changed
Implement support to export/import project config

### Related issue
https://github.com/project-chip/certification-tool/issues/448
https://github.com/project-chip/certification-tool/issues/503

### Testing
Service GET `api/v1/projects/{id}/export` is working
<img width="1116" alt="Screenshot 2024-11-28 at 16 02 41" src="https://github.com/user-attachments/assets/5b3148a1-33af-4615-8a18-eeeebfb90799">


Service POST `api/v1/projects/import` is working
<img width="1134" alt="Screenshot 2024-11-28 at 15 49 47" src="https://github.com/user-attachments/assets/ed2c86aa-5465-42ff-8844-c9a9d4542d25">


Unit test added and passing
<img width="356" alt="Screenshot 2024-11-28 at 15 47 11" src="https://github.com/user-attachments/assets/d26ebeae-b617-4037-803c-3f5f9eade28c">



