### PR TITLE
[Camera] Adds support for camera app yaml test cases through camera-controller

### DIFF
--- a/app/constants/websockets_constants.py
+++ b/app/constants/websockets_constants.py
@@ -33,6 +33,7 @@ class MessageTypeEnum(str, Enum):
     TIME_OUT_NOTIFICATION = "time_out_notification"
     TEST_LOG_RECORDS = "test_log_records"
     INVALID_MESSAGE = "invalid_message"
+    STREAM_VERIFICATION_REQUEST = "stream_verification_request"
 
 
 # Enum keys used with messages at the top level

--- a/app/test_engine/models/manual_test_case.py
+++ b/app/test_engine/models/manual_test_case.py
@@ -25,7 +25,9 @@ from app.user_prompt_support import (
     UploadFile,
     UploadFilePromptRequest,
     UserPromptSupport,
+    TextInputPromptRequest,
     UserResponseStatusEnum,
+    StreamVerificationPromptRequest
 )
 
 from .test_case import TestCase
@@ -51,6 +53,49 @@ class ManualVerificationTestStep(TestStep, UserPromptSupport):
     def __init__(self, name: str, verification: Optional[str] = None) -> None:
         super().__init__(name=name)
         self.verification = verification
+    
+    async def prompt_verification_step_with_response(self, textInputPrompt: TextInputPromptRequest)->str:
+        """Prompt user to verify the video stream.
+
+        Returns:
+            str: string response received as user input
+        """
+        prompt_response = await self.invoke_prompt_and_get_str_response(textInputPrompt)
+        return prompt_response
+
+    async def prompt_stream_verification_step(self) -> bool:
+        """Prompt user to verify the video stream.
+
+        Raises:
+            ValueError: When receiving an unexpected response
+
+        Returns:
+            bool: False if user responds Failed
+        """
+        prompt = self.name
+        if self.verification is not None:
+            prompt += f"\n\n{self.verification}"
+
+        options = {
+            "PASS": PromptOptions.PASS,
+            "FAIL": PromptOptions.FAIL,
+        }
+        prompt_request = StreamVerificationPromptRequest(
+            prompt=prompt, options=options, timeout=OUTCOME_TIMEOUT_S
+        )
+        prompt_response = await self.send_prompt_request(prompt_request)
+        self.__evaluate_user_response_for_errors(prompt_response)
+
+        if prompt_response.response == PromptOptions.FAIL:
+            self.append_failure("User stated manual step FAILED.")
+            return False
+        elif prompt_response.response == PromptOptions.PASS:
+            logger.info("User stated this manual step PASSED.")
+            return True
+        else:
+            raise ValueError(
+                f"Received unknown prompt option: {prompt_response.response}"
+            )
 
     async def prompt_verification_step(self) -> bool:
         """Sends a prompt request to present instructions and get outcome from user.

--- a/app/user_prompt_support/__init__.py
+++ b/app/user_prompt_support/__init__.py
@@ -19,6 +19,7 @@ from .prompt_request import (
     PromptRequest,
     TextInputPromptRequest,
     UploadFilePromptRequest,
+    StreamVerificationPromptRequest
 )
 from .prompt_response import PromptResponse
 from .uploaded_file_support import UploadedFileSupport, UploadFile

--- a/app/user_prompt_support/prompt_request.py
+++ b/app/user_prompt_support/prompt_request.py
@@ -61,3 +61,8 @@ class MessagePromptRequest(PromptRequest):
     @property
     def messageType(self) -> MessageTypeEnum:
         return MessageTypeEnum.MESSAGE_REQUEST
+
+class StreamVerificationPromptRequest(OptionsSelectPromptRequest):
+    @property
+    def messageType(self) -> MessageTypeEnum:
+        return MessageTypeEnum.STREAM_VERIFICATION_REQUEST

--- a/test_collections/matter/sdk_tests/support/chip/chip_server.py
+++ b/test_collections/matter/sdk_tests/support/chip/chip_server.py
@@ -34,6 +34,8 @@ from ..sdk_container import DOCKER_LOGS_PATH, DOCKER_PAA_CERTS_PATH, SDKContaine
 CHIP_TOOL_EXE = "./chip-tool"
 CHIP_TOOL_ARG_PAA_CERTS_PATH = "--paa-trust-store-path"
 
+#TODO: Use chip-camera-controller for camera tests.
+
 # Chip App Parameters
 CHIP_APP_EXE = "./chip-app1"
 

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_test.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_test.py
@@ -30,17 +30,17 @@ from app.test_engine.models.manual_test_case import (
     ManualLogUploadStep,
     ManualVerificationTestStep,
 )
-from app.user_prompt_support.prompt_request import MessagePromptRequest
+from app.user_prompt_support.prompt_request import MessagePromptRequest, PromptRequest, TextInputPromptRequest
 from app.user_prompt_support.uploaded_file_support import UploadFile
 from app.user_prompt_support.user_prompt_manager import user_prompt_manager
 from app.user_prompt_support.user_prompt_support import UserPromptSupport
-
 from ...chip.chip_server import ChipServerType
 from ...sdk_container import SDKContainer
 from ...yaml_tests.matter_yaml_runner import MatterYAMLRunner
 
 CHIP_TOOL_DEFAULT_PROMPT_TIMEOUT_S = 60  # seconds
 OUTCOME_TIMEOUT_S = 60 * 10  # Seconds
+EXTENDED_PROMPT_TIMEOUT_S = 300
 
 
 class ChipPromptTypeEnum(str, Enum):
@@ -170,34 +170,59 @@ class ChipTest(TestCase, UserPromptSupport, TestRunnerHooks, TestParserHooks):
     def step_unknown(self) -> None:
         self.__runned += 1
 
-    async def step_manual(self) -> None:
+    async def step_manual(self, request) -> None:
         step = self.current_test_step
         if not isinstance(step, ManualVerificationTestStep):
             raise TestError(f"Unexpected user prompt found in test step: {step.name}")
 
         try:
-            await asyncio.wait_for(
-                self.__prompt_user_manual_step(step), OUTCOME_TIMEOUT_S
-            )
+            if request and request.command == "VerifyVideoStream":
+                await asyncio.wait_for(
+                    self.__prompt_stream_verification_manual_step(step), OUTCOME_TIMEOUT_S
+                )
+            else:
+                await asyncio.wait_for(
+                    self.__prompt_user_manual_step(step), OUTCOME_TIMEOUT_S
+                )
         except asyncio.TimeoutError:
             self.current_test_step.append_failure("Prompt timed out.")
         self.next_step()
 
-    def show_prompt(
+    async def show_prompt(
         self,
         msg: str,
         placeholder: Optional[str] = None,
         default_value: Optional[str] = None,
-    ) -> None:
-        pass
+    ) -> str:
+        step = self.current_test_step
+        if not isinstance(step, ManualVerificationTestStep):
+            raise TestError(f"Unexpected user prompt found in test step: {step.name}")
+        userPrompt = TextInputPromptRequest(prompt=msg, timeout=EXTENDED_PROMPT_TIMEOUT_S, default_value=default_value, placeholder_text="Input", regex_pattern=None)
+        response = await self.__prompt_user_manual_step_with_response(step, userPrompt)
+        if response == None:
+            raise ValueError("Did not receive any input value")
+        return response
 
     # Other methods
+    async def __prompt_user_manual_step_with_response(self, step: ManualVerificationTestStep, prompt: PromptRequest) -> str:
+        result = await step.prompt_verification_step_with_response(prompt)
+
+        if not result:
+            self.current_test_step.append_failure("Manual Test Step Failure.")
+            result = "Failed getting response"
+        return result
 
     async def __prompt_user_manual_step(self, step: ManualVerificationTestStep) -> None:
         result = await step.prompt_verification_step()
 
         if not result:
             self.current_test_step.append_failure("Manual Test Step Failure.")
+
+    async def __prompt_stream_verification_manual_step(self, step: ManualVerificationTestStep) -> None:
+        result = await step.prompt_stream_verification_step()
+
+        if not result:
+            self.current_test_step.append_failure("Video Verification Test Step Failure.")
 
     def __report_failures(self, logger: Any, request: TestStep, received: Any) -> None:
         """

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
@@ -162,7 +162,7 @@ class YamlTestCase(TestCase):
         Disabled steps are ignored.
         (Such tests will be marked as 'Steps Disabled' elsewhere)
 
-        UserPrompt are special cases that will prompt test operator for input.
+        UserPrompt, PromptWithResponse or VerifyVideoStream are special cases that will prompt test operator for input.
         """
         if yaml_step.disabled:
             test_engine_logger.info(
@@ -171,7 +171,7 @@ class YamlTestCase(TestCase):
             return
 
         step = TestStep(yaml_step.label)
-        if yaml_step.command == "UserPrompt":
+        if yaml_step.command in ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"]:
             step = ManualVerificationTestStep(
                 name=yaml_step.label,
                 verification=yaml_step.verification,

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
@@ -50,8 +50,8 @@ def _test_type(test: YamlTest) -> MatterTestType:
     if all(s.disabled is True for s in steps):
         return MatterTestType.MANUAL
 
-    # if any step has a UserPrompt, categorize as semi-automated
-    if any(s.command == "UserPrompt" for s in steps):
+    # if any step has a UserPrompt, PromptWithResponse or VerifyVideoStream command, categorize as semi-automated
+    if any(s.command in ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"] for s in steps):
         return MatterTestType.SEMI_AUTOMATED
 
     # Otherwise Automated


### PR DESCRIPTION
#### Problem
* For the Camera Controller
* Add SDP User Prompt and Video Prompt support in certification-tool/backend.
* Add WebSocket based communication between certification-tool/backend and certification-tool/frontend to transfer video frames produced by camera-controller.

#### Change overview
* Adds support for user prompt pop-up to receive Offer SDP / ICECandidate values from the test operator.
* Adds support Video Verification pop up to verify WebRTC connection with DUT.

#### Testing
* Excute TestHarness and check WebRTC Requestor/Provider operations