### PR TITLE
Implement rename test run execution name

### DIFF
--- a/app/crud/crud_test_run_execution.py
+++ b/app/crud/crud_test_run_execution.py
@@ -23,7 +23,7 @@ from sqlalchemy.orm import Session
 from app.crud import operator as crud_operator
 from app.crud import project as crud_project
 from app.crud import test_run_config as crud_test_run_config
-from app.crud.base import CRUDBaseCreate, CRUDBaseDelete, CRUDBaseRead
+from app.crud.base import CRUDBaseCreate, CRUDBaseDelete, CRUDBaseRead, CRUDBaseUpdate
 from app.models import Project, TestCaseExecution, TestRunExecution, TestSuiteExecution
 from app.schemas import (
     TestRunConfigCreate,
@@ -35,6 +35,7 @@ from app.schemas.test_run_config import TestRunConfigInDB
 from app.schemas.test_run_execution import (
     TestRunExecutionCreate,
     TestRunExecutionStats,
+    TestRunExecutionUpdate,
     TestRunExecutionWithStats,
 )
 from app.schemas.test_selection import TestSelection
@@ -51,6 +52,7 @@ class CRUDTestRunExecution(
     CRUDBaseRead[TestRunExecution],
     CRUDBaseDelete[TestRunExecution],
     CRUDBaseCreate[TestRunExecution, TestRunExecutionCreate],
+    CRUDBaseUpdate[TestRunExecution, TestRunExecutionUpdate],
 ):
     def get_multi(
         self,

--- a/app/schemas/test_run_execution.py
+++ b/app/schemas/test_run_execution.py
@@ -82,6 +82,13 @@ class TestRunExecutionWithChildren(TestRunExecution):
     test_suite_executions: Optional[List[TestSuiteExecution]]
 
 
+class TestRunExecutionUpdate(TestRunExecutionBase):
+    pass
+
+    class Config:
+        orm_mode = True
+
+
 # Additional Properties properties stored in DB
 class TestRunExecutionInDB(TestRunExecutionInDBBase):
     operator_id: Optional[int]

--- a/app/tests/crud/test_test_run_execution.py
+++ b/app/tests/crud/test_test_run_execution.py
@@ -31,6 +31,7 @@ from app.models.test_enums import TestStateEnum
 from app.schemas.test_run_config import TestRunConfigCreate
 from app.schemas.test_run_execution import (
     TestRunExecutionCreate,
+    TestRunExecutionUpdate,
     TestRunExecutionWithStats,
 )
 from app.tests.utils.operator import operator_base_dict
@@ -76,6 +77,20 @@ def test_get_test_run_execution(db: Session) -> None:
     assert test_run_execution.id == stored_test_run_execution.id
     assert test_run_execution.title == stored_test_run_execution.title
     assert test_run_execution.description == stored_test_run_execution.description
+
+
+def test_update_test_run_execution(db: Session) -> None:
+    run = create_random_test_run_execution(db=db)
+
+    renamed_title = "New Title"
+
+    test_run_execution_update = TestRunExecutionUpdate(title=renamed_title)
+
+    test_run_updated = crud.test_run_execution.update(
+        db=db, db_obj=run, obj_in=test_run_execution_update
+    )
+
+    assert test_run_updated.title == renamed_title
 
 
 def test_test_run_archive(db: Session) -> None:


### PR DESCRIPTION
### What changed
Implement the backend endpoint to rename a test run execution
**PUT** `api/v1/test_run_executions/{execution-id}/rename?new_execution_name={new-execution-name}`

**Important**: TODO frontend implementation

### Related Issue
https://github.com/project-chip/certification-tool/issues/460

### Testing
<img width="898" alt="Screenshot 2025-01-10 at 11 02 51" src="https://github.com/user-attachments/assets/f2d0e621-33c4-4014-a179-963c2d90b4f8" />
