### PR TITLE
[Camera] Update backend to allow python testing framework to invoke perform video stream verification

### DIFF
--- a/app/constants/websockets_constants.py
+++ b/app/constants/websockets_constants.py
@@ -21,6 +21,9 @@ INVALID_JSON_ERROR_STR = "The message received is not a valid JSON object"
 MISSING_TYPE_ERROR_STR = "The message is missing a type key"
 NO_HANDLER_FOR_MSG_ERROR_STR = "There is no handler registered for this message type"
 
+UDP_SOCKET_PORT = 5000
+UDP_SOCKET_INTERFACE = "0.0.0.0"
+
 
 # Enum Keys for different types of messages currently supported by the tool
 class MessageTypeEnum(str, Enum):

--- a/app/constants/websockets_constants.py
+++ b/app/constants/websockets_constants.py
@@ -33,6 +33,7 @@ class MessageTypeEnum(str, Enum):
     TIME_OUT_NOTIFICATION = "time_out_notification"
     TEST_LOG_RECORDS = "test_log_records"
     INVALID_MESSAGE = "invalid_message"
+    STREAM_VERIFICATION_REQUEST = "stream_verification_request"
 
 
 # Enum keys used with messages at the top level

--- a/app/constants/websockets_constants.py
+++ b/app/constants/websockets_constants.py
@@ -37,6 +37,7 @@ class MessageTypeEnum(str, Enum):
     TEST_LOG_RECORDS = "test_log_records"
     INVALID_MESSAGE = "invalid_message"
     STREAM_VERIFICATION_REQUEST = "stream_verification_request"
+    IMAGE_VERIFICATION_REQUEST = "image_verification_request"
 
 
 # Enum keys used with messages at the top level

--- a/app/test_engine/models/manual_test_case.py
+++ b/app/test_engine/models/manual_test_case.py
@@ -25,7 +25,9 @@ from app.user_prompt_support import (
     UploadFile,
     UploadFilePromptRequest,
     UserPromptSupport,
+    TextInputPromptRequest,
     UserResponseStatusEnum,
+    StreamVerificationPromptRequest
 )
 
 from .test_case import TestCase
@@ -51,6 +53,49 @@ class ManualVerificationTestStep(TestStep, UserPromptSupport):
     def __init__(self, name: str, verification: Optional[str] = None) -> None:
         super().__init__(name=name)
         self.verification = verification
+    
+    async def prompt_verification_step_with_response(self, textInputPrompt: TextInputPromptRequest)->str:
+        """Prompt user to verify the video stream.
+
+        Returns:
+            str: string response received as user input
+        """
+        prompt_response = await self.invoke_prompt_and_get_str_response(textInputPrompt)
+        return prompt_response
+
+    async def prompt_stream_verification_step(self) -> bool:
+        """Prompt user to verify the video stream.
+
+        Raises:
+            ValueError: When receiving an unexpected response
+
+        Returns:
+            bool: False if user responds Failed
+        """
+        prompt = self.name
+        if self.verification is not None:
+            prompt += f"\n\n{self.verification}"
+
+        options = {
+            "PASS": PromptOptions.PASS,
+            "FAIL": PromptOptions.FAIL,
+        }
+        prompt_request = StreamVerificationPromptRequest(
+            prompt=prompt, options=options, timeout=OUTCOME_TIMEOUT_S
+        )
+        prompt_response = await self.send_prompt_request(prompt_request)
+        self.__evaluate_user_response_for_errors(prompt_response)
+
+        if prompt_response.response == PromptOptions.FAIL:
+            self.append_failure("User stated manual step FAILED.")
+            return False
+        elif prompt_response.response == PromptOptions.PASS:
+            logger.info("User stated this manual step PASSED.")
+            return True
+        else:
+            raise ValueError(
+                f"Received unknown prompt option: {prompt_response.response}"
+            )
 
     async def prompt_verification_step(self) -> bool:
         """Sends a prompt request to present instructions and get outcome from user.

--- a/app/test_engine/models/manual_test_case.py
+++ b/app/test_engine/models/manual_test_case.py
@@ -22,12 +22,12 @@ from app.test_engine.logger import test_engine_logger as logger
 from app.user_prompt_support import (
     OptionsSelectPromptRequest,
     PromptResponse,
+    StreamVerificationPromptRequest,
+    TextInputPromptRequest,
     UploadFile,
     UploadFilePromptRequest,
     UserPromptSupport,
-    TextInputPromptRequest,
     UserResponseStatusEnum,
-    StreamVerificationPromptRequest
 )
 
 from .test_case import TestCase
@@ -53,8 +53,10 @@ class ManualVerificationTestStep(TestStep, UserPromptSupport):
     def __init__(self, name: str, verification: Optional[str] = None) -> None:
         super().__init__(name=name)
         self.verification = verification
-    
-    async def prompt_verification_step_with_response(self, textInputPrompt: TextInputPromptRequest)->str:
+
+    async def prompt_verification_step_with_response(
+        self, textInputPrompt: TextInputPromptRequest
+    ) -> str:
         """Prompt user to verify the video stream.
 
         Returns:

--- a/app/user_prompt_support/__init__.py
+++ b/app/user_prompt_support/__init__.py
@@ -18,6 +18,7 @@ from .prompt_request import (
     OptionsSelectPromptRequest,
     PromptRequest,
     StreamVerificationPromptRequest,
+    ImageVerificationPromptRequest,
     TextInputPromptRequest,
     UploadFilePromptRequest,
 )

--- a/app/user_prompt_support/__init__.py
+++ b/app/user_prompt_support/__init__.py
@@ -19,6 +19,7 @@ from .prompt_request import (
     PromptRequest,
     TextInputPromptRequest,
     UploadFilePromptRequest,
+    StreamVerificationPromptRequest
 )
 from .prompt_response import PromptResponse
 from .uploaded_file_support import UploadedFileSupport, UploadFile

--- a/app/user_prompt_support/__init__.py
+++ b/app/user_prompt_support/__init__.py
@@ -17,9 +17,9 @@ from .constants import UserResponseStatusEnum
 from .prompt_request import (
     OptionsSelectPromptRequest,
     PromptRequest,
+    StreamVerificationPromptRequest,
     TextInputPromptRequest,
     UploadFilePromptRequest,
-    StreamVerificationPromptRequest
 )
 from .prompt_response import PromptResponse
 from .uploaded_file_support import UploadedFileSupport, UploadFile

--- a/app/user_prompt_support/__init__.py
+++ b/app/user_prompt_support/__init__.py
@@ -15,10 +15,10 @@
 #
 from .constants import UserResponseStatusEnum
 from .prompt_request import (
+    ImageVerificationPromptRequest,
     OptionsSelectPromptRequest,
     PromptRequest,
     StreamVerificationPromptRequest,
-    ImageVerificationPromptRequest,
     TextInputPromptRequest,
     UploadFilePromptRequest,
 )

--- a/app/user_prompt_support/prompt_request.py
+++ b/app/user_prompt_support/prompt_request.py
@@ -61,3 +61,8 @@ class MessagePromptRequest(PromptRequest):
     @property
     def messageType(self) -> MessageTypeEnum:
         return MessageTypeEnum.MESSAGE_REQUEST
+
+class StreamVerificationPromptRequest(OptionsSelectPromptRequest):
+    @property
+    def messageType(self) -> MessageTypeEnum:
+        return MessageTypeEnum.STREAM_VERIFICATION_REQUEST

--- a/app/user_prompt_support/prompt_request.py
+++ b/app/user_prompt_support/prompt_request.py
@@ -67,3 +67,11 @@ class StreamVerificationPromptRequest(OptionsSelectPromptRequest):
     @property
     def messageType(self) -> MessageTypeEnum:
         return MessageTypeEnum.STREAM_VERIFICATION_REQUEST
+
+
+class ImageVerificationPromptRequest(OptionsSelectPromptRequest):
+    image_hex_str: str
+
+    @property
+    def messageType(self) -> MessageTypeEnum:
+        return MessageTypeEnum.IMAGE_VERIFICATION_REQUEST

--- a/app/user_prompt_support/prompt_request.py
+++ b/app/user_prompt_support/prompt_request.py
@@ -62,6 +62,7 @@ class MessagePromptRequest(PromptRequest):
     def messageType(self) -> MessageTypeEnum:
         return MessageTypeEnum.MESSAGE_REQUEST
 
+
 class StreamVerificationPromptRequest(OptionsSelectPromptRequest):
     @property
     def messageType(self) -> MessageTypeEnum:

--- a/test_collections/matter/sdk_tests/support/chip/chip_server.py
+++ b/test_collections/matter/sdk_tests/support/chip/chip_server.py
@@ -34,6 +34,8 @@ from ..sdk_container import DOCKER_LOGS_PATH, DOCKER_PAA_CERTS_PATH, SDKContaine
 CHIP_TOOL_EXE = "./chip-tool"
 CHIP_TOOL_ARG_PAA_CERTS_PATH = "--paa-trust-store-path"
 
+#TODO: Use chip-camera-controller for camera tests.
+
 # Chip App Parameters
 CHIP_APP_EXE = "./chip-app1"
 

--- a/test_collections/matter/sdk_tests/support/chip/chip_server.py
+++ b/test_collections/matter/sdk_tests/support/chip/chip_server.py
@@ -34,7 +34,7 @@ from ..sdk_container import DOCKER_LOGS_PATH, DOCKER_PAA_CERTS_PATH, SDKContaine
 CHIP_TOOL_EXE = "./chip-tool"
 CHIP_TOOL_ARG_PAA_CERTS_PATH = "--paa-trust-store-path"
 
-#TODO: Use chip-camera-controller for camera tests.
+# TODO: Use chip-camera-controller for camera tests.
 
 # Chip App Parameters
 CHIP_APP_EXE = "./chip-app1"

--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
@@ -34,6 +34,7 @@ class SDKPythonTestResultEnum(str, Enum):
     STEP_UNKNOWN = "step_unknown"
     STEP_MANUAL = "step_manual"
     SHOW_PROMPT = "show_prompt"
+    SHOW_VIDEO_PROMPT = "show_video_prompt"
 
 
 class SDKPythonTestResultBase(BaseModel):
@@ -114,6 +115,11 @@ class SDKPythonTestResultShowPrompt(SDKPythonTestResultBase):
     msg: str
     placeholder: Optional[str]
     default_value: Optional[str]
+
+
+class SDKPythonTestResultShowVideoPrompt(SDKPythonTestResultBase):
+    type = SDKPythonTestResultEnum.SHOW_VIDEO_PROMPT
+    msg: str
 
 
 class SDKPythonTestRunnerHooks(TestRunnerHooks):
@@ -204,6 +210,9 @@ class SDKPythonTestRunnerHooks(TestRunnerHooks):
                 msg=msg, placeholder=placeholder, default_value=default_value
             )
         )
+
+    def show_video_prompt(self, msg: str) -> None:
+        self.results.put(SDKPythonTestResultShowVideoPrompt(msg=msg))
 
     def step_start_list(self) -> None:
         pass

--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
@@ -222,10 +222,8 @@ class SDKPythonTestRunnerHooks(TestRunnerHooks):
         self.results.put(SDKPythonTestResultShowVideoPrompt(msg=msg))
 
     def show_image_prompt(self, msg: str, img_hex_str: str) -> None:
-        self.results.put(SDKPythonTestResultShowImagePrompt(
-            msg=msg,
-            img_hex_str=img_hex_str
-        )
+        self.results.put(
+            SDKPythonTestResultShowImagePrompt(msg=msg, img_hex_str=img_hex_str)
         )
 
     def step_start_list(self) -> None:

--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
@@ -35,6 +35,7 @@ class SDKPythonTestResultEnum(str, Enum):
     STEP_MANUAL = "step_manual"
     SHOW_PROMPT = "show_prompt"
     SHOW_VIDEO_PROMPT = "show_video_prompt"
+    SHOW_IMAGE_PROMPT = "show_image_prompt"
 
 
 class SDKPythonTestResultBase(BaseModel):
@@ -120,6 +121,12 @@ class SDKPythonTestResultShowPrompt(SDKPythonTestResultBase):
 class SDKPythonTestResultShowVideoPrompt(SDKPythonTestResultBase):
     type = SDKPythonTestResultEnum.SHOW_VIDEO_PROMPT
     msg: str
+
+
+class SDKPythonTestResultShowImagePrompt(SDKPythonTestResultBase):
+    type = SDKPythonTestResultEnum.SHOW_IMAGE_PROMPT
+    msg: str
+    img_hex_str: str
 
 
 class SDKPythonTestRunnerHooks(TestRunnerHooks):
@@ -213,6 +220,13 @@ class SDKPythonTestRunnerHooks(TestRunnerHooks):
 
     def show_video_prompt(self, msg: str) -> None:
         self.results.put(SDKPythonTestResultShowVideoPrompt(msg=msg))
+
+    def show_image_prompt(self, msg: str, img_hex_str: str) -> None:
+        self.results.put(SDKPythonTestResultShowImagePrompt(
+            msg=msg,
+            img_hex_str=img_hex_str
+        )
+        )
 
     def step_start_list(self) -> None:
         pass

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -63,8 +63,8 @@ class PythonTestCaseError(Exception):
 
 
 class PromptOptions(IntEnum):
-    FAIL = 0
     PASS = 1
+    FAIL = 2
 
 
 class PythonTestCase(TestCase, UserPromptSupport):

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -30,6 +30,7 @@ from app.test_engine.models.test_case import CUSTOM_TEST_IDENTIFIER
 from app.user_prompt_support.prompt_request import (
     OptionsSelectPromptRequest,
     StreamVerificationPromptRequest,
+    ImageVerificationPromptRequest,
     TextInputPromptRequest,
 )
 from app.user_prompt_support.user_prompt_support import UserPromptSupport
@@ -175,6 +176,25 @@ class PythonTestCase(TestCase, UserPromptSupport):
         if self.test_socket and user_response.response_str:
             response = f"{user_response.response_str}\n".encode()
             self.test_socket._sock.sendall(response)  # type: ignore[attr-defined]
+
+    async def show_image_prompt(
+        self,
+        msg: str,
+        img_hex_str: str
+    ) -> None:
+        options = {
+            "PASS": PromptOptions.PASS,
+            "FAIL": PromptOptions.FAIL,
+        }
+        prompt_request = ImageVerificationPromptRequest(
+            prompt=msg, options=options, timeout=120, image_hex_str=img_hex_str
+        )
+
+        user_response = await self.send_prompt_request(prompt_request)
+
+        if self.test_socket and user_response.response_str:
+            response = f"{user_response.response_str}\n".encode()
+            self.test_socket._sock.sendall(response)
 
     @classmethod
     def pics(cls) -> set[str]:

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -28,9 +28,9 @@ from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestCase, TestStep
 from app.test_engine.models.test_case import CUSTOM_TEST_IDENTIFIER
 from app.user_prompt_support.prompt_request import (
+    ImageVerificationPromptRequest,
     OptionsSelectPromptRequest,
     StreamVerificationPromptRequest,
-    ImageVerificationPromptRequest,
     TextInputPromptRequest,
 )
 from app.user_prompt_support.user_prompt_support import UserPromptSupport

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_test.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_test.py
@@ -30,10 +30,14 @@ from app.test_engine.models.manual_test_case import (
     ManualLogUploadStep,
     ManualVerificationTestStep,
 )
-from app.user_prompt_support.prompt_request import MessagePromptRequest, PromptRequest, TextInputPromptRequest
+from app.user_prompt_support.prompt_request import (
+    MessagePromptRequest,
+    TextInputPromptRequest,
+)
 from app.user_prompt_support.uploaded_file_support import UploadFile
 from app.user_prompt_support.user_prompt_manager import user_prompt_manager
 from app.user_prompt_support.user_prompt_support import UserPromptSupport
+
 from ...chip.chip_server import ChipServerType
 from ...sdk_container import SDKContainer
 from ...yaml_tests.matter_yaml_runner import MatterYAMLRunner
@@ -170,7 +174,7 @@ class ChipTest(TestCase, UserPromptSupport, TestRunnerHooks, TestParserHooks):
     def step_unknown(self) -> None:
         self.__runned += 1
 
-    async def step_manual(self, request) -> None:
+    async def step_manual(self, request: TestStep) -> None:
         step = self.current_test_step
         if not isinstance(step, ManualVerificationTestStep):
             raise TestError(f"Unexpected user prompt found in test step: {step.name}")
@@ -178,7 +182,8 @@ class ChipTest(TestCase, UserPromptSupport, TestRunnerHooks, TestParserHooks):
         try:
             if request and request.command == "VerifyVideoStream":
                 await asyncio.wait_for(
-                    self.__prompt_stream_verification_manual_step(step), OUTCOME_TIMEOUT_S
+                    self.__prompt_stream_verification_manual_step(step),
+                    OUTCOME_TIMEOUT_S,
                 )
             else:
                 await asyncio.wait_for(
@@ -206,7 +211,7 @@ class ChipTest(TestCase, UserPromptSupport, TestRunnerHooks, TestParserHooks):
             timeout=EXTENDED_PROMPT_TIMEOUT_S,
             default_value=default_value,
             placeholder_text=placeholder,
-            regex_pattern=None
+            regex_pattern=None,
         )
         response = await self.__prompt_user_manual_step_with_response(step, userPrompt)
         if response is None:
@@ -214,7 +219,9 @@ class ChipTest(TestCase, UserPromptSupport, TestRunnerHooks, TestParserHooks):
         return response
 
     # Other methods
-    async def __prompt_user_manual_step_with_response(self, step: ManualVerificationTestStep, prompt: PromptRequest) -> str:
+    async def __prompt_user_manual_step_with_response(
+        self, step: ManualVerificationTestStep, prompt: TextInputPromptRequest
+    ) -> str:
         result = await step.prompt_verification_step_with_response(prompt)
 
         if not result:
@@ -228,11 +235,15 @@ class ChipTest(TestCase, UserPromptSupport, TestRunnerHooks, TestParserHooks):
         if not result:
             self.current_test_step.append_failure("Manual Test Step Failure.")
 
-    async def __prompt_stream_verification_manual_step(self, step: ManualVerificationTestStep) -> None:
+    async def __prompt_stream_verification_manual_step(
+        self, step: ManualVerificationTestStep
+    ) -> None:
         result = await step.prompt_stream_verification_step()
 
         if not result:
-            self.current_test_step.append_failure("Video Verification Test Step Failure.")
+            self.current_test_step.append_failure(
+                "Video Verification Test Step Failure."
+            )
 
     def __report_failures(self, logger: Any, request: TestStep, received: Any) -> None:
         """

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
@@ -165,7 +165,7 @@ class YamlTestCase(TestCase):
         Disabled steps are ignored.
         (Such tests will be marked as 'Steps Disabled' elsewhere)
 
-        UserPrompt are special cases that will prompt test operator for input.
+        UserPrompt, PromptWithResponse or VerifyVideoStream are special cases that will prompt test operator for input.
         """
         if yaml_step.disabled:
             test_engine_logger.info(
@@ -174,7 +174,7 @@ class YamlTestCase(TestCase):
             return
 
         step = TestStep(yaml_step.label)
-        if yaml_step.command == "UserPrompt":
+        if yaml_step.command in ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"]:
             step = ManualVerificationTestStep(
                 name=yaml_step.label,
                 verification=yaml_step.verification,

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
@@ -165,7 +165,8 @@ class YamlTestCase(TestCase):
         Disabled steps are ignored.
         (Such tests will be marked as 'Steps Disabled' elsewhere)
 
-        UserPrompt, PromptWithResponse or VerifyVideoStream are special cases that will prompt test operator for input.
+        UserPrompt, PromptWithResponse or VerifyVideoStream are special cases that will
+        prompt test operator for input.
         """
         if yaml_step.disabled:
             test_engine_logger.info(
@@ -174,7 +175,11 @@ class YamlTestCase(TestCase):
             return
 
         step = TestStep(yaml_step.label)
-        if yaml_step.command in ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"]:
+        if yaml_step.command in [
+            "UserPrompt",
+            "PromptWithResponse",
+            "VerifyVideoStream",
+        ]:
             step = ManualVerificationTestStep(
                 name=yaml_step.label,
                 verification=yaml_step.verification,

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
@@ -50,8 +50,12 @@ def _test_type(test: YamlTest) -> MatterTestType:
     if all(s.disabled is True for s in steps):
         return MatterTestType.MANUAL
 
-    # if any step has a UserPrompt, PromptWithResponse or VerifyVideoStream command, categorize as semi-automated
-    if any(s.command in ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"] for s in steps):
+    # if any step has a UserPrompt, PromptWithResponse or VerifyVideoStream command,
+    # categorize as semi-automated
+    if any(
+        s.command in ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"]
+        for s in steps
+    ):
         return MatterTestType.SEMI_AUTOMATED
 
     # Otherwise Automated

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/yaml_test_parser.py
@@ -50,8 +50,8 @@ def _test_type(test: YamlTest) -> MatterTestType:
     if all(s.disabled is True for s in steps):
         return MatterTestType.MANUAL
 
-    # if any step has a UserPrompt, categorize as semi-automated
-    if any(s.command == "UserPrompt" for s in steps):
+    # if any step has a UserPrompt, PromptWithResponse or VerifyVideoStream command, categorize as semi-automated
+    if any(s.command in ["UserPrompt", "PromptWithResponse", "VerifyVideoStream"] for s in steps):
         return MatterTestType.SEMI_AUTOMATED
 
     # Otherwise Automated


### PR DESCRIPTION
#### Problem
* For the Camera Controller
* This PR adds a hook to allow the python testing framework to invoke Video verification prompt.
* This is required to validate WebRTC based python TCs.

#### Change overview
* Adds support to run camera app yaml test cases using camera-controller 
* Adds a hook for the python test framework to invoke video verification

#### Testing
* Excute TestHarness and check WebRTC Requestor/Provider operations
