### PR TITLE
[Fix] Recommissioning Refactoring to V1.5

### DIFF
--- a/.version_information
+++ b/.version_information
@@ -1,1 +1,1 @@
-spring2025
+v2.12-beta1+spring2025

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -15,7 +15,6 @@
 #
 import re
 from asyncio import sleep
-from enum import IntEnum
 from inspect import iscoroutinefunction
 from multiprocessing.managers import BaseManager
 from pathlib import Path
@@ -42,19 +41,15 @@ from .python_testing_hooks_proxy import (
     SDKPythonTestResultBase,
     SDKPythonTestRunnerHooks,
 )
-from .utils import EXECUTABLE, RUNNER_CLASS_PATH, DUTCommissioningError
-from .utils import PromptOption as PromptOptionUtils
 from .utils import (
+    EXECUTABLE,
+    RUNNER_CLASS_PATH,
+    DUTCommissioningError,
+    PromptOption,
     commission_device,
     generate_command_arguments,
     should_perform_new_commissioning,
 )
-
-
-class PromptOption(IntEnum):
-    YES = 1
-    NO = 2
-
 
 # Custom type variable used to annotate the factory method in PythonTestCase.
 T = TypeVar("T", bound="PythonTestCase")
@@ -347,7 +342,7 @@ class NoCommissioningPythonTestCase(PythonTestCase):
         user_response = await prompt_for_commissioning_mode(
             self, logger, None, self.cancel
         )
-        if user_response == PromptOptionUtils.FAIL:
+        if user_response == PromptOption.FAIL:
             raise DUTCommissioningError(
                 "User chose prompt option FAILED for DUT is in Commissioning Mode"
             )
@@ -356,14 +351,6 @@ class NoCommissioningPythonTestCase(PythonTestCase):
 class LegacyPythonTestCase(PythonTestCase):
     async def setup(self) -> None:
         await super().setup()
-
-        user_response = await prompt_for_commissioning_mode(
-            self, logger, None, self.cancel
-        )
-        if user_response == PromptOptionUtils.FAIL:
-            raise DUTCommissioningError(
-                "User chose prompt option FAILED for DUT is in Commissioning Mode"
-            )
 
         await self.prompt_about_commissioning()
 
@@ -376,29 +363,46 @@ class LegacyPythonTestCase(PythonTestCase):
 
         prompt = "Should the DUT be commissioned to run this test case?"
         options = {
-            "YES": PromptOption.YES,
-            "NO": PromptOption.NO,
+            "YES": PromptOption.PASS,
+            "NO": PromptOption.FAIL,
         }
         prompt_request = OptionsSelectPromptRequest(prompt=prompt, options=options)
         logger.info(f'User prompt: "{prompt}"')
         prompt_response = await self.send_prompt_request(prompt_request)
 
         match prompt_response.response:
-            case PromptOption.YES:
-                logger.info("User chose prompt option YES")
+            case PromptOption.PASS:
+                config = TestEnvironmentConfigMatter(**self.config)
 
                 # If a local copy of admin_storage.json file exists, prompt user if the
                 # execution should retrieve the previous commissioning information or
                 # if it should perform a new commissioning
-                config = TestEnvironmentConfigMatter(**self.config)
                 if await should_perform_new_commissioning(
                     self, config=config, logger=logger
                 ):
+                    logger.info("User chose prompt option YES")
+                    user_response = await prompt_for_commissioning_mode(
+                        self, logger, None, self.cancel
+                    )
+                    if user_response == PromptOption.FAIL:
+                        raise DUTCommissioningError(
+                            "User chose prompt option FAILED for DUT is in "
+                            "Commissioning Mode"
+                        )
+
                     logger.info("Commission DUT")
                     await commission_device(config, logger)
 
-            case PromptOption.NO:
+            case PromptOption.FAIL:
                 logger.info("User chose prompt option NO")
+                user_response = await prompt_for_commissioning_mode(
+                    self, logger, None, self.cancel
+                )
+                if user_response == PromptOption.FAIL:
+                    raise DUTCommissioningError(
+                        "User chose prompt option FAILED for DUT is in "
+                        "Commissioning Mode"
+                    )
 
             case _:
                 raise ValueError(

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -126,15 +126,6 @@ class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
     async def setup(self) -> None:
         await super().setup()
 
-        user_response = await prompt_for_commissioning_mode(
-            self, logger, None, self.cancel
-        )
-
-        if user_response == PromptOption.FAIL:
-            raise DUTCommissioningError(
-                "User chose prompt option FAILED for DUT is in Commissioning Mode"
-            )
-
         matter_config = TestEnvironmentConfigMatter(**self.config)
 
         # If in BLE-Thread or NFC-Thread mode and a Thread Auto-Config was provided by
@@ -153,5 +144,15 @@ class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
         if await should_perform_new_commissioning(
             self, config=matter_config, logger=logger
         ):
+            logger.info("User chose prompt option YES")
+            user_response = await prompt_for_commissioning_mode(
+                self, logger, None, self.cancel
+            )
+
+            if user_response == PromptOption.FAIL:
+                raise DUTCommissioningError(
+                    "User chose prompt option FAILED for DUT is in Commissioning Mode"
+                )
+
             logger.info("Commission DUT")
             await commission_device(matter_config, logger=logger)

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
@@ -442,6 +442,10 @@ async def test_should_perform_new_commissioning_no() -> None:
 
     suite_instance = suite_class(TestSuiteExecution())
 
+    # Mock prompt response
+    mock_prompt_response = mock.Mock()
+    mock_prompt_response.response = PromptOption.PASS
+
     with mock.patch(
         "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
         ".PythonTestSuite.setup"
@@ -461,12 +465,13 @@ async def test_should_perform_new_commissioning_no() -> None:
         "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
         ".should_perform_new_commissioning",
         return_value=False,
-    ) as mock_should_perform_new_commissioning:
+    ) as mock_should_perform_new_commissioning, mock.patch(
+        "app.user_prompt_support.user_prompt_support.UserPromptSupport.send_prompt_request",
+        return_value=mock_prompt_response,
+    ):
         await suite_instance.setup()
 
         mock_should_perform_new_commissioning.assert_called_once()
-
         python_suite_setup.assert_called_once()
-
-        mock_prompt_commissioning.assert_called_once()
+        mock_prompt_commissioning.assert_not_called()
         mock_commission_device.assert_not_called()

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_suite.py
@@ -20,6 +20,7 @@ from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestSuite
 
 from ...chip.chip_server import ChipServerType
+from ...utils import ADMIN_STORAGE_FILE_HOST
 from ...yaml_tests.models.chip_suite import ChipSuite
 
 
@@ -50,6 +51,12 @@ class YamlTestSuite(TestSuite):
     async def setup(self) -> None:
         """Override Setup to log YAML version."""
         logger.info(f"YAML Version: {self.yaml_version}")
+
+        # If admin_storage.json file exists, it should be removed since the
+        # commissioning information will be overwritten and this information will be no
+        # longer valid
+        if ADMIN_STORAGE_FILE_HOST.exists():
+            ADMIN_STORAGE_FILE_HOST.unlink()
 
     @classmethod
     def class_factory(


### PR DESCRIPTION
Cherry picking two fixes related to the feature of "reusing the existing commissioning" that were included in the release `v.14.1` of TH.

Commits: https://github.com/project-chip/certification-tool-backend/pull/187 and https://github.com/project-chip/certification-tool-backend/pull/189.