### PR TITLE
[FIX] Starting Backend Without Internet Access

### DIFF
--- a/test_collections/matter/sdk_tests/scripts/fetch_sdk_tests_and_runner.sh
+++ b/test_collections/matter/sdk_tests/scripts/fetch_sdk_tests_and_runner.sh
@@ -49,7 +49,7 @@ PYTHON_TESTING_SCRIPTS_TEST_COLLECTION_PATH="$PYTHON_TESTING_TEST_COLLECTION_PAT
 CURRENT_SDK_CHECKOUT_VERSION="$TEST_COLLECTIONS_SDK_CHECKOUT_PATH/.version"
 
 install_matter_wheels () {
-  pip install ${TEST_COLLECTIONS_SDK_CHECKOUT_PATH}/sdk_runner/*.whl --force-reinstall
+  pip install ${TEST_COLLECTIONS_SDK_CHECKOUT_PATH}/sdk_runner/*.whl --force-reinstall $@
 }
 
 for arg in "$@"
@@ -87,7 +87,7 @@ else
     else
         echo "Current version of test yaml are up to date with SDK: $SDK_SHA"
         # Need to install wheels after docker restart.
-        install_matter_wheels
+        install_matter_wheels --no-deps
         exit 0
     fi
 fi


### PR DESCRIPTION
Starting the backend service of TH without access to the internet results in failure due to the `prestart.sh `script ran on the initialization. That happens because the pip command try to install the necessary wheels files from the project but try to search any dependency required online.

This solution changes the pip command to install without the dependencies if the current version of test yaml and SDK are up to date.