### PR TITLE
Use discriminator for nfc thread

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -127,7 +127,8 @@
         ".devcontainer",
         "test_collections/matter/sdk_tests/*.json",
         "test_collections/matter/sdk_tests/support/performance_tests/",
-        "test_collections/matter/config.py"
+        "test_collections/matter/config.py",
+        "app/platform-test.json"
     ],
     "enableFiletypes": [
         "shellscript"

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -102,8 +102,7 @@ async def generate_command_arguments(
             and "qr-code" not in test_parameters.keys()
         ):
             # Retrieve arguments from dut_config
-            if pairing_mode != DutPairingModeEnum.NFC_THREAD:
-                arguments.append(f"--discriminator {dut_config.discriminator}")
+            arguments.append(f"--discriminator {dut_config.discriminator}")
             arguments.append(f"--passcode {dut_config.setup_code}")
 
         for name, value in test_parameters.items():
@@ -111,8 +110,7 @@ async def generate_command_arguments(
             arguments.append(f"--{name} {arg_value}")
     else:
         # Retrieve arguments from dut_config
-        if pairing_mode != DutPairingModeEnum.NFC_THREAD:
-            arguments.append(f"--discriminator {dut_config.discriminator}")
+        arguments.append(f"--discriminator {dut_config.discriminator}")
         arguments.append(f"--passcode {dut_config.setup_code}")
 
     return arguments

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -239,6 +239,7 @@ async def test_generate_command_arguments_nfc_thread() -> None:
     mock_dut_config = DutConfig(
         setup_code="8765",
         pairing_mode=DutPairingModeEnum.NFC_THREAD,
+        discriminator="456",
     )
 
     mock_config.dut_config = mock_dut_config
@@ -267,6 +268,7 @@ async def test_generate_command_arguments_nfc_thread() -> None:
                 "23402081111111122222222051000112233445566778899aabbccddeeff030444454d4"
                 "f"
             ),
+            "--discriminator 456",
             "--passcode 8765",
             "--paa-trust-store-path /paa-root-certs",
             "--storage_path /root/admin_storage.json",
@@ -286,6 +288,7 @@ async def test_generate_command_arguments_nfc_thread_for_external_network() -> N
     mock_dut_config = DutConfig(
         setup_code="8765",
         pairing_mode=DutPairingModeEnum.NFC_THREAD,
+        discriminator="783",
     )
 
     mock_config.dut_config = mock_dut_config
@@ -310,6 +313,7 @@ async def test_generate_command_arguments_nfc_thread_for_external_network() -> N
             "4f20410d477d767e424a5f2ef25c16fc9b621e90c0402a0f7f8000300000f0102123402081"
             "111111122222222051000112233445566778899aabbccddeeff030444454d4f"
         ),
+        "--discriminator 783",
         "--passcode 8765",
         "--paa-trust-store-path /paa-root-certs",
         "--storage_path /root/admin_storage.json",

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
@@ -465,6 +465,7 @@ async def test_pairing_nfc_thread_command_params() -> None:
     chip_server: ChipServer = ChipServer()
     hex_dataset = "c0ffee"
     setup_code = "0123456"
+    discriminator = "1234"
 
     with mock.patch.object(
         target=runner,
@@ -475,9 +476,12 @@ async def test_pairing_nfc_thread_command_params() -> None:
         result = await runner.pairing_nfc_thread(
             hex_dataset=hex_dataset,
             setup_code=setup_code,
+            discriminator=discriminator,
         )
 
-    expected_params = f"{hex(chip_server.node_id)} hex:{hex_dataset} {setup_code}"
+    expected_params = (
+        f"{hex(chip_server.node_id)} hex:{hex_dataset} {setup_code} {discriminator}"
+    )
     expected_command = f"pairing nfc-thread {expected_params}"
 
     assert result is True

--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -323,12 +323,14 @@ class MatterYAMLRunner(metaclass=Singleton):
         self,
         hex_dataset: str,
         setup_code: str,
+        discriminator: str,
     ) -> bool:
         return await self.pairing(
             PAIRING_MODE_NFC_THREAD,
             hex(self.chip_server.node_id),
             f"hex:{hex_dataset}",
             setup_code,
+            discriminator,
         )
 
     def set_pics(self, pics: PICS) -> None:

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -129,7 +129,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
         elif (
             self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.NFC_THREAD
         ):
-            pair_result = await self.__pair_with_dut_nfc_thread()
+            pair_result = await self.__pair_with_dut_ble_thread()
         elif (
             self.config_matter.dut_config.pairing_mode
             is DutPairingModeEnum.WIFIPAF_WIFI
@@ -144,7 +144,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
     async def __pair_with_dut_onnetwork(self) -> bool:
         return await self.runner.pairing_on_network(
             setup_code=self.config_matter.dut_config.setup_code,
-            discriminator=self.config_matter.dut_config.discriminator,  # type: ignore
+            discriminator=self.config_matter.dut_config.discriminator,
         )
 
     async def __pair_with_dut_ble_wifi(self) -> bool:
@@ -155,7 +155,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
             ssid=self.config_matter.network.wifi.ssid,
             password=self.config_matter.network.wifi.password,
             setup_code=self.config_matter.dut_config.setup_code,
-            discriminator=self.config_matter.dut_config.discriminator,  # type: ignore
+            discriminator=self.config_matter.dut_config.discriminator,
         )
 
     async def __pair_with_dut_wifipaf_wifi(self) -> bool:
@@ -166,7 +166,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
             ssid=self.config_matter.network.wifi.ssid,
             password=self.config_matter.network.wifi.password,
             setup_code=self.config_matter.dut_config.setup_code,
-            discriminator=self.config_matter.dut_config.discriminator,  # type: ignore
+            discriminator=self.config_matter.dut_config.discriminator,
         )
 
     async def __pair_with_dut_ble_thread(self) -> bool:
@@ -186,27 +186,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
         return await self.runner.pairing_ble_thread(
             hex_dataset=hex_dataset,
             setup_code=self.config_matter.dut_config.setup_code,
-            discriminator=self.config_matter.dut_config.discriminator,  # type: ignore
-        )
-
-    async def __pair_with_dut_nfc_thread(self) -> bool:
-        if self.config_matter.network.thread is None:
-            raise DUTCommissioningError("Tool config is missing thread config.")
-
-        # if thread has ThreadAutoConfig, bring up border router
-        thread_config = self.config_matter.network.thread
-        if isinstance(thread_config, ThreadExternalConfig):
-            hex_dataset = thread_config.operational_dataset_hex
-        elif isinstance(thread_config, ThreadAutoConfig):
-            border_router = await self.__start_border_router(thread_config)
-            hex_dataset = border_router.active_dataset
-        else:
-            raise DUTCommissioningError("Invalid thread configuration")
-
-        return await self.runner.pairing_nfc_thread(
-            hex_dataset=hex_dataset,
-            setup_code=self.config_matter.dut_config.setup_code,
-            discriminator=self.config_matter.dut_config.discriminator,  # type: ignore
+            discriminator=self.config_matter.dut_config.discriminator,
         )
 
     async def __start_border_router(

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -129,7 +129,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
         elif (
             self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.NFC_THREAD
         ):
-            pair_result = await self.__pair_with_dut_ble_thread()
+            pair_result = await self.__pair_with_dut_nfc_thread()
         elif (
             self.config_matter.dut_config.pairing_mode
             is DutPairingModeEnum.WIFIPAF_WIFI
@@ -184,6 +184,26 @@ class ChipSuite(TestSuite, UserPromptSupport):
             raise DUTCommissioningError("Invalid thread configuration")
 
         return await self.runner.pairing_ble_thread(
+            hex_dataset=hex_dataset,
+            setup_code=self.config_matter.dut_config.setup_code,
+            discriminator=self.config_matter.dut_config.discriminator,
+        )
+
+    async def __pair_with_dut_nfc_thread(self) -> bool:
+        if self.config_matter.network.thread is None:
+            raise DUTCommissioningError("Tool config is missing thread config.")
+
+        # if thread has ThreadAutoConfig, bring up border router
+        thread_config = self.config_matter.network.thread
+        if isinstance(thread_config, ThreadExternalConfig):
+            hex_dataset = thread_config.operational_dataset_hex
+        elif isinstance(thread_config, ThreadAutoConfig):
+            border_router = await self.__start_border_router(thread_config)
+            hex_dataset = border_router.active_dataset
+        else:
+            raise DUTCommissioningError("Invalid thread configuration")
+
+        return await self.runner.pairing_nfc_thread(
             hex_dataset=hex_dataset,
             setup_code=self.config_matter.dut_config.setup_code,
             discriminator=self.config_matter.dut_config.discriminator,

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -206,6 +206,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
         return await self.runner.pairing_nfc_thread(
             hex_dataset=hex_dataset,
             setup_code=self.config_matter.dut_config.setup_code,
+            discriminator=self.config_matter.dut_config.discriminator,  # type: ignore
         )
 
     async def __start_border_router(

--- a/test_collections/matter/test_environment_config.py
+++ b/test_collections/matter/test_environment_config.py
@@ -53,7 +53,7 @@ class EnhancedSetupFlowConfig(BaseModel):
 
 
 class DutConfig(BaseModel):
-    discriminator: Optional[str]
+    discriminator: str
     setup_code: str
     pairing_mode: DutPairingModeEnum
     chip_timeout: Optional[str]
@@ -95,29 +95,6 @@ class TestEnvironmentConfigMatter(TestEnvironmentConfig):
             if not isinstance(dut_config, dict):
                 dut_config = dut_config.__dict__
 
-            # Discriminator field must be informed when pairing_mode is other
-            # than nfc_thread
-            if (
-                dut_config
-                and dut_config["pairing_mode"] != DutPairingModeEnum.NFC_THREAD
-                and "discriminator" not in dut_config
-            ):
-                raise TestEnvironmentConfigMatterError(
-                    "The discriminator is mandatory for pairing mode "
-                    f" {dut_config['pairing_mode']}"
-                )
-
-            # Discriminator field must NOT be informed when pairing_mode is nfc_thread
-            if (
-                dut_config
-                and dut_config["pairing_mode"] == DutPairingModeEnum.NFC_THREAD
-                and "discriminator" in dut_config
-            ):
-                raise TestEnvironmentConfigMatterError(
-                    "The discriminator must not be informed for pairing mode "
-                    f"{dut_config['pairing_mode']}"
-                )
-
             # Check if the informed field in dut_config is valid
             for field, _ in dut_config.items():
                 if field not in valid_properties:
@@ -130,11 +107,6 @@ class TestEnvironmentConfigMatter(TestEnvironmentConfig):
             # mandatory
             mandatory_fields = valid_properties.copy()
             mandatory_fields.remove("chip_timeout")
-
-            # discriminator is not mandatory for nfc_thread pairing mode
-            if dut_config["pairing_mode"] == DutPairingModeEnum.NFC_THREAD:
-                mandatory_fields.remove("discriminator")
-
             mandatory_fields.remove("enhanced_setup_flow")
 
             for field in mandatory_fields:


### PR DESCRIPTION
### What changed
The goal of this PR is to revert the changes introduced in PR #185, which made the discriminator field optional for NFC thread pairing.

### Testing
Unit tests have been updated accordingly and are all passing.

