### PR TITLE
Remove commissioning information when running YAML scripts

### DIFF
--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_suite.py
@@ -20,6 +20,7 @@ from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestSuite
 
 from ...chip.chip_server import ChipServerType
+from ...utils import ADMIN_STORAGE_FILE_HOST
 from ...yaml_tests.models.chip_suite import ChipSuite
 
 
@@ -50,6 +51,12 @@ class YamlTestSuite(TestSuite):
     async def setup(self) -> None:
         """Override Setup to log YAML version."""
         logger.info(f"YAML Version: {self.yaml_version}")
+
+        # If admin_storage.json file exists, it should be removed since the
+        # commissioning information will be overwritten and this information will be no
+        # longer valid
+        if ADMIN_STORAGE_FILE_HOST.exists():
+            ADMIN_STORAGE_FILE_HOST.unlink()
 
     @classmethod
     def class_factory(


### PR DESCRIPTION
### What changed
The goal of this PR is to remove commissioning information when running YAML scripts, since the pior commissioning information stored in TH is no longer valid when running YAML tests.

### Testing

- Unit Tests running successfully

- Developer test:
  Perform the following steps:

1.  Start a python test execution.
  2. Start a YAML test execution.
  3. Start a python test execution.
  
  **Expected result**: The prompt asking to reuse commissioning information is not presented since the file was removed at step 2 (Start a YAML test execution)

