### PR TITLE
Refatoring prompts for recommissioning

### DIFF
--- a/.version_information
+++ b/.version_information
@@ -1,1 +1,1 @@
-spring2025
+v2.12-beta1+spring2025

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -380,6 +380,7 @@ class LegacyPythonTestCase(PythonTestCase):
                 if await should_perform_new_commissioning(
                     self, config=config, logger=logger
                 ):
+                    logger.info("User chose prompt option YES")
                     user_response = await prompt_for_commissioning_mode(
                         self, logger, None, self.cancel
                     )
@@ -388,8 +389,6 @@ class LegacyPythonTestCase(PythonTestCase):
                             "User chose prompt option FAILED for DUT is in "
                             "Commissioning Mode"
                         )
-
-                    logger.info("User chose prompt option YES")
 
                     logger.info("Commission DUT")
                     await commission_device(config, logger)

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -15,7 +15,6 @@
 #
 import re
 from asyncio import sleep
-from enum import IntEnum
 from inspect import iscoroutinefunction
 from multiprocessing.managers import BaseManager
 from pathlib import Path
@@ -42,14 +41,15 @@ from .python_testing_hooks_proxy import (
     SDKPythonTestResultBase,
     SDKPythonTestRunnerHooks,
 )
-from .utils import EXECUTABLE, RUNNER_CLASS_PATH, DUTCommissioningError
-from .utils import PromptOption
 from .utils import (
+    EXECUTABLE,
+    RUNNER_CLASS_PATH,
+    DUTCommissioningError,
+    PromptOption,
     commission_device,
     generate_command_arguments,
     should_perform_new_commissioning,
 )
-
 
 # Custom type variable used to annotate the factory method in PythonTestCase.
 T = TypeVar("T", bound="PythonTestCase")
@@ -385,7 +385,8 @@ class LegacyPythonTestCase(PythonTestCase):
                     )
                     if user_response == PromptOption.FAIL:
                         raise DUTCommissioningError(
-                            "User chose prompt option FAILED for DUT is in Commissioning Mode"
+                            "User chose prompt option FAILED for DUT is in "
+                            "Commissioning Mode"
                         )
 
                     logger.info("User chose prompt option YES")
@@ -400,7 +401,8 @@ class LegacyPythonTestCase(PythonTestCase):
                 )
                 if user_response == PromptOption.FAIL:
                     raise DUTCommissioningError(
-                        "User chose prompt option FAILED for DUT is in Commissioning Mode"
+                        "User chose prompt option FAILED for DUT is in "
+                        "Commissioning Mode"
                     )
 
             case _:

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -126,15 +126,6 @@ class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
     async def setup(self) -> None:
         await super().setup()
 
-        user_response = await prompt_for_commissioning_mode(
-            self, logger, None, self.cancel
-        )
-
-        if user_response == PromptOption.FAIL:
-            raise DUTCommissioningError(
-                "User chose prompt option FAILED for DUT is in Commissioning Mode"
-            )
-
         matter_config = TestEnvironmentConfigMatter(**self.config)
 
         # If in BLE-Thread mode and a Thread Auto-Config was provided by the user,
@@ -153,5 +144,14 @@ class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
         if await should_perform_new_commissioning(
             self, config=matter_config, logger=logger
         ):
+            user_response = await prompt_for_commissioning_mode(
+                self, logger, None, self.cancel
+            )
+
+            if user_response == PromptOption.FAIL:
+                raise DUTCommissioningError(
+                    "User chose prompt option FAILED for DUT is in Commissioning Mode"
+                )
+
             logger.info("Commission DUT")
             await commission_device(matter_config, logger=logger)

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -144,6 +144,7 @@ class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
         if await should_perform_new_commissioning(
             self, config=matter_config, logger=logger
         ):
+            logger.info("User chose prompt option YES")
             user_response = await prompt_for_commissioning_mode(
                 self, logger, None, self.cancel
             )

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
@@ -442,6 +442,10 @@ async def test_should_perform_new_commissioning_no() -> None:
 
     suite_instance = suite_class(TestSuiteExecution())
 
+    # Mock prompt response
+    mock_prompt_response = mock.Mock()
+    mock_prompt_response.response = PromptOption.PASS
+
     with mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
         ".PythonTestSuite.setup"
@@ -461,12 +465,13 @@ async def test_should_perform_new_commissioning_no() -> None:
         "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
         ".should_perform_new_commissioning",
         return_value=False,
-    ) as mock_should_perform_new_commissioning:
+    ) as mock_should_perform_new_commissioning, mock.patch(
+        "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
+        return_value=mock_prompt_response,
+    ):
         await suite_instance.setup()
 
         mock_should_perform_new_commissioning.assert_called_once()
-
         python_suite_setup.assert_called_once()
-
-        mock_prompt_commissioning.assert_called_once()
+        mock_prompt_commissioning.assert_not_called()
         mock_commission_device.assert_not_called()


### PR DESCRIPTION
### What Changed
The Goal of this PR if to refactor the prompt displays or recommissioning feature.

### Testing
Unit Tests Running 100%
<img width="368" alt="Screenshot 2025-01-27 at 11 33 48" src="https://github.com/user-attachments/assets/d2cadc02-d1d6-47dc-8fbb-90a39a30dc72" />

Development Testing
`Recommissioning` dialog is now being displayed before `DUT In commissioning Mode` Prompt.
The changes affect both `Python Testing Suite` and  `Python Testing Suite - Old script format` suites
<img width="470" alt="Screenshot 2025-01-27 at 11 37 06" src="https://github.com/user-attachments/assets/d8442453-5507-4158-96ec-dddac76f29a9" />

<img width="373" alt="Screenshot 2025-01-27 at 11 37 16" src="https://github.com/user-attachments/assets/9d18d23b-40b9-406f-ba18-2d0d4b73db6d" />

