### PR TITLE
[FIX] Removing Performance Collection From PICS Validation

### DIFF
--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -23,6 +23,9 @@ from app.test_engine.models.test_declarations import (
     TestCollectionDeclaration,
 )
 from app.test_engine.test_script_manager import test_script_manager
+from test_collections.matter.sdk_tests.support.performance_tests.sdk_performance_tests import (  # noqa
+    STRESS_TEST_COLLECTION,
+)
 
 
 def applicable_test_cases_list(pics: PICS) -> PICSApplicableTestCases:
@@ -68,6 +71,11 @@ def __applicable_test_cases(
     mandatory: bool,
 ) -> list:
     applicable_tests: list = []
+
+    # The Performance Test Collection should not be considered for the PICS.
+    # NOTE: The second parameter for the dictionary's "pop" method is provided so we may
+    # prevent a conditional exception when the following key is not present.
+    test_collections.pop(STRESS_TEST_COLLECTION, None)
 
     for test_collection in test_collections.values():
         if test_collection.mandatory == mandatory:

--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -46,14 +46,15 @@ def applicable_test_cases_list(pics: PICS) -> PICSApplicableTestCases:
         logger.debug(f"Applicable test cases: {applicable_tests}")
         return PICSApplicableTestCases(test_cases=applicable_tests)
 
-    test_collections = test_script_manager.test_collections
+    # Getting a copy of Test Collections Dict so we may add/remove items safely
+    test_collections_copy = test_script_manager.test_collections.copy()
     enabled_pics = set([item.number for item in pics.all_enabled_items()])
 
     applicable_mandatories_tests = __applicable_test_cases(
-        test_collections, enabled_pics, True
+        test_collections_copy, enabled_pics, True
     )
     applicable_remaining_tests = __applicable_test_cases(
-        test_collections, enabled_pics, False
+        test_collections_copy, enabled_pics, False
     )
 
     # Add first the mandatories test cases
@@ -72,7 +73,7 @@ def __applicable_test_cases(
 ) -> list:
     applicable_tests: list = []
 
-    # The Performance Test Collection should not be considered for the PICS.
+    # The 'Performance Tests' Collection should not be considered for the PICS tests.
     # NOTE: The second parameter for the dictionary's "pop" method is provided so we may
     # prevent a conditional exception when the following key is not present.
     test_collections.pop(STRESS_TEST_COLLECTION, None)

--- a/app/test_engine/test_script_manager.py
+++ b/app/test_engine/test_script_manager.py
@@ -383,4 +383,4 @@ class TestScriptManager(object, metaclass=Singleton):
                 )
 
 
-test_script_manager = TestScriptManager()
+test_script_manager: TestScriptManager = TestScriptManager()

--- a/test_collections/matter/sdk_tests/support/performance_tests/sdk_performance_tests.py
+++ b/test_collections/matter/sdk_tests/support/performance_tests/sdk_performance_tests.py
@@ -32,6 +32,8 @@ from .models.test_suite import PerformanceSuiteType
 #
 ###
 
+STRESS_TEST_COLLECTION = "SDK Performance Tests"
+STRESS_TEST_SUITE = "Performance Test Suite"
 STRESS_TEST_PATH = Path(__file__).resolve().parent / "scripts/sdk/"
 STRESS_TEST_FOLDER = SDKTestFolder(path=STRESS_TEST_PATH, filename_pattern="TC_*")
 
@@ -41,7 +43,7 @@ def _init_test_suites(
 ) -> dict[PerformanceSuiteType, PerformanceSuiteDeclaration]:
     return {
         PerformanceSuiteType.PERFORMANCE: PerformanceSuiteDeclaration(
-            name="Performance Test Suite",
+            name=STRESS_TEST_SUITE,
             suite_type=PerformanceSuiteType.PERFORMANCE,
             version=performance_test_version,
         ),
@@ -84,7 +86,7 @@ def sdk_performance_test_collection(
 ) -> PerformanceCollectionDeclaration:
     """Declare a new collection of test suites."""
     collection = PerformanceCollectionDeclaration(
-        name="SDK Performance Tests", folder=performance_test_folder
+        name=STRESS_TEST_COLLECTION, folder=performance_test_folder
     )
 
     files = performance_test_folder.file_paths(extension=".py")


### PR DESCRIPTION
Removing the Performance collection from PICS applicable tests validation.

This solves the issue from this TH version that using a **PICS** file results in auto-selecting the Performance test in background, even this collection not being visible in the "select tests" UI.

**Before:**
<img width="1620" alt="Screenshot 2025-03-10 at 09 58 15" src="https://github.com/user-attachments/assets/ecdec8f4-1464-4e7d-a32e-8827fcd0600c" />

**After:**
<img width="1616" alt="Screenshot 2025-03-10 at 09 59 05" src="https://github.com/user-attachments/assets/f6c4a390-6152-4588-b713-a6c49b96dcdd" />
