### PR TITLE
Add apps folder when copying apps from container to host

### DIFF
--- a/.version_information
+++ b/.version_information
@@ -1,1 +1,1 @@
-v2.12-beta1+spring2025
+v2.12-beta2+spring2025

--- a/test_collections/matter/scripts/update-sample-apps.sh
+++ b/test_collections/matter/scripts/update-sample-apps.sh
@@ -45,7 +45,7 @@ fi
 print_script_step "Updating Sample APPs"
 # TODO - Uncomment line bellow and remove the subsequent line when the SDK IMAGE contains the apps folder
 # sudo docker run -t -v ~/apps:/apps $SDK_DOCKER_IMAGE bash -c "rm -v /apps/*; cp -v apps/* /apps/"
-sudo docker run -t -v ~/apps:/apps $SDK_DOCKER_IMAGE bash -c "rm -v /apps/*; cp -v chip-* /apps/; cp -v thermostat-app /apps/; cp -v lit-icd-app /apps/;cp -v fabric-* /apps/; cp -v matter-network-manager-app /apps/"
+sudo docker run -t -v ~/apps:/apps $SDK_DOCKER_IMAGE bash -c "rm -v /apps/*; cp -v apps/* /apps/; cp -v chip-* /apps/; cp -v thermostat-app /apps/; cp -v lit-icd-app /apps/;cp -v fabric-* /apps/; cp -v matter-network-manager-app /apps/"
 echo "Setting Sample APPs ownership"
 sudo chown -R `whoami` ~/apps
 


### PR DESCRIPTION
### What changed
The goal of this PR is to workaround the copy of the app from container to host to also consider apps folder.

### Related Issue
https://github.com/project-chip/certification-tool/issues/526