### PR TITLE
[Camera] Add CameraAppTestSuite for Matter Camera TCs

### DIFF
--- a/test_collections/matter/sdk_tests/support/chip/chip_server.py
+++ b/test_collections/matter/sdk_tests/support/chip/chip_server.py
@@ -122,7 +122,6 @@ class ChipServer(metaclass=Singleton):
         self.__use_paa_certs = use_paa_certs
         self.__server_type = server_type
 
-
         if server_type == ChipServerType.CHIP_CAMERA_CONTROLLER:
             prefix = CHIP_CAMERA_CONTROLLER_EXE
             command = ["interactive", "server"]

--- a/test_collections/matter/sdk_tests/support/chip/chip_server.py
+++ b/test_collections/matter/sdk_tests/support/chip/chip_server.py
@@ -34,6 +34,8 @@ from ..sdk_container import DOCKER_LOGS_PATH, DOCKER_PAA_CERTS_PATH, SDKContaine
 CHIP_TOOL_EXE = "./chip-tool"
 CHIP_TOOL_ARG_PAA_CERTS_PATH = "--paa-trust-store-path"
 
+CHIP_CAMERA_CONTROLLER_EXE = "./chip-camera-controller"
+
 # Chip App Parameters
 CHIP_APP_EXE = "./chip-app1"
 
@@ -49,6 +51,7 @@ class UnsupportedChipServerType(Exception):
 class ChipServerType(str, Enum):
     CHIP_TOOL = "chip-tool"
     CHIP_APP = "chip-app"
+    CHIP_CAMERA_CONTROLLER = "chip-camera-controller"
 
 
 class ChipServer(metaclass=Singleton):
@@ -119,7 +122,11 @@ class ChipServer(metaclass=Singleton):
         self.__use_paa_certs = use_paa_certs
         self.__server_type = server_type
 
-        if server_type == ChipServerType.CHIP_TOOL:
+
+        if server_type == ChipServerType.CHIP_CAMERA_CONTROLLER:
+            prefix = CHIP_CAMERA_CONTROLLER_EXE
+            command = ["interactive", "server"]
+        elif server_type == ChipServerType.CHIP_TOOL:
             prefix = CHIP_TOOL_EXE
             command = ["interactive", "server"]
         elif server_type == ChipServerType.CHIP_APP:

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_yaml_parser.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_yaml_parser.py
@@ -103,12 +103,12 @@ def test_test_type_all_disabled_steps() -> None:
     disabled_step = MatterTestStep(label="Disabled Test Step", disabled=True)
     five_disabled_steps_test = yaml_test_instance(tests=[disabled_step] * 5)
 
-    type = _test_type(five_disabled_steps_test)
+    type, _ = _test_type(five_disabled_steps_test)
     assert type == MatterTestType.MANUAL
 
     # simulated in path overrides test type to simulated
     five_disabled_steps_test.path = Path("TC_XX_Simulated.yaml")
-    type = _test_type(five_disabled_steps_test)
+    type, _ = _test_type(five_disabled_steps_test)
     assert type == MatterTestType.SIMULATED
 
 
@@ -117,12 +117,12 @@ def test_test_type_some_disabled_steps() -> None:
     enabled_step = MatterTestStep(label="Enabled Test Step", disabled=False)
     test = yaml_test_instance(tests=[disabled_step, enabled_step])
 
-    type = _test_type(test)
+    type, _ = _test_type(test)
     assert type == MatterTestType.AUTOMATED
 
     # simulated in path overrides test type to simulated
     test.path = Path("TC_XX_Simulated.yaml")
-    type = _test_type(test)
+    type, _ = _test_type(test)
     assert type == MatterTestType.SIMULATED
 
 
@@ -130,12 +130,12 @@ def test_test_type_all_enabled_steps_no_prompts() -> None:
     enabled_step = MatterTestStep(label="Enabled Test Step")
     five_enabled_steps_test = yaml_test_instance(tests=[enabled_step] * 5)
 
-    type = _test_type(five_enabled_steps_test)
+    type, _ = _test_type(five_enabled_steps_test)
     assert type == MatterTestType.AUTOMATED
 
     # simulated in path overrides test type to simulated
     five_enabled_steps_test.path = Path("TC_XX_Simulated.yaml")
-    type = _test_type(five_enabled_steps_test)
+    type, _ = _test_type(five_enabled_steps_test)
     assert type == MatterTestType.SIMULATED
 
 
@@ -144,10 +144,10 @@ def test_test_type_all_enabled_steps_some_prompts() -> None:
     prompt_step = MatterTestStep(label="Prompt Test Step", command="UserPrompt")
     test = yaml_test_instance(tests=[enabled_step, prompt_step])
 
-    type = _test_type(test)
+    type, _ = _test_type(test)
     assert type == MatterTestType.SEMI_AUTOMATED
 
     # simulated in path overrides test type to simulated
     test.path = Path("TC_XX_Simulated.yaml")
-    type = _test_type(test)
+    type, _ = _test_type(test)
     assert type == MatterTestType.SIMULATED

--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -233,9 +233,9 @@ class MatterYAMLRunner(metaclass=Singleton):
             server_type == ChipServerType.CHIP_TOOL
             or server_type == ChipServerType.CHIP_CAMERA_CONTROLLER
         ):
-            test_path = f"{YAML_TESTS_PATH}/{test_id}.yaml"
+            test_path = f"{YAML_TESTS_PATH}/{test_path}.yaml"
         else:
-            test_path = f"{YAML_TESTS_PATH}/{test_id}_Simulated.yaml"
+            test_path = f"{YAML_TESTS_PATH}/{test_path}_Simulated.yaml"
 
         parser_config = TestParserConfig(pics_path, self.specifications, test_options)
         parser_builder_config = TestParserBuilderConfig(

--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -229,14 +229,6 @@ class MatterYAMLRunner(metaclass=Singleton):
             pics_path = f"{PICS_FILE_PATH}"
             self.logger.info(f"Using PICS file: {pics_path}")
 
-        if (
-            server_type == ChipServerType.CHIP_TOOL
-            or server_type == ChipServerType.CHIP_CAMERA_CONTROLLER
-        ):
-            test_path = f"{YAML_TESTS_PATH}/{test_path}.yaml"
-        else:
-            test_path = f"{YAML_TESTS_PATH}/{test_path}_Simulated.yaml"
-
         parser_config = TestParserConfig(pics_path, self.specifications, test_options)
         parser_builder_config = TestParserBuilderConfig(
             [test_path], parser_config, test_parser_hooks

--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -229,12 +229,24 @@ class MatterYAMLRunner(metaclass=Singleton):
             pics_path = f"{PICS_FILE_PATH}"
             self.logger.info(f"Using PICS file: {pics_path}")
 
+        if (
+            server_type == ChipServerType.CHIP_TOOL
+            or server_type == ChipServerType.CHIP_CAMERA_CONTROLLER
+        ):
+            test_path = f"{YAML_TESTS_PATH}/{test_id}.yaml"
+        else:
+            test_path = f"{YAML_TESTS_PATH}/{test_id}_Simulated.yaml"
+
         parser_config = TestParserConfig(pics_path, self.specifications, test_options)
         parser_builder_config = TestParserBuilderConfig(
             [test_path], parser_config, test_parser_hooks
         )
 
-        if server_type == ChipServerType.CHIP_TOOL:
+        # Reuse chip-tool adapter for camera-controller
+        if (
+            server_type == ChipServerType.CHIP_TOOL
+            or server_type == ChipServerType.CHIP_CAMERA_CONTROLLER
+        ):
             adapter = ChipToolAdapter.Adapter(parser_config.definitions)
         elif server_type == ChipServerType.CHIP_APP:
             adapter = ChipAppAdapter.Adapter(parser_config.definitions)

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -89,7 +89,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
             self.runner.reset_pics_state()
 
         self.__dut_commissioned_successfully = False
-        if self.server_type == ChipServerType.CHIP_TOOL:
+        if self.server_type == ChipServerType.CHIP_TOOL or self.server_type == ChipServerType.CHIP_CAMERA_CONTROLLER:
             logger.info("Commission DUT")
             user_response = await prompt_for_commissioning_mode(
                 self, logger, None, self.cancel
@@ -227,7 +227,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
         # Only unpair if commissioning was successfull during setup
         if self.__dut_commissioned_successfully:
             # Unpair is not applicable for simulated apps case
-            if self.server_type == ChipServerType.CHIP_TOOL:
+            if self.server_type == ChipServerType.CHIP_TOOL or self.server_type == ChipServerType.CHIP_CAMERA_CONTROLLER:
                 logger.info("Unpairing DUT from server")
                 await self.runner.unpair()
             elif self.server_type == ChipServerType.CHIP_APP:

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -89,7 +89,10 @@ class ChipSuite(TestSuite, UserPromptSupport):
             self.runner.reset_pics_state()
 
         self.__dut_commissioned_successfully = False
-        if self.server_type == ChipServerType.CHIP_TOOL or self.server_type == ChipServerType.CHIP_CAMERA_CONTROLLER:
+        if (
+            self.server_type == ChipServerType.CHIP_TOOL
+            or self.server_type == ChipServerType.CHIP_CAMERA_CONTROLLER
+        ):
             logger.info("Commission DUT")
             user_response = await prompt_for_commissioning_mode(
                 self, logger, None, self.cancel
@@ -227,7 +230,10 @@ class ChipSuite(TestSuite, UserPromptSupport):
         # Only unpair if commissioning was successfull during setup
         if self.__dut_commissioned_successfully:
             # Unpair is not applicable for simulated apps case
-            if self.server_type == ChipServerType.CHIP_TOOL or self.server_type == ChipServerType.CHIP_CAMERA_CONTROLLER:
+            if (
+                self.server_type == ChipServerType.CHIP_TOOL
+                or self.server_type == ChipServerType.CHIP_CAMERA_CONTROLLER
+            ):
                 logger.info("Unpairing DUT from server")
                 await self.runner.unpair()
             elif self.server_type == ChipServerType.CHIP_APP:

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/constants/yaml_constants.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/constants/yaml_constants.py
@@ -1,0 +1,17 @@
+#
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+USER_ACTIONS = ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"]

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
@@ -232,7 +232,7 @@ class YamlCameraChipTestCase(YamlTestCase, ChipTest):
             self._append_automated_test_step(step)
 
 
-class YamlCameraSemiAutomatedChipTestCase(YamlChipTestCase, ChipManualPromptTest):
+class YamlCameraSemiAutomatedChipTestCase(YamlCameraChipTestCase, ChipManualPromptTest):
     """Camera Semi-Automated test cases, need special step for users to attach logs
     for manual steps, so inheriting from ChipManualPromptTest.
     """

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
@@ -29,6 +29,7 @@ from ...chip.chip_server import ChipServerType
 from ...models.matter_test_models import MatterTestStep, MatterTestType
 from ...yaml_tests.models.chip_test import ChipManualPromptTest, ChipTest
 from .yaml_test_models import YamlTest
+from .test_suite import SuiteType
 
 # Custom type variable used to annotate the factory method in YamlTestCase.
 T = TypeVar("T", bound="YamlTestCase")
@@ -81,11 +82,18 @@ class YamlTestCase(TestCase):
         if test.type == MatterTestType.MANUAL:
             case_class = YamlManualTestCase
         elif test.type == MatterTestType.SEMI_AUTOMATED:
-            case_class = YamlSemiAutomatedChipTestCase
+            if test.suite_type == SuiteType.CAMERA_AUTOMATED:
+                case_class = YamlCameraSemiAutomatedChipTestCase
+            else:
+                case_class = YamlSemiAutomatedChipTestCase
+
         elif test.type == MatterTestType.SIMULATED:
             case_class = YamlSimulatedTestCase
         else:  # Automated
-            case_class = YamlChipTestCase
+            if test.suite_type == SuiteType.CAMERA_AUTOMATED:
+                case_class = YamlCameraChipTestCase
+            else:
+                case_class = YamlChipTestCase
 
         return case_class.__class_factory(test=test, yaml_version=yaml_version)
 
@@ -165,7 +173,7 @@ class YamlTestCase(TestCase):
         Disabled steps are ignored.
         (Such tests will be marked as 'Steps Disabled' elsewhere)
 
-        UserPrompt are special cases that will prompt test operator for input.
+        UserPrompt, PromptWithResponse or VerifyVideoStream are special cases that will prompt test operator for input.
         """
         if yaml_step.disabled:
             test_engine_logger.info(
@@ -174,7 +182,7 @@ class YamlTestCase(TestCase):
             return
 
         step = TestStep(yaml_step.label)
-        if yaml_step.command == "UserPrompt":
+        if yaml_step.command in ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"]:
             step = ManualVerificationTestStep(
                 name=yaml_step.label,
                 verification=yaml_step.verification,
@@ -206,6 +214,23 @@ class YamlChipTestCase(YamlTestCase, ChipTest):
         self.test_steps = [TestStep("Start chip-tool test")]
         for step in self.yaml_test.steps:
             self._append_automated_test_step(step)
+
+
+class YamlCameraChipTestCase(YamlTestCase, ChipTest):
+    """Automated test cases using chip-camera-controller."""
+
+    server_type = ChipServerType.CHIP_CAMERA_CONTROLLER
+
+    def create_test_steps(self) -> None:
+        self.test_steps = [TestStep("Start chip-camera-controller test")]
+        for step in self.yaml_test.steps:
+            self._append_automated_test_step(step)
+
+
+class YamlCameraSemiAutomatedChipTestCase(YamlChipTestCase, ChipManualPromptTest):
+    """Camera Semi-Automated test cases, need special step for users to attach logs
+    for manual steps, so inheriting from ChipManualPromptTest.
+    """
 
 
 class YamlSemiAutomatedChipTestCase(YamlChipTestCase, ChipManualPromptTest):

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
@@ -28,8 +28,8 @@ from app.test_engine.models.test_case import CUSTOM_TEST_IDENTIFIER
 from ...chip.chip_server import ChipServerType
 from ...models.matter_test_models import MatterTestStep, MatterTestType
 from ...yaml_tests.models.chip_test import ChipManualPromptTest, ChipTest
-from .yaml_test_models import YamlTest
 from .test_suite import SuiteType
+from .yaml_test_models import YamlTest
 
 # Custom type variable used to annotate the factory method in YamlTestCase.
 T = TypeVar("T", bound="YamlTestCase")
@@ -173,7 +173,8 @@ class YamlTestCase(TestCase):
         Disabled steps are ignored.
         (Such tests will be marked as 'Steps Disabled' elsewhere)
 
-        UserPrompt, PromptWithResponse or VerifyVideoStream are special cases that will prompt test operator for input.
+        UserPrompt, PromptWithResponse or VerifyVideoStream are special cases that will
+        prompt test operator for input.
         """
         if yaml_step.disabled:
             test_engine_logger.info(
@@ -182,7 +183,11 @@ class YamlTestCase(TestCase):
             return
 
         step = TestStep(yaml_step.label)
-        if yaml_step.command in ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"]:
+        if yaml_step.command in [
+            "UserPrompt",
+            "PromptWithResponse",
+            "VerifyVideoStream",
+        ]:
             step = ManualVerificationTestStep(
                 name=yaml_step.label,
                 verification=yaml_step.verification,

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
@@ -28,6 +28,7 @@ from app.test_engine.models.test_case import CUSTOM_TEST_IDENTIFIER
 from ...chip.chip_server import ChipServerType
 from ...models.matter_test_models import MatterTestStep, MatterTestType
 from ...yaml_tests.models.chip_test import ChipManualPromptTest, ChipTest
+from .constants.yaml_constants import USER_ACTIONS
 from .test_suite import SuiteType
 from .yaml_test_models import YamlTest
 
@@ -183,11 +184,7 @@ class YamlTestCase(TestCase):
             return
 
         step = TestStep(yaml_step.label)
-        if yaml_step.command in [
-            "UserPrompt",
-            "PromptWithResponse",
-            "VerifyVideoStream",
-        ]:
+        if yaml_step.command in USER_ACTIONS:
             step = ManualVerificationTestStep(
                 name=yaml_step.label,
                 verification=yaml_step.verification,

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_declarations.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_declarations.py
@@ -26,6 +26,7 @@ from ...models.sdk_test_folder import SDKTestFolder
 from .test_case import YamlTestCase
 from .test_suite import SuiteType, YamlTestSuite
 from .yaml_test_models import YamlTest
+from typing import Optional
 
 
 class YamlCollectionDeclaration(TestCollectionDeclaration):
@@ -53,11 +54,13 @@ class YamlCaseDeclaration(TestCaseDeclaration):
     """Direct initialization for YAML Test Case."""
 
     class_ref: Type[YamlTestCase]
+    suite_type: Optional[SuiteType] = None
 
     def __init__(self, test: YamlTest, yaml_version: str) -> None:
         super().__init__(
             YamlTestCase.class_factory(test=test, yaml_version=yaml_version)
         )
+        self.suite_type = test.suite_type
 
     @property
     def test_type(self) -> MatterTestType:

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_declarations.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_declarations.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Type
+from typing import Optional, Type
 
 from app.test_engine.models.test_declarations import (
     TestCaseDeclaration,
@@ -26,7 +26,6 @@ from ...models.sdk_test_folder import SDKTestFolder
 from .test_case import YamlTestCase
 from .test_suite import SuiteType, YamlTestSuite
 from .yaml_test_models import YamlTest
-from typing import Optional
 
 
 class YamlCollectionDeclaration(TestCollectionDeclaration):

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_suite.py
@@ -32,6 +32,7 @@ class SuiteType(Enum):
     SIMULATED = 1
     AUTOMATED = 2
     MANUAL = 3
+    CAMERA_AUTOMATED = 4
 
 
 # Custom Type variable used to annotate the factory methods of classmethod.
@@ -69,6 +70,8 @@ class YamlTestSuite(TestSuite):
             suite_class = ManualYamlTestSuite
         elif suite_type == SuiteType.SIMULATED:
             suite_class = SimulatedYamlTestSuite
+        elif suite_type == SuiteType.CAMERA_AUTOMATED:
+            suite_class = ChipCameraYamlTestSuite
         elif suite_type == SuiteType.AUTOMATED:
             suite_class = ChipYamlTestSuite
 
@@ -108,6 +111,16 @@ class ChipYamlTestSuite(YamlTestSuite, ChipSuite):
 
     async def setup(self) -> None:
         """Due top multi inheritance, we need to call setup on both super classes."""
+        await YamlTestSuite.setup(self)
+        await ChipSuite.setup(self)
+
+
+class ChipCameraYamlTestSuite(YamlTestSuite, ChipSuite):
+    server_type = ChipServerType.CHIP_CAMERA_CONTROLLER
+
+    async def setup(self) -> None:
+        """Due top multi inheritance, we need to call setup on both super classes."""
+        self.server_type = ChipServerType.CHIP_CAMERA_CONTROLLER
         await YamlTestSuite.setup(self)
         await ChipSuite.setup(self)
 

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_models.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_models.py
@@ -13,14 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any
+from typing import Any, Optional
 
 from pydantic_yaml import YamlModelMixin
 
 from ...models.matter_test_models import MatterTest
-
 from .test_suite import SuiteType
-from typing import Optional
 
 ###
 # This file declares YAML models that are used to parse the YAML Test Cases.
@@ -29,5 +27,6 @@ from typing import Optional
 
 class YamlTest(YamlModelMixin, MatterTest):
     suite_type: Optional[SuiteType] = None
+
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(steps=kwargs["tests"], **kwargs)

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_models.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_models.py
@@ -19,11 +19,15 @@ from pydantic_yaml import YamlModelMixin
 
 from ...models.matter_test_models import MatterTest
 
+from .test_suite import SuiteType
+from typing import Optional
+
 ###
 # This file declares YAML models that are used to parse the YAML Test Cases.
 ###
 
 
 class YamlTest(YamlModelMixin, MatterTest):
+    suite_type: Optional[SuiteType] = None
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(steps=kwargs["tests"], **kwargs)

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
@@ -24,6 +24,7 @@ from .constants.yaml_constants import USER_ACTIONS
 from .test_suite import SuiteType
 from .yaml_test_models import YamlTest
 
+
 class YamlParserException(Exception):
     """Raised when an error occurs during the parser of yaml file."""
 
@@ -62,10 +63,7 @@ def _test_type(test: YamlTest) -> tuple[MatterTestType, SuiteType]:
 
     # if any step has a UserPrompt, PromptWithResponse or VerifyVideoStream command,
     # categorize as semi-automated
-    if any(
-        s.command in USER_ACTIONS
-        for s in steps
-    ):
+    if any(s.command in USER_ACTIONS for s in steps):
         if re.search(camera_test_pattern, test.name):
             return MatterTestType.SEMI_AUTOMATED, SuiteType.CAMERA_AUTOMATED
         else:

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
@@ -13,15 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import re
 from pathlib import Path
 
 from loguru import logger
 from pydantic import ValidationError
 
 from ...models.matter_test_models import MatterTestType
-from .yaml_test_models import YamlTest
 from .test_suite import SuiteType
-import re
+from .yaml_test_models import YamlTest
 
 
 class YamlParserException(Exception):
@@ -60,8 +60,12 @@ def _get_types(test: YamlTest) -> tuple[MatterTestType, SuiteType]:
     if all(s.disabled is True for s in steps):
         return MatterTestType.MANUAL, SuiteType.MANUAL
 
-    # if any step has a UserPrompt, PromptWithResponse or VerifyVideoStream command, categorize as semi-automated
-    if any(s.command in ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"] for s in steps):
+    # if any step has a UserPrompt, PromptWithResponse or VerifyVideoStream command,
+    # categorize as semi-automated
+    if any(
+        s.command in ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"]
+        for s in steps
+    ):
         if re.search(camera_test_pattern, test.name):
             return MatterTestType.SEMI_AUTOMATED, SuiteType.CAMERA_AUTOMATED
         else:
@@ -72,7 +76,8 @@ def _get_types(test: YamlTest) -> tuple[MatterTestType, SuiteType]:
     if re.search(camera_test_pattern, test.name):
         return MatterTestType.AUTOMATED, SuiteType.CAMERA_AUTOMATED
     else:
-        return MatterTestType.AUTOMATED, SuiteType.AUTOMATED    
+        return MatterTestType.AUTOMATED, SuiteType.AUTOMATED
+
 
 def parse_yaml_test(path: Path) -> YamlTest:
     """Parse a single YAML file into YamlTest model.

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
@@ -20,9 +20,9 @@ from loguru import logger
 from pydantic import ValidationError
 
 from ...models.matter_test_models import MatterTestType
+from .constants.yaml_constants import USER_ACTIONS
 from .test_suite import SuiteType
 from .yaml_test_models import YamlTest
-
 
 class YamlParserException(Exception):
     """Raised when an error occurs during the parser of yaml file."""
@@ -63,7 +63,7 @@ def _test_type(test: YamlTest) -> tuple[MatterTestType, SuiteType]:
     # if any step has a UserPrompt, PromptWithResponse or VerifyVideoStream command,
     # categorize as semi-automated
     if any(
-        s.command in ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"]
+        s.command in USER_ACTIONS
         for s in steps
     ):
         if re.search(camera_test_pattern, test.name):

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
@@ -28,8 +28,8 @@ class YamlParserException(Exception):
     """Raised when an error occurs during the parser of yaml file."""
 
 
-def _get_types(test: YamlTest) -> tuple[MatterTestType, SuiteType]:
-    """Determine the type of a test based on the parsed yaml.
+def _test_type(test: YamlTest) -> tuple[MatterTestType, SuiteType]:
+    """Determine the type of a test and test suite based on the parsed yaml.
 
     This is mainly determined by the number of disabled test steps.
 
@@ -89,7 +89,7 @@ def parse_yaml_test(path: Path) -> YamlTest:
             yaml_str = file.read()
             test = YamlTest.parse_raw(yaml_str, proto="yaml")
             test.path = path
-            test_type, suite_type = _get_types(test)
+            test_type, suite_type = _test_type(test)
             test.type = test_type
             test.suite_type = suite_type
         except ValidationError as e:

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
@@ -20,13 +20,15 @@ from pydantic import ValidationError
 
 from ...models.matter_test_models import MatterTestType
 from .yaml_test_models import YamlTest
+from .test_suite import SuiteType
+import re
 
 
 class YamlParserException(Exception):
     """Raised when an error occurs during the parser of yaml file."""
 
 
-def _test_type(test: YamlTest) -> MatterTestType:
+def _get_types(test: YamlTest) -> tuple[MatterTestType, SuiteType]:
     """Determine the type of a test based on the parsed yaml.
 
     This is mainly determined by the number of disabled test steps.
@@ -35,28 +37,42 @@ def _test_type(test: YamlTest) -> MatterTestType:
         test (YamlTest): parsed yaml model
 
     Returns:
-        TestType:
-            - Manual: All steps disabled
-            - Semi-Automated: some steps are disabled
-            - Automated: no disabled steps
-            - Simulated: Tests where file name have "Simulated"
+        tuple[MatterTestType, SuiteType]:
+            SuiteType:
+              - Manual: All steps disabled
+              - Semi-Automated: some steps are disabled
+              - Automated: no disabled steps
+              - Simulated: Tests where file name have "Simulated"
+            SuiteType:
+              -  SIMULATED: Simulated Test Suite
+              -  AUTOMATED: Automated Test Suite
+              -  MANUAL: Manual Test Suite
+              -  CAMERA_AUTOMATED: Automated Camera Test Suite
     """
+    camera_test_pattern = r"\[TC-WEBRTC-\d+\.\d+\]"
+
     if test.path is not None and "Simulated" in str(test.path):
-        return MatterTestType.SIMULATED
+        return MatterTestType.SIMULATED, SuiteType.SIMULATED
 
     steps = test.steps
 
     # If all disabled:
     if all(s.disabled is True for s in steps):
-        return MatterTestType.MANUAL
+        return MatterTestType.MANUAL, SuiteType.MANUAL
 
-    # if any step has a UserPrompt, categorize as semi-automated
-    if any(s.command == "UserPrompt" for s in steps):
-        return MatterTestType.SEMI_AUTOMATED
+    # if any step has a UserPrompt, PromptWithResponse or VerifyVideoStream command, categorize as semi-automated
+    if any(s.command in ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"] for s in steps):
+        if re.search(camera_test_pattern, test.name):
+            return MatterTestType.SEMI_AUTOMATED, SuiteType.CAMERA_AUTOMATED
+        else:
+            return MatterTestType.SEMI_AUTOMATED, SuiteType.AUTOMATED
 
-    # Otherwise Automated
-    return MatterTestType.AUTOMATED
-
+    # Otherwise
+    # If test case is camera related, then return SuiteType.CAMERA_AUTOMATED
+    if re.search(camera_test_pattern, test.name):
+        return MatterTestType.AUTOMATED, SuiteType.CAMERA_AUTOMATED
+    else:
+        return MatterTestType.AUTOMATED, SuiteType.AUTOMATED    
 
 def parse_yaml_test(path: Path) -> YamlTest:
     """Parse a single YAML file into YamlTest model.
@@ -68,7 +84,9 @@ def parse_yaml_test(path: Path) -> YamlTest:
             yaml_str = file.read()
             test = YamlTest.parse_raw(yaml_str, proto="yaml")
             test.path = path
-            test.type = _test_type(test)
+            test_type, suite_type = _get_types(test)
+            test.type = test_type
+            test.suite_type = suite_type
         except ValidationError as e:
             logger.error(str(e))
             raise YamlParserException(f"The YAML file {path} is invalid") from e

--- a/test_collections/matter/sdk_tests/support/yaml_tests/sdk_yaml_tests.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/sdk_yaml_tests.py
@@ -76,7 +76,7 @@ def _init_test_suites(yaml_version: str) -> dict[SuiteType, YamlSuiteDeclaration
             name="CameraAppTestSuite",
             suite_type=SuiteType.CAMERA_AUTOMATED,
             version=yaml_version,
-        )
+        ),
     }
 
 
@@ -110,9 +110,9 @@ def _parse_all_yaml(
                 suites[SuiteType.SIMULATED].add_test_case(test_case)
             else:
                 if test_case.suite_type == SuiteType.CAMERA_AUTOMATED:
-                  suites[SuiteType.CAMERA_AUTOMATED].add_test_case(test_case)
+                    suites[SuiteType.CAMERA_AUTOMATED].add_test_case(test_case)
                 else:
-                  suites[SuiteType.AUTOMATED].add_test_case(test_case)
+                    suites[SuiteType.AUTOMATED].add_test_case(test_case)
 
         except YamlParserException:
             # If an exception was raised during parse process, the yaml file will be

--- a/test_collections/matter/sdk_tests/support/yaml_tests/sdk_yaml_tests.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/sdk_yaml_tests.py
@@ -72,6 +72,11 @@ def _init_test_suites(yaml_version: str) -> dict[SuiteType, YamlSuiteDeclaration
             suite_type=SuiteType.SIMULATED,
             version=yaml_version,
         ),
+        SuiteType.CAMERA_AUTOMATED: YamlSuiteDeclaration(
+            name="CameraAppTestSuite",
+            suite_type=SuiteType.CAMERA_AUTOMATED,
+            version=yaml_version,
+        )
     }
 
 
@@ -85,10 +90,11 @@ def _parse_yaml_to_test_case_declaration(
 def _parse_all_yaml(
     yaml_files: list[Path], yaml_version: str
 ) -> list[YamlSuiteDeclaration]:
-    """Parse all yaml files and organize them in the 3 test suites:
+    """Parse all yaml files and organize them in the 4 test suites:
     - Automated and Semi-Automated using Chip-Tool
     - Simulated using Chip-App1
     - Manual
+    - Automated and Semi-Automated using chip-camera-controller
     """
     suites = _init_test_suites(yaml_version)
 
@@ -103,7 +109,11 @@ def _parse_all_yaml(
             elif test_case.test_type == MatterTestType.SIMULATED:
                 suites[SuiteType.SIMULATED].add_test_case(test_case)
             else:
-                suites[SuiteType.AUTOMATED].add_test_case(test_case)
+                if test_case.suite_type == SuiteType.CAMERA_AUTOMATED:
+                  suites[SuiteType.CAMERA_AUTOMATED].add_test_case(test_case)
+                else:
+                  suites[SuiteType.AUTOMATED].add_test_case(test_case)
+
         except YamlParserException:
             # If an exception was raised during parse process, the yaml file will be
             # ignored and the loop will continue with the next yaml file


### PR DESCRIPTION
#### Problem
* For the Camera Controller
* Add functionality to use camera-controller only for camera app test cases. 
* The test cases in FirstChipToolSuite are always executed with chip-tool.
* The camera test cases should either run with camera-controller with the separate test suite within Yaml meant for camera test cases only.

#### Change overview
* This PR adds a new Test Suite CameraAppTestSuite to test Matter Camera automated TCs only with chip-camera-controller.
* The FirstChipToolSuite test suite in TH, which is used to run automated and semi-automated test cases, only runs the test cases using chip-tool.
* Since the Camera/WebRTC TCs require chip-camera-controller to run the test cases, it cannot be clubbed with the existing FirstChipToolSuite(also TH allows running multiple test cases in suite at once). Hence a new test suite is required for Camera/WebRTC TCs alone.

#### Testing
* Excute TestHarness and check WebRTC Requestor/Provider operations