### PR TITLE
Fix the checking for storage-path

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -132,6 +132,7 @@ def __retrieve_storage_path(config: TestEnvironmentConfigMatter) -> Path:
 
     if (
         config.test_parameters
+        and TEST_PARAMETER_STORAGE_PATH_KEY in config.test_parameters
         and config.test_parameters[TEST_PARAMETER_STORAGE_PATH_KEY]
     ):
         storage_path = Path(config.test_parameters[TEST_PARAMETER_STORAGE_PATH_KEY])


### PR DESCRIPTION
### What Changed
The goal of this PR is to check for storage-path when other arguments was set but storage-path.