### PR TITLE
[Feature] DO NOT require commissioning every test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ htmlcov
 __pycache__
 app.egg-info
 logs
+admin_storage.json
 /docker-stack.yml
 .DS_Store
 app/chip-tool/chip-tool

--- a/app/container_manager/container_manager.py
+++ b/app/container_manager/container_manager.py
@@ -129,18 +129,18 @@ class ContainerManager(object, metaclass=Singleton):
         container: Container,
         container_file_path: Path,
         destination_path: Path,
-        container_file_name: str,
+        destination_file_name: str,
     ) -> None:
         try:
             logger.info(
                 "### File Copy: CONTAINER->HOST"
                 f" From Container Path: {str(container_file_path)}"
-                f" To Host Path: {str(destination_path)}/{container_file_name}"
+                f" To Host Path: {str(destination_path)}/{destination_file_name}"
                 f" Container Name: {str(container.name)}"
             )
             stream, _ = container.get_archive(str(container_file_path))
             with open(
-                f"{str(destination_path)}/{container_file_name}",
+                f"{str(destination_path)}/{destination_file_name}",
                 "wb",
             ) as f:
                 for d in stream:

--- a/test_collections/matter/config.py
+++ b/test_collections/matter/config.py
@@ -23,9 +23,9 @@ class MatterSettings(BaseSettings):
 
     # SDK Docker Image
     SDK_DOCKER_IMAGE: str = "ghcr.io/rquidute/chip-cert-bins"
-    SDK_DOCKER_TAG: str = "f99a2c3b16d3d26f91a0c5efb2770d1c488697d1"
-    # SDK SHA: used to fetch test YAML from SDK.
-    SDK_SHA: str = "f99a2c3b16d3d26f91a0c5efb2770d1c488697d1"
+    SDK_DOCKER_TAG: str = "017e8b59aed3809c5fdb601950bdb44d53e721b2"
+    # SDK SHA: used to fetch tests (YAML and Python) from SDK.
+    SDK_SHA: str = "017e8b59aed3809c5fdb601950bdb44d53e721b2"
 
     class Config:
         case_sensitive = True

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -35,7 +35,7 @@ from app.user_prompt_support.user_prompt_support import UserPromptSupport
 from test_collections.matter.test_environment_config import TestEnvironmentConfigMatter
 
 from ...pics import PICS_FILE_PATH
-from ...sdk_container import SDKContainer
+from ...sdk_container import ADMIN_STORAGE_FILE, SDKContainer
 from ...utils import prompt_for_commissioning_mode
 from .python_test_models import PythonTest, PythonTestType
 from .python_testing_hooks_proxy import (
@@ -372,9 +372,16 @@ class LegacyPythonTestCase(PythonTestCase):
             case PromptOption.YES:
                 logger.info("User chose prompt option YES")
                 logger.info("Commission DUT")
-                await commission_device(
-                    TestEnvironmentConfigMatter(**self.config), logger
-                )
+
+                if ADMIN_STORAGE_FILE.exists():
+                    self.sdk_container.copy_file_to_container(
+                        host_file_path=ADMIN_STORAGE_FILE,
+                        destination_container_path=Path("/root"),
+                    )
+                else:
+                    await commission_device(
+                        TestEnvironmentConfigMatter(**self.config), logger
+                    )
 
             case PromptOption.NO:
                 logger.info("User chose prompt option NO")

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -42,10 +42,9 @@ from .python_testing_hooks_proxy import (
     SDKPythonTestResultBase,
     SDKPythonTestRunnerHooks,
 )
+from .utils import EXECUTABLE, RUNNER_CLASS_PATH, DUTCommissioningError
+from .utils import PromptOption as PromptOptionUtils
 from .utils import (
-    EXECUTABLE,
-    RUNNER_CLASS_PATH,
-    DUTCommissioningError,
     commission_device,
     generate_command_arguments,
     should_perform_new_commissioning,
@@ -348,7 +347,7 @@ class NoCommissioningPythonTestCase(PythonTestCase):
         user_response = await prompt_for_commissioning_mode(
             self, logger, None, self.cancel
         )
-        if user_response == PromptOption.NO:
+        if user_response == PromptOptionUtils.FAIL:
             raise DUTCommissioningError(
                 "User chose prompt option FAILED for DUT is in Commissioning Mode"
             )
@@ -361,7 +360,7 @@ class LegacyPythonTestCase(PythonTestCase):
         user_response = await prompt_for_commissioning_mode(
             self, logger, None, self.cancel
         )
-        if user_response == PromptOption.NO:
+        if user_response == PromptOptionUtils.FAIL:
             raise DUTCommissioningError(
                 "User chose prompt option FAILED for DUT is in Commissioning Mode"
             )

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 from enum import Enum
-from pathlib import Path
 from typing import Type, TypeVar
 
 from app.schemas.test_environment_config import ThreadAutoConfig

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 from enum import Enum
+from pathlib import Path
 from typing import Type, TypeVar
 
 from app.schemas.test_environment_config import ThreadAutoConfig
@@ -28,7 +29,7 @@ from test_collections.matter.test_environment_config import (
     TestEnvironmentConfigMatter,
 )
 
-from ...sdk_container import SDKContainer
+from ...sdk_container import ADMIN_STORAGE_FILE, SDKContainer
 from ...utils import PromptOption, prompt_for_commissioning_mode
 from .utils import DUTCommissioningError, commission_device
 
@@ -145,4 +146,10 @@ class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
             await self.border_router.start_device(matter_config.network.thread)
             await self.border_router.form_thread_topology()
 
-        await commission_device(matter_config, logger)
+        if ADMIN_STORAGE_FILE.exists():
+            self.sdk_container.copy_file_to_container(
+                host_file_path=ADMIN_STORAGE_FILE,
+                destination_container_path=Path("/root"),
+            )
+        else:
+            await commission_device(matter_config, logger)

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -30,11 +30,7 @@ from test_collections.matter.test_environment_config import (
 )
 
 from ...sdk_container import SDKContainer
-from ...utils import (
-    PromptOption,
-    prompt_for_commissioning_mode,
-    prompt_re_use_commissioning,
-)
+from ...utils import PromptOption, prompt_for_commissioning_mode
 from .utils import (
     DUTCommissioningError,
     commission_device,

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -40,7 +40,7 @@ from ...utils import (
     ADMIN_STORAGE_FILE_HOST,
     ADMIN_STORAGE_FILE_HOST_PATH,
     PromptOption,
-    prompt_re_use_commissioning,
+    prompt_reuse_commissioning,
 )
 
 # Command line params
@@ -167,7 +167,7 @@ async def commission_device(
         raise DUTCommissioningError("Failed to commission DUT")
 
     # Copy admin_storage.json file from container, in case the user wants to
-    # re-use this information in the next execution
+    # reuse this information in the next execution
     __copy_admin_storage_file(config, logger)
 
 
@@ -203,7 +203,7 @@ async def should_perform_new_commissioning(
     # the previous commissioning information or if it should perform a
     # new commissioning
     if ADMIN_STORAGE_FILE_HOST.exists():
-        user_response = await prompt_re_use_commissioning(prompt_support, logger)
+        user_response = await prompt_reuse_commissioning(prompt_support, logger)
         if user_response == PromptOption.PASS:
             logger.info(f"Copying file {str(ADMIN_STORAGE_FILE_HOST)} to container")
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -166,8 +166,8 @@ async def commission_device(
     if exit_code:
         raise DUTCommissioningError("Failed to commission DUT")
 
-    # Copy admin_storage.json file from container, in case user want in the next
-    # execution re-use this information
+    # Copy admin_storage.json file from container, in case the user wants to
+    # re-use this information in the next execution
     __copy_admin_storage_file(config, logger)
 
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -112,7 +112,7 @@ class DUTCommissioningError(Exception):
     pass
 
 
-def __retrieve_storage_path(config: TestEnvironmentConfigMatte):
+def __retrieve_storage_path(config: TestEnvironmentConfigMatter):
     storage_path = ADMIN_STORAGE_FILE_CONTAINER_DEFAULT_PATH.joinpath(
         ADMIN_STORAGE_FILE_DEFAULT_NAME
     )

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -138,7 +138,7 @@ def __copy_admin_storage_file(
     sdk_container.copy_file_from_container(
         container_file_path=Path(storage_path),
         destination_path=ADMIN_STORAGE_FILE_HOST_PATH,
-        container_file_name=ADMIN_STORAGE_FILE_DEFAULT_NAME,
+        destination_file_name=ADMIN_STORAGE_FILE_DEFAULT_NAME,
     )
 
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -23,6 +23,7 @@ import loguru
 
 from app.schemas.test_environment_config import ThreadAutoConfig
 from app.test_engine.logger import PYTHON_TEST_LEVEL
+from app.user_prompt_support import UserPromptSupport
 from test_collections.matter.sdk_tests.support.otbr_manager.otbr_manager import (
     ThreadBorderRouter,
 )
@@ -112,7 +113,7 @@ class DUTCommissioningError(Exception):
     pass
 
 
-def __retrieve_storage_path(config: TestEnvironmentConfigMatter):
+def __retrieve_storage_path(config: TestEnvironmentConfigMatter) -> Path:
     storage_path = ADMIN_STORAGE_FILE_CONTAINER_DEFAULT_PATH.joinpath(
         ADMIN_STORAGE_FILE_DEFAULT_NAME
     )

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -16,6 +16,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Generator, cast
 
 import loguru
@@ -121,6 +122,11 @@ async def commission_device(
     handle_logs(cast(Generator, exec_result.output), logger)
 
     exit_code = sdk_container.exec_exit_code(exec_result.exec_id)
+
+    sdk_container.copy_file_from_container(
+        container_file_path=Path("/root/admin_storage.json"),
+        destination_path=Path("/app/backend/"),
+    )
 
     if exit_code:
         raise DUTCommissioningError("Failed to commission DUT")

--- a/test_collections/matter/sdk_tests/support/sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/sdk_container.py
@@ -88,8 +88,6 @@ DOCKER_STRESS_TEST_SIMULATED_ACCESSORY_SCRIPT_PATH = (
     "/root/python_testing/scripts/sdk/simulated_accessory.py"
 )
 
-ADMIN_STORAGE_FILE = Path("/app/backend/admin_storage.json")
-
 
 class SDKContainerNotRunning(Exception):
     """Raised when we attempt to use the docker container, but it is not running"""
@@ -295,12 +293,16 @@ class SDKContainer(metaclass=Singleton):
         self.__pics_file_created = False
 
     def copy_file_from_container(
-        self, container_file_path: Path, destination_path: Path
+        self,
+        container_file_path: Path,
+        destination_path: Path,
+        container_file_name: str,
     ) -> None:
         container_manager.copy_file_from_container(
             container=self.__container,
             container_file_path=container_file_path,
             destination_path=destination_path,
+            container_file_name=container_file_name,
         )
 
     def copy_file_to_container(

--- a/test_collections/matter/sdk_tests/support/sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/sdk_container.py
@@ -296,13 +296,13 @@ class SDKContainer(metaclass=Singleton):
         self,
         container_file_path: Path,
         destination_path: Path,
-        container_file_name: str,
+        destination_file_name: str,
     ) -> None:
         container_manager.copy_file_from_container(
             container=self.__container,
             container_file_path=container_file_path,
             destination_path=destination_path,
-            container_file_name=container_file_name,
+            destination_file_name=destination_file_name,
         )
 
     def copy_file_to_container(

--- a/test_collections/matter/sdk_tests/support/sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/sdk_container.py
@@ -88,6 +88,8 @@ DOCKER_STRESS_TEST_SIMULATED_ACCESSORY_SCRIPT_PATH = (
     "/root/python_testing/scripts/sdk/simulated_accessory.py"
 )
 
+ADMIN_STORAGE_FILE = Path("/app/backend/admin_storage.json")
+
 
 class SDKContainerNotRunning(Exception):
     """Raised when we attempt to use the docker container, but it is not running"""
@@ -291,3 +293,21 @@ class SDKContainer(metaclass=Singleton):
 
     def reset_pics_state(self) -> None:
         self.__pics_file_created = False
+
+    def copy_file_from_container(
+        self, container_file_path: Path, destination_path: Path
+    ) -> None:
+        container_manager.copy_file_from_container(
+            container=self.__container,
+            container_file_path=container_file_path,
+            destination_path=destination_path,
+        )
+
+    def copy_file_to_container(
+        self, host_file_path: Path, destination_container_path: Path
+    ) -> None:
+        container_manager.copy_file_to_container(
+            container=self.__container,
+            host_file_path=host_file_path,
+            destination_container_path=destination_container_path,
+        )

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
@@ -21,12 +21,21 @@ from unittest import mock
 
 import pytest
 
+from app.default_environment_config import default_environment_config
+from app.models.project import Project
 from app.models.test_case_execution import TestCaseExecution
+from app.models.test_run_execution import TestRunExecution
+from app.models.test_suite_execution import TestSuiteExecution
 from app.test_engine.logger import test_engine_logger
+from app.user_prompt_support import UserPromptSupport
 
 from ...models.matter_test_models import MatterTestStep, MatterTestType
 from ...python_testing.models import PythonTestCase
 from ...python_testing.models.python_test_models import PythonTest, PythonTestType
+from ...python_testing.models.test_case import LegacyPythonTestCase, PromptOption
+from ...python_testing.models.utils import DUTCommissioningError
+
+# from ...utils import PromptOption
 
 
 def python_test_instance(
@@ -197,3 +206,218 @@ def test_multiple_steps_for_python_tests() -> None:
             s for s in instance.test_steps if s.name == test_step.label
         ]
         assert len(steps_from_python) == no_steps
+
+
+@pytest.mark.asyncio
+async def test_should_raise_DUTCommissioningError_prompt_commissioning_failed() -> None:
+    """Test when user responds FAIL to commissioning mode prompt.
+
+    Should raise DUTCommissioningError.
+    """
+    test_case_execution = TestCaseExecution()
+    test = python_test_instance(name="test_name", path=Path("path"))
+    test.python_test_type = PythonTestType.MANDATORY
+
+    test_case = LegacyPythonTestCase.class_factory(
+        test=test,
+        python_test_version="version",
+        mandatory=False,
+    )(test_case_execution)
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".prompt_for_commissioning_mode",
+        return_value=PromptOption.NO,
+    ), pytest.raises(DUTCommissioningError):
+        await test_case.setup()
+
+
+@pytest.mark.asyncio
+async def test_legacy_python_test_case_no_new_commissioning() -> None:
+    """Test when user doesn't want to perform new commissioning.
+
+    Flow:
+    1. prompt_for_commissioning_mode returns YES
+    2. prompt_about_commissioning returns NO
+    3. No commissioning should be performed
+    """
+    project = Project(name="test_project")
+    project.config = {
+        "matter_node_id": 1234,
+        "matter_discriminator": 5678,
+        "matter_setup_pin": "12345678",
+        "matter_use_operational_credentials": False,
+        "network": {
+            "wifi": {
+                "ssid": "test_ssid",
+                "password": "test_password",
+            },
+            "thread": {
+                "rcp_serial_path": "/dev/ttyACM0",
+                "rcp_baudrate": 115200,
+                "on_mesh_prefix": "fd11:11:11:11::/64",
+                "network_interface": "wpan0",
+                "dataset": {
+                    "channel": 15,
+                    "panid": "0x1234",
+                    "xpanid": "1111111122222222",
+                    "masterkey": "00112233445566778899aabbccddeeff",
+                },
+                "operational_dataset_hex": "0e080000000000010000000300001235",
+            },
+        },
+        "dut_config": {
+            "discriminator": 5678,
+            "setup_code": "12345678",
+            "pairing_mode": "onnetwork",
+            "chip_timeout": 10000,
+            "chip_use_paa_certs": False,
+            "trace_log": True,
+        },
+    }
+
+    test_run_execution = TestRunExecution()
+    test_run_execution.project = project
+
+    test_suite_execution = TestSuiteExecution()
+    test_suite_execution.test_run_execution = test_run_execution
+
+    test_case_execution = TestCaseExecution()
+    test_case_execution.test_suite_execution = test_suite_execution
+
+    test = python_test_instance(name="test_name", path=Path("path"))
+    test.python_test_type = PythonTestType.MANDATORY
+
+    test_case = LegacyPythonTestCase.class_factory(
+        test=test,
+        python_test_version="version",
+        mandatory=False,
+    )(test_case_execution)
+
+    mock_prompt_response_no = mock.Mock()
+    mock_prompt_response_no.response = PromptOption.NO
+
+    mock_config = mock.Mock()
+    mock_config.__dict__ = project.config
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".prompt_for_commissioning_mode",
+        return_value=PromptOption.YES,
+    ) as mock_prompt_commissioning, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.utils"
+        ".commission_device"
+    ) as mock_commission_device, mock.patch(
+        "test_collections.matter.test_environment_config.TestEnvironmentConfigMatter",
+        return_value=mock_config,
+    ), mock.patch(
+        "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
+        side_effect=[mock_prompt_response_no, mock_prompt_response_no],
+    ), mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case.logger"
+    ) as mock_logger:
+        await test_case.setup()
+
+        mock_prompt_commissioning.assert_called_once()
+        mock_commission_device.assert_not_called()
+        mock_logger.info.assert_any_call("User chose prompt option NO")
+
+
+@pytest.mark.asyncio
+async def test_legacy_python_test_case_new_commissioning() -> None:
+    """Test when user doesn't want to perform new commissioning.
+
+    Flow:
+    1. prompt_for_commissioning_mode returns YES
+    2. prompt_about_commissioning returns NO
+    3. No commissioning should be performed
+    """
+    # Configurando a hierarquia completa de execução
+    project = Project(name="test_project")
+    project.config = {
+        "matter_node_id": 1234,
+        "matter_discriminator": 5678,
+        "matter_setup_pin": "12345678",
+        "matter_use_operational_credentials": False,
+        "network": {
+            "wifi": {
+                "ssid": "test_ssid",
+                "password": "test_password",
+            },
+            "thread": {
+                "rcp_serial_path": "/dev/ttyACM0",
+                "rcp_baudrate": 115200,
+                "on_mesh_prefix": "fd11:11:11:11::/64",
+                "network_interface": "wpan0",
+                "dataset": {
+                    "channel": 15,
+                    "panid": "0x1234",
+                    "xpanid": "1111111122222222",
+                    "masterkey": "00112233445566778899aabbccddeeff",
+                },
+                "operational_dataset_hex": "0e080000000000010000000300001235",
+            },
+        },
+        "dut_config": {
+            "discriminator": 5678,
+            "setup_code": "12345678",
+            "pairing_mode": "onnetwork",
+            "chip_timeout": 10000,
+            "chip_use_paa_certs": False,
+            "trace_log": True,
+        },
+    }
+
+    test_run_execution = TestRunExecution()
+    test_run_execution.project = project
+
+    test_suite_execution = TestSuiteExecution()
+    test_suite_execution.test_run_execution = test_run_execution
+
+    test_case_execution = TestCaseExecution()
+    test_case_execution.test_suite_execution = test_suite_execution
+
+    test = python_test_instance(name="test_name", path=Path("path"))
+    test.python_test_type = PythonTestType.MANDATORY
+
+    test_case = LegacyPythonTestCase.class_factory(
+        test=test,
+        python_test_version="version",
+        mandatory=False,
+    )(test_case_execution)
+
+    # Criando dois mocks de resposta diferentes
+    mock_prompt_response_yes = mock.Mock()
+    mock_prompt_response_yes.response = PromptOption.YES
+
+    mock_prompt_response_no = mock.Mock()
+    mock_prompt_response_no.response = PromptOption.NO
+
+    mock_config = mock.Mock()
+    mock_config.__dict__ = project.config
+
+    # Criando um mock para simular o output do commission_device
+    mock_exec_result = mock.Mock()
+    mock_exec_result.output = (bytes(f"log line {i}", "utf-8") for i in range(3))
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".prompt_for_commissioning_mode",
+        return_value=PromptOption.YES,
+    ) as mock_prompt_commissioning, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".commission_device",
+        return_value=mock_exec_result,
+    ) as mock_commission_device, mock.patch(
+        "test_collections.matter.test_environment_config.TestEnvironmentConfigMatter",
+        return_value=mock_config,
+    ), mock.patch(
+        "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
+        side_effect=[mock_prompt_response_yes, mock_prompt_response_no],
+    ), mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case.logger"
+    ) as mock_logger:
+        await test_case.setup()
+
+        mock_prompt_commissioning.assert_called_once()
+        mock_commission_device.assert_called()

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
@@ -222,7 +222,7 @@ async def test_should_raise_DUTCommissioningError_prompt_commissioning_failed() 
         test=test,
         python_test_version="version",
         mandatory=False,
-    )(test_case_execution)
+    )(test_case_execution) # type: ignore
 
     with mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
@@ -292,7 +292,7 @@ async def test_legacy_python_test_case_no_new_commissioning() -> None:
         test=test,
         python_test_version="version",
         mandatory=False,
-    )(test_case_execution)
+    )(test_case_execution) # type: ignore
 
     mock_prompt_response_no = mock.Mock()
     mock_prompt_response_no.response = PromptOption.NO
@@ -383,7 +383,7 @@ async def test_legacy_python_test_case_new_commissioning() -> None:
         test=test,
         python_test_version="version",
         mandatory=False,
-    )(test_case_execution)
+    )(test_case_execution) # type: ignore
 
     mock_prompt_response_yes = mock.Mock()
     mock_prompt_response_yes.response = PromptOption.YES

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
@@ -218,11 +218,11 @@ async def test_should_raise_DUTCommissioningError_prompt_commissioning_failed() 
     test = python_test_instance(name="test_name", path=Path("path"))
     test.python_test_type = PythonTestType.MANDATORY
 
-    test_case = LegacyPythonTestCase.class_factory(
+    test_case = LegacyPythonTestCase.class_factory(  # type: ignore
         test=test,
         python_test_version="version",
         mandatory=False,
-    )(test_case_execution) # type: ignore
+    )(test_case_execution)
 
     with mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
@@ -288,11 +288,11 @@ async def test_legacy_python_test_case_no_new_commissioning() -> None:
     test = python_test_instance(name="test_name", path=Path("path"))
     test.python_test_type = PythonTestType.MANDATORY
 
-    test_case = LegacyPythonTestCase.class_factory(
+    test_case = LegacyPythonTestCase.class_factory(  # type: ignore
         test=test,
         python_test_version="version",
         mandatory=False,
-    )(test_case_execution) # type: ignore
+    )(test_case_execution)
 
     mock_prompt_response_no = mock.Mock()
     mock_prompt_response_no.response = PromptOption.NO
@@ -379,11 +379,11 @@ async def test_legacy_python_test_case_new_commissioning() -> None:
     test = python_test_instance(name="test_name", path=Path("path"))
     test.python_test_type = PythonTestType.MANDATORY
 
-    test_case = LegacyPythonTestCase.class_factory(
+    test_case = LegacyPythonTestCase.class_factory(  # type: ignore
         test=test,
         python_test_version="version",
         mandatory=False,
-    )(test_case_execution) # type: ignore
+    )(test_case_execution)
 
     mock_prompt_response_yes = mock.Mock()
     mock_prompt_response_yes.response = PromptOption.YES

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
@@ -332,7 +332,6 @@ async def test_legacy_python_test_case_new_commissioning() -> None:
     2. prompt_about_commissioning returns NO
     3. No commissioning should be performed
     """
-    # Configurando a hierarquia completa de execução
     project = Project(name="test_project")
     project.config = {
         "matter_node_id": 1234,
@@ -386,7 +385,6 @@ async def test_legacy_python_test_case_new_commissioning() -> None:
         mandatory=False,
     )(test_case_execution)
 
-    # Criando dois mocks de resposta diferentes
     mock_prompt_response_yes = mock.Mock()
     mock_prompt_response_yes.response = PromptOption.YES
 
@@ -396,7 +394,6 @@ async def test_legacy_python_test_case_new_commissioning() -> None:
     mock_config = mock.Mock()
     mock_config.__dict__ = project.config
 
-    # Criando um mock para simular o output do commission_device
     mock_exec_result = mock.Mock()
     mock_exec_result.output = (bytes(f"log line {i}", "utf-8") for i in range(3))
 

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
@@ -32,10 +32,9 @@ from app.user_prompt_support import UserPromptSupport
 from ...models.matter_test_models import MatterTestStep, MatterTestType
 from ...python_testing.models import PythonTestCase
 from ...python_testing.models.python_test_models import PythonTest, PythonTestType
-from ...python_testing.models.test_case import LegacyPythonTestCase, PromptOption
+from ...python_testing.models.test_case import LegacyPythonTestCase
 from ...python_testing.models.utils import DUTCommissioningError
-
-# from ...utils import PromptOption
+from ...utils import PromptOption
 
 
 def python_test_instance(
@@ -227,7 +226,7 @@ async def test_should_raise_DUTCommissioningError_prompt_commissioning_failed() 
     with mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
         ".prompt_for_commissioning_mode",
-        return_value=PromptOption.NO,
+        return_value=PromptOption.FAIL,
     ), pytest.raises(DUTCommissioningError):
         await test_case.setup()
 
@@ -295,7 +294,7 @@ async def test_legacy_python_test_case_no_new_commissioning() -> None:
     )(test_case_execution)
 
     mock_prompt_response_no = mock.Mock()
-    mock_prompt_response_no.response = PromptOption.NO
+    mock_prompt_response_no.response = PromptOption.FAIL
 
     mock_config = mock.Mock()
     mock_config.__dict__ = project.config
@@ -303,7 +302,7 @@ async def test_legacy_python_test_case_no_new_commissioning() -> None:
     with mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
         ".prompt_for_commissioning_mode",
-        return_value=PromptOption.YES,
+        return_value=PromptOption.PASS,
     ) as mock_prompt_commissioning, mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.utils"
         ".commission_device"
@@ -386,10 +385,10 @@ async def test_legacy_python_test_case_new_commissioning() -> None:
     )(test_case_execution)
 
     mock_prompt_response_yes = mock.Mock()
-    mock_prompt_response_yes.response = PromptOption.YES
+    mock_prompt_response_yes.response = PromptOption.PASS
 
     mock_prompt_response_no = mock.Mock()
-    mock_prompt_response_no.response = PromptOption.NO
+    mock_prompt_response_no.response = PromptOption.FAIL
 
     mock_config = mock.Mock()
     mock_config.__dict__ = project.config
@@ -400,7 +399,7 @@ async def test_legacy_python_test_case_new_commissioning() -> None:
     with mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
         ".prompt_for_commissioning_mode",
-        return_value=PromptOption.YES,
+        return_value=PromptOption.PASS,
     ) as mock_prompt_commissioning, mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
         ".commission_device",

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
@@ -32,6 +32,7 @@ from ...python_testing.models.test_suite import (
     SuiteType,
 )
 from ...sdk_container import SDKContainer
+from ...utils import PromptOption
 
 
 def test_python_suite_class_factory_name() -> None:
@@ -107,7 +108,6 @@ async def test_suite_setup_log_python_version() -> None:
 
     for type in list(SuiteType):
         python_test_version = "best_version"
-        # Create a subclass of PythonTestSuite
         suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
             suite_type=type,
             name="SomeSuite",
@@ -116,6 +116,10 @@ async def test_suite_setup_log_python_version() -> None:
         )
 
         suite_instance = suite_class(TestSuiteExecution())
+
+        # Mock prompt response
+        mock_prompt_response = mock.Mock()
+        mock_prompt_response.response = PromptOption.PASS
 
         with mock.patch.object(
             target=test_engine_logger, attribute="info"
@@ -136,6 +140,9 @@ async def test_suite_setup_log_python_version() -> None:
             ".PythonTestSuite.config",
             new_callable=mock.PropertyMock,
             return_value=default_environment_config.__dict__,
+        ), mock.patch(
+            "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
+            return_value=mock_prompt_response,
         ):
             await suite_instance.setup()
 
@@ -159,6 +166,10 @@ async def test_suite_setup_without_pics() -> None:
 
         suite_instance = suite_class(TestSuiteExecution())
 
+        # Mock prompt response
+        mock_prompt_response = mock.Mock()
+        mock_prompt_response.response = PromptOption.PASS
+
         with mock.patch.object(target=sdk_container, attribute="start"), mock.patch(
             target="test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
             ".PythonTestSuite.pics",
@@ -178,6 +189,9 @@ async def test_suite_setup_without_pics() -> None:
             ".PythonTestSuite.config",
             new_callable=mock.PropertyMock,
             return_value=default_environment_config.__dict__,
+        ), mock.patch(
+            "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
+            return_value=mock_prompt_response,
         ):
             await suite_instance.setup()
 
@@ -188,6 +202,10 @@ async def test_suite_setup_without_pics() -> None:
 @pytest.mark.asyncio
 async def test_suite_setup_with_pics() -> None:
     sdk_container: SDKContainer = SDKContainer()
+
+    # Mock prompt response
+    mock_prompt_response = mock.Mock()
+    mock_prompt_response.response = PromptOption.PASS
 
     for type in list(SuiteType):
         python_test_version = "best_version"
@@ -220,6 +238,9 @@ async def test_suite_setup_with_pics() -> None:
             ".PythonTestSuite.config",
             new_callable=mock.PropertyMock,
             return_value=default_environment_config.__dict__,
+        ), mock.patch(
+            "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
+            return_value=mock_prompt_response,
         ):
             await suite_instance.setup()
 
@@ -242,6 +263,10 @@ async def test_commissioning_suite_setup_with_pics() -> None:
 
     suite_instance = suite_class(TestSuiteExecution())
 
+    # Mock prompt response
+    mock_prompt_response = mock.Mock()
+    mock_prompt_response.response = PromptOption.PASS
+
     with mock.patch.object(target=sdk_container, attribute="start"), mock.patch(
         target="test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
         ".PythonTestSuite.pics",
@@ -257,6 +282,9 @@ async def test_commissioning_suite_setup_with_pics() -> None:
         ".PythonTestSuite.config",
         new_callable=mock.PropertyMock,
         return_value=default_environment_config.__dict__,
+    ), mock.patch(
+        "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
+        return_value=mock_prompt_response,
     ):
         await suite_instance.setup()
 
@@ -279,6 +307,10 @@ async def test_commissioning_suite_setup() -> None:
 
     suite_instance = suite_class(TestSuiteExecution())
 
+    # Mock prompt response
+    mock_prompt_response = mock.Mock()
+    mock_prompt_response.response = PromptOption.PASS
+
     with mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
         ".PythonTestSuite.setup"
@@ -293,6 +325,181 @@ async def test_commissioning_suite_setup() -> None:
         ".PythonTestSuite.config",
         new_callable=mock.PropertyMock,
         return_value=default_environment_config.__dict__,
+    ), mock.patch(
+        "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
+        return_value=mock_prompt_response,
     ):
         await suite_instance.setup()
         python_suite_setup.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_commissioning_suite_setup_fail() -> None:
+    """Test that when prompt_for_commissioning_mode returns FAIL, the setup process
+    should raise DUTCommissioningError.
+    """
+    from test_collections.matter.sdk_tests.support.python_testing.models.utils import (
+        DUTCommissioningError,
+    )
+
+    suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
+        suite_type=SuiteType.COMMISSIONING,
+        name="SomeSuite",
+        python_test_version="Some version",
+        mandatory=False,
+    )
+
+    suite_instance = suite_class(TestSuiteExecution())
+
+    # Mock prompt response
+    mock_prompt_response = mock.Mock()
+    mock_prompt_response.response = PromptOption.FAIL
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".PythonTestSuite.setup"
+    ) as python_suite_setup, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".prompt_for_commissioning_mode",
+        return_value=PromptOption.FAIL,
+    ) as mock_prompt_commissioning, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".commission_device"
+    ) as mock_commission_device, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".PythonTestSuite.config",
+        new_callable=mock.PropertyMock,
+        return_value=default_environment_config.__dict__,
+    ), mock.patch(
+        "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
+        return_value=mock_prompt_response,
+    ):
+        # Verifica se a exceção correta é lançada
+        with pytest.raises(DUTCommissioningError) as exc_info:
+            await suite_instance.setup()
+
+        # Verifica a mensagem de erro
+        assert (
+            str(exc_info.value)
+            == "User chose prompt option FAILED for DUT is in Commissioning Mode"
+        )
+
+        # Verifica se prompt_for_commissioning_mode foi chamado
+        mock_prompt_commissioning.assert_called_once()
+
+        # Verifica se commission_device NÃO foi chamado
+        mock_commission_device.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_should_perform_new_commissioning_yes() -> None:
+    """Test that when should_perform_new_commissioning returns True,
+    the setup process performs a new commissioning.
+    """
+    suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
+        suite_type=SuiteType.COMMISSIONING,
+        name="SomeSuite",
+        python_test_version="Some version",
+        mandatory=False,
+    )
+
+    suite_instance = suite_class(TestSuiteExecution())
+
+    # Mock prompt response para "NO" (queremos fazer um novo comissionamento)
+    mock_prompt_response = mock.Mock()
+    mock_prompt_response.response = PromptOption.FAIL  # NO = FAIL neste contexto
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".PythonTestSuite.setup"
+    ) as python_suite_setup, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".prompt_for_commissioning_mode",
+        return_value=PromptOption.PASS,
+    ) as mock_prompt_commissioning, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".commission_device"
+    ) as mock_commission_device, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".PythonTestSuite.config",
+        new_callable=mock.PropertyMock,
+        return_value=default_environment_config.__dict__,
+    ), mock.patch(
+        "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
+        return_value=mock_prompt_response,
+    ), mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".should_perform_new_commissioning",
+        return_value=True,
+    ) as mock_should_perform_new_commissioning:
+        await suite_instance.setup()
+
+        # Verifica se should_perform_new_commissioning foi chamado
+        mock_should_perform_new_commissioning.assert_called_once()
+
+        # Verifica se o setup base foi chamado
+        python_suite_setup.assert_called_once()
+
+        # Verifica se o prompt de comissionamento foi chamado e retornou PASS
+        mock_prompt_commissioning.assert_called_once()
+        assert mock_prompt_commissioning.return_value == PromptOption.PASS
+
+        # Verifica se commission_device foi chamado
+        mock_commission_device.assert_called_once()
+        assert mock_commission_device.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_should_perform_new_commissioning_no() -> None:
+    """Test that when should_perform_new_commissioning returns False,
+    the setup process skips the new commissioning.
+    """
+    suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
+        suite_type=SuiteType.COMMISSIONING,
+        name="SomeSuite",
+        python_test_version="Some version",
+        mandatory=False,
+    )
+
+    suite_instance = suite_class(TestSuiteExecution())
+
+    # Mock prompt response para "YES" (queremos reutilizar o comissionamento)
+    mock_prompt_response = mock.Mock()
+    mock_prompt_response.response = PromptOption.PASS  # YES = PASS neste contexto
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".PythonTestSuite.setup"
+    ) as python_suite_setup, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".prompt_for_commissioning_mode",
+        return_value=PromptOption.PASS,
+    ) as mock_prompt_commissioning, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".commission_device"
+    ) as mock_commission_device, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".PythonTestSuite.config",
+        new_callable=mock.PropertyMock,
+        return_value=default_environment_config.__dict__,
+    ), mock.patch(
+        "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
+        return_value=mock_prompt_response,
+    ), mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".should_perform_new_commissioning",
+        return_value=False,
+    ) as mock_should_perform_new_commissioning:
+        await suite_instance.setup()
+
+        # Verifica se should_perform_new_commissioning foi chamado
+        mock_should_perform_new_commissioning.assert_called_once()
+
+        # Verifica se o setup base foi chamado
+        python_suite_setup.assert_called_once()
+
+        # Verifica se o prompt de comissionamento foi chamado
+        mock_prompt_commissioning.assert_called_once()
+
+        # Verifica que commission_device NÃO foi chamado
+        mock_commission_device.assert_not_called()

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
@@ -374,20 +374,15 @@ async def test_commissioning_suite_setup_fail() -> None:
         "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
         return_value=mock_prompt_response,
     ):
-        # Verifica se a exceção correta é lançada
         with pytest.raises(DUTCommissioningError) as exc_info:
             await suite_instance.setup()
 
-        # Verifica a mensagem de erro
         assert (
             str(exc_info.value)
             == "User chose prompt option FAILED for DUT is in Commissioning Mode"
         )
 
-        # Verifica se prompt_for_commissioning_mode foi chamado
         mock_prompt_commissioning.assert_called_once()
-
-        # Verifica se commission_device NÃO foi chamado
         mock_commission_device.assert_not_called()
 
 
@@ -405,9 +400,9 @@ async def test_should_perform_new_commissioning_yes() -> None:
 
     suite_instance = suite_class(TestSuiteExecution())
 
-    # Mock prompt response para "NO" (queremos fazer um novo comissionamento)
+    # Mock prompt response para "NO" - No commissioning
     mock_prompt_response = mock.Mock()
-    mock_prompt_response.response = PromptOption.FAIL  # NO = FAIL neste contexto
+    mock_prompt_response.response = PromptOption.FAIL
 
     with mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
@@ -434,17 +429,13 @@ async def test_should_perform_new_commissioning_yes() -> None:
     ) as mock_should_perform_new_commissioning:
         await suite_instance.setup()
 
-        # Verifica se should_perform_new_commissioning foi chamado
         mock_should_perform_new_commissioning.assert_called_once()
 
-        # Verifica se o setup base foi chamado
         python_suite_setup.assert_called_once()
 
-        # Verifica se o prompt de comissionamento foi chamado e retornou PASS
         mock_prompt_commissioning.assert_called_once()
         assert mock_prompt_commissioning.return_value == PromptOption.PASS
 
-        # Verifica se commission_device foi chamado
         mock_commission_device.assert_called_once()
         assert mock_commission_device.call_count == 1
 
@@ -463,9 +454,9 @@ async def test_should_perform_new_commissioning_no() -> None:
 
     suite_instance = suite_class(TestSuiteExecution())
 
-    # Mock prompt response para "YES" (queremos reutilizar o comissionamento)
+    # Mock prompt response para "YES" - Perform the commissioning
     mock_prompt_response = mock.Mock()
-    mock_prompt_response.response = PromptOption.PASS  # YES = PASS neste contexto
+    mock_prompt_response.response = PromptOption.PASS
 
     with mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
@@ -492,14 +483,9 @@ async def test_should_perform_new_commissioning_no() -> None:
     ) as mock_should_perform_new_commissioning:
         await suite_instance.setup()
 
-        # Verifica se should_perform_new_commissioning foi chamado
         mock_should_perform_new_commissioning.assert_called_once()
 
-        # Verifica se o setup base foi chamado
         python_suite_setup.assert_called_once()
 
-        # Verifica se o prompt de comissionamento foi chamado
         mock_prompt_commissioning.assert_called_once()
-
-        # Verifica que commission_device NÃO foi chamado
         mock_commission_device.assert_not_called()

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
@@ -25,6 +25,9 @@ from app.models.test_suite_execution import TestSuiteExecution
 from app.schemas import PICS
 from app.test_engine.logger import test_engine_logger
 from app.tests.utils.test_pics_data import create_random_pics
+from test_collections.matter.sdk_tests.support.python_testing.models.utils import (
+    DUTCommissioningError,
+)
 
 from ...python_testing.models.test_suite import (
     CommissioningPythonTestSuite,
@@ -338,9 +341,6 @@ async def test_commissioning_suite_setup_fail() -> None:
     """Test that when prompt_for_commissioning_mode returns FAIL, the setup process
     should raise DUTCommissioningError.
     """
-    from test_collections.matter.sdk_tests.support.python_testing.models.utils import (
-        DUTCommissioningError,
-    )
 
     suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
         suite_type=SuiteType.COMMISSIONING,
@@ -400,10 +400,6 @@ async def test_should_perform_new_commissioning_yes() -> None:
 
     suite_instance = suite_class(TestSuiteExecution())
 
-    # Mock prompt response para "NO" - No commissioning
-    mock_prompt_response = mock.Mock()
-    mock_prompt_response.response = PromptOption.FAIL
-
     with mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
         ".PythonTestSuite.setup"
@@ -420,9 +416,6 @@ async def test_should_perform_new_commissioning_yes() -> None:
         new_callable=mock.PropertyMock,
         return_value=default_environment_config.__dict__,
     ), mock.patch(
-        "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
-        return_value=mock_prompt_response,
-    ), mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
         ".should_perform_new_commissioning",
         return_value=True,
@@ -430,14 +423,9 @@ async def test_should_perform_new_commissioning_yes() -> None:
         await suite_instance.setup()
 
         mock_should_perform_new_commissioning.assert_called_once()
-
         python_suite_setup.assert_called_once()
-
         mock_prompt_commissioning.assert_called_once()
-        assert mock_prompt_commissioning.return_value == PromptOption.PASS
-
         mock_commission_device.assert_called_once()
-        assert mock_commission_device.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -454,10 +442,6 @@ async def test_should_perform_new_commissioning_no() -> None:
 
     suite_instance = suite_class(TestSuiteExecution())
 
-    # Mock prompt response para "YES" - Perform the commissioning
-    mock_prompt_response = mock.Mock()
-    mock_prompt_response.response = PromptOption.PASS
-
     with mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
         ".PythonTestSuite.setup"
@@ -473,9 +457,6 @@ async def test_should_perform_new_commissioning_no() -> None:
         ".PythonTestSuite.config",
         new_callable=mock.PropertyMock,
         return_value=default_environment_config.__dict__,
-    ), mock.patch(
-        "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
-        return_value=mock_prompt_response,
     ), mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
         ".should_perform_new_commissioning",

--- a/test_collections/matter/sdk_tests/support/utils.py
+++ b/test_collections/matter/sdk_tests/support/utils.py
@@ -106,8 +106,8 @@ async def prompt_re_use_commissioning(
     prompt_response = await __prompt_pass_fail_options(
         prompt_support=prompt_support,
         logger=logger,
-        prompt="Do you want to re-use previous commissioning information?\n"
-        "If you select NO, a new commissioning will performed",
+        prompt="Do you want to re-use the previous commissioning information?\n"
+        "If you select NO, a new commissioning will be performed",
         options=options,
         on_success=None,
         on_failure=None,

--- a/test_collections/matter/sdk_tests/support/utils.py
+++ b/test_collections/matter/sdk_tests/support/utils.py
@@ -26,7 +26,8 @@ from app.user_prompt_support.prompt_request import OptionsSelectPromptRequest
 from app.user_prompt_support.user_prompt_support import UserPromptSupport
 
 ADMIN_STORAGE_FILE_DEFAULT_NAME = "admin_storage.json"
-ADMIN_STORAGE_FILE_HOST_PATH = Path("/app/backend")
+# Retrieve the root folder
+ADMIN_STORAGE_FILE_HOST_PATH = Path(__file__).parents[3].parent
 ADMIN_STORAGE_FILE_HOST = ADMIN_STORAGE_FILE_HOST_PATH.joinpath(
     ADMIN_STORAGE_FILE_DEFAULT_NAME
 )
@@ -94,7 +95,7 @@ async def prompt_for_commissioning_mode(
     return prompt_response
 
 
-async def prompt_re_use_commissioning(
+async def prompt_reuse_commissioning(
     prompt_support: UserPromptSupport,
     logger: loguru.Logger,
 ) -> PromptOption:
@@ -106,7 +107,7 @@ async def prompt_re_use_commissioning(
     prompt_response = await __prompt_pass_fail_options(
         prompt_support=prompt_support,
         logger=logger,
-        prompt="Do you want to re-use the previous commissioning information?\n"
+        prompt="Do you want to reuse the previous commissioning information?\n"
         "If you select NO, a new commissioning will be performed",
         options=options,
         on_success=None,

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -86,7 +86,13 @@ class ChipSuite(TestSuite, UserPromptSupport):
         self.__dut_commissioned_successfully = False
         if self.server_type == ChipServerType.CHIP_TOOL:
             logger.info("Commission DUT")
-            await prompt_for_commissioning_mode(self, logger, None, self.cancel)
+            user_response = await prompt_for_commissioning_mode(
+                self, logger, None, self.cancel
+            )
+            if user_response == PromptOption.FAIL:
+                raise DUTCommissioningError(
+                    "User chose prompt option FAILED for DUT is in Commissioning Mode"
+                )
             await self.__commission_dut_allowing_retries()
         elif self.server_type == ChipServerType.CHIP_APP:
             logger.info("Verify Test suite prerequisites")


### PR DESCRIPTION
### What changed
The goal of this PR is to store the commissioning information so the user will no have to factory reset their devices. The users will be prompted if they want to user the existing commissioning information. This affect the Python test cases.

### Related Issue
https://github.com/project-chip/certification-tool/issues/456

### Testing
- Unit Tests Added and all passing

<img width="280" alt="Screenshot 2025-01-02 at 11 40 54" src="https://github.com/user-attachments/assets/4d259156-a30a-4410-8905-5d1c7ea269f2" />


- New prompt will be displayed when a previous commission was performed 
<img width="558" alt="Screenshot 2024-12-27 at 12 54 30" src="https://github.com/user-attachments/assets/251d4538-bba5-4af2-a4a2-508592d7a02a" />


