### PR TITLE
Copy mock_server from cert-bins to host

### DIFF
--- a/test_collections/matter/config.py
+++ b/test_collections/matter/config.py
@@ -23,9 +23,9 @@ class MatterSettings(BaseSettings):
 
     # SDK Docker Image
     SDK_DOCKER_IMAGE: str = "connectedhomeip/chip-cert-bins"
-    SDK_DOCKER_TAG: str = "e34015c518af92d6fc923d9da711ef3f792584e5"
+    SDK_DOCKER_TAG: str = "6cc5fb11559a4fa8264c7de968600b00f8f06c25"
     # SDK SHA: used to fetch tests (YAML and Python) from SDK.
-    SDK_SHA: str = "e34015c518af92d6fc923d9da711ef3f792584e5"
+    SDK_SHA: str = "6cc5fb11559a4fa8264c7de968600b00f8f06c25"
 
     class Config:
         case_sensitive = True

--- a/test_collections/matter/scripts/update-sample-apps.sh
+++ b/test_collections/matter/scripts/update-sample-apps.sh
@@ -43,7 +43,7 @@ fi
 
 
 print_script_step "Updating Sample APPs"
-sudo docker run -t -v ~/apps:/apps -v ~/mock_server:/mock_server $SDK_DOCKER_IMAGE bash -c "rm -v /apps/*; cp -v apps/* /apps/; cp -v -r mock_server/* /mock_server/"
+sudo docker run -t -v ~/apps:/apps -v ~/mock_server:/mock_server $SDK_DOCKER_IMAGE bash -c "rm -v /apps/*; rm -v /mock_server/*; cp -v apps/* /apps/; cp -v -r mock_server/* /mock_server/"
 echo "Setting Sample APPs ownership"
 sudo chown -R `whoami` ~/apps
 

--- a/test_collections/matter/scripts/update-sample-apps.sh
+++ b/test_collections/matter/scripts/update-sample-apps.sh
@@ -43,7 +43,7 @@ fi
 
 
 print_script_step "Updating Sample APPs"
-sudo docker run -t -v ~/apps:/apps $SDK_DOCKER_IMAGE bash -c "rm -v /apps/*; cp -v apps/* /apps/"
+sudo docker run -t -v ~/apps:/apps -v ~/mock_server:/mock_server $SDK_DOCKER_IMAGE bash -c "rm -v /apps/*; cp -v apps/* /apps/; cp -v -r mock_server/* /mock_server/"
 echo "Setting Sample APPs ownership"
 sudo chown -R `whoami` ~/apps
 


### PR DESCRIPTION
### What changed
Updated code to copy files from cert-bins image to host.

### Related Issue
https://github.com/project-chip/certification-tool/issues/530

### Testing
The mock_server folder is not available on host
<img width="284" alt="Screenshot 2025-03-24 at 17 51 48" src="https://github.com/user-attachments/assets/2a9fe365-d92e-469b-a40c-849122194382" />
