### PR TITLE
[FIX] Adding Timeout To Server Exit

### DIFF
--- a/test_collections/matter/sdk_tests/support/chip/chip_server.py
+++ b/test_collections/matter/sdk_tests/support/chip/chip_server.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from random import randrange
-from time import time
+from time import sleep, time
 from typing import Generator, Optional, Union, cast
 
 import loguru
@@ -177,7 +177,8 @@ class ChipServer(metaclass=Singleton):
         timeout = time() + CHIP_SERVER_EXIT_TIMEOUT
         exit_code = self.sdk_container.exec_exit_code(self.__chip_server_id)
 
-        while time() <= timeout:
+        while exit_code is not None and time() <= timeout:
+            sleep(CHIP_SERVER_EXIT_TIMEOUT / 5)
             exit_code = self.sdk_container.exec_exit_code(self.__chip_server_id)
 
         if exit_code is None:

--- a/test_collections/matter/sdk_tests/support/chip/chip_server.py
+++ b/test_collections/matter/sdk_tests/support/chip/chip_server.py
@@ -19,6 +19,7 @@ from datetime import datetime
 from enum import Enum
 from pathlib import Path
 from random import randrange
+from time import time
 from typing import Generator, Optional, Union, cast
 
 import loguru
@@ -37,6 +38,8 @@ CHIP_TOOL_ARG_PAA_CERTS_PATH = "--paa-trust-store-path"
 # Chip App Parameters
 CHIP_APP_EXE = "./chip-app1"
 
+CHIP_SERVER_EXIT_TIMEOUT = 30  # seconds
+
 
 class ChipServerStartingError(Exception):
     """Raised when we fail to start the chip server"""
@@ -44,6 +47,10 @@ class ChipServerStartingError(Exception):
 
 class UnsupportedChipServerType(Exception):
     """Raised when we attempt to use a chip server, but the type is not supported"""
+
+
+class ChipServerExitError(Exception):
+    """Raised when a timout happens when trying to exit the chip server"""
 
 
 class ChipServerType(str, Enum):
@@ -165,9 +172,16 @@ class ChipServer(metaclass=Singleton):
             )
             return None
 
+        # A given timeout in seconds is provided to wait for the chip server exit code
+        # In case the timeout is triggered, the process continues after logging
+        timeout = time() + CHIP_SERVER_EXIT_TIMEOUT
         exit_code = self.sdk_container.exec_exit_code(self.__chip_server_id)
-        while exit_code is None:
+
+        while time() <= timeout:
             exit_code = self.sdk_container.exec_exit_code(self.__chip_server_id)
+
+        if exit_code is None:
+            raise ChipServerExitError("Timeout while waiting to exit chip server")
 
         return exit_code
 

--- a/test_collections/matter/sdk_tests/support/chip/chip_server.py
+++ b/test_collections/matter/sdk_tests/support/chip/chip_server.py
@@ -50,7 +50,7 @@ class UnsupportedChipServerType(Exception):
 
 
 class ChipServerExitError(Exception):
-    """Raised when a timout happens when trying to exit the chip server"""
+    """Raised when a timout happens while trying to exit the chip server"""
 
 
 class ChipServerType(str, Enum):

--- a/test_collections/matter/sdk_tests/support/chip/chip_server.py
+++ b/test_collections/matter/sdk_tests/support/chip/chip_server.py
@@ -173,12 +173,18 @@ class ChipServer(metaclass=Singleton):
             return None
 
         # A given timeout in seconds is provided to wait for the chip server exit code
+        # To avoid excessive attempts, we verify 5 times over the timeout value provided
         # In case the timeout is triggered, the process continues after logging
+        sleeping_seconds = CHIP_SERVER_EXIT_TIMEOUT / 5
         timeout = time() + CHIP_SERVER_EXIT_TIMEOUT
         exit_code = self.sdk_container.exec_exit_code(self.__chip_server_id)
 
-        while exit_code is not None and time() <= timeout:
-            sleep(CHIP_SERVER_EXIT_TIMEOUT / 5)
+        while exit_code is None and time() <= timeout:
+            self.logger.info(
+                f"Sleeping for {sleeping_seconds} seconds before verifying chip server "
+                "exit code again."
+            )
+            sleep(sleeping_seconds)
             exit_code = self.sdk_container.exec_exit_code(self.__chip_server_id)
 
         if exit_code is None:


### PR DESCRIPTION
This change adds a fail-safe mechanism by including a timeout when stopping the chip server, after a test execution of YAML tests.

Currently the code uses a while loop that waits only to the exit code return for killing the chip server process in the SDK.
That may never happen, so this PRs included a timeout logic for the chip server exit.