### PR TITLE
Added logs for applicable test cases

### DIFF
--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -101,6 +101,7 @@ def __handle_platform_certification(
         # TODO Need to fetch platform-test.json from repo
         # Issue: https://github.com/project-chip/certification-tool/issues/571
         platform_tests = __read_platform_test_cases("platform-test.json")
+        logger.info(f"Listing platform-test.json test cases: {sorted(platform_tests)}")
 
         # Only add platform tests that don't already exist with any suffix
         for test in platform_tests:
@@ -115,13 +116,26 @@ def __handle_platform_certification(
         # Create a new list with dmp_test_skip plus the same tests with
         # " (Semi-automated)" and " (Steps Disabled)" suffixes
         # These suffixes may be added during the test parsing process
+        logger.info(f"Listing dmp_test_skip test cases: {sorted(dmp_test_skip)}")
         extended_skip_list = dmp_test_skip.copy()
         for test in dmp_test_skip:
             extended_skip_list.append(f"{test} (Semi-automated)")
             extended_skip_list.append(f"{test} (Steps Disabled)")
 
+        # Make a copy of applicable test cases before removing for logging purposes
+        applicable_tests_combined_original = applicable_tests_combined.copy()
+
         # Remove tests from the extended list from applicable_tests_combined
         applicable_tests_combined.difference_update(extended_skip_list)
+
+        # Logging the removed test cases due to DMP file content
+        removed_tests = applicable_tests_combined_original - applicable_tests_combined
+        logger.info(f"Listing test cases removed due to dmp: {sorted(removed_tests)}")
+
+    logger.info(
+        "Listing applicable tests cases "
+        f"for execution: {sorted(applicable_tests_combined)}"
+    )
 
     return applicable_tests_combined
 


### PR DESCRIPTION
### What Changed
Added logs while TH is performing the logic to retrieves the eligible test cases.

### Related Issue
https://github.com/project-chip/certification-tool/issues/586

### Testing

- Logging DMP execution:
INFO     | 2025-05-05 13:58:43.233 | app.pics_applicable_test_cases:__handle_platform_certification:119 | Listing dmp_test_skip test cases: ['DLOG-2.1', 'TC-ACE-1.1', 'TC-ACE-1.2', 'TC-ACE-1.3', 'TC-ACE-1.4', 'TC-ACE-1.5', 'TC-ACE-1.6', 'TC-ACL-2.1', 'TC-ACL-2.10', 'TC-ACL-2.3', 'TC-ACL-2.4', 'TC-ACL-2.5', 'TC-ACL-2.6', 'TC-ACL-2.7', 'TC-ACL-2.8', 'TC-ACL-2.9', 'TC-BDX-1.2', 'TC-BDX-1.4', 'TC-BDX-2.1', 'TC-BDX-2.2', 'TC-CADMIN-1.10', 'TC-CADMIN-1.11', 'TC-CADMIN-1.13', 'TC-CADMIN-1.14', 'TC-CADMIN-1.15', 'TC-CADMIN-1.16', 'TC-CADMIN-1.19', 'TC-CADMIN-1.20', 'TC-CADMIN-1.21', 'TC-CADMIN-1.22', 'TC-CADMIN-1.23', 'TC-CADMIN-1.24', 'TC-CADMIN-1.25', 'TC-CADMIN-1.26', 'TC-CADMIN-1.3', 'TC-CADMIN-1.4', 'TC-CADMIN-1.5', 'TC-CADMIN-1.6', 'TC-CADMIN-1.9', 'TC-CGEN-2.1', 'TC-CGEN-2.2', 'TC-CGEN-2.4', 'TC-CNET-1.3', 'TC-CNET-1.4', 'TC-CNET-4.1', 'TC-CNET-4.10', 'TC-CNET-4.11', 'TC-CNET-4.12', 'TC-CNET-4.13', 'TC-CNET-4.14', 'TC-CNET-4.15', 'TC-CNET-4.16', 'TC-CNET-4.2', 'TC-CNET-4.20', 'TC-CNET-4.3', 'TC-CNET-4.4', 'TC-CNET-4.5', 'TC-CNET-4.6', 'TC-CNET-4.9', 'TC-DA-1.2', 'TC-DA-1.5', 'TC-DD-3.1', 'TC-DD-3.19', 'TC-DD-3.2', 'TC-DD-3.3', 'TC-DGGEN-2.1', 'TC-DGGEN-2.2', 'TC-DGGEN-2.3', 'TC-DGGEN-2.4', 'TC-DGGEN-3.1', 'TC-DGGEN-3.2', 'TC-DGSW-2.1', 'TC-DGSW-2.2', 'TC-DGSW-2.3', 'TC-DGWIFI-2.1', 'TC-DGWIFI-2.2', 'TC-DGWIFI-2.3', 'TC-G-2.1', 'TC-G-2.2', 'TC-G-2.3', 'TC-G-2.4', 'TC-GRPKEY-2.1', 'TC-GRPKEY-2.2', 'TC-GRPKEY-5.4', 'TC-ICDB-1.1', 'TC-ICDB-1.3', 'TC-ICDB-2.1', 'TC-ICDB-2.2', 'TC-ICDB-2.3', 'TC-ICDB-2.4', 'TC-ICDB-2.5', 'TC-ICDM-2.1', 'TC-ICDM-3.1', 'TC-ICDM-3.2', 'TC-ICDM-3.3', 'TC-ICDM-3.4', 'TC-ICDM-4.1', 'TC-ICDM-5.1', 'TC-ICDM-5.2', 'TC-IDM-1.2', 'TC-IDM-1.4', 'TC-IDM-2.2', 'TC-IDM-3.2', 'TC-IDM-4.4', 'TC-IDM-5.2', 'TC-IDM-7.1', 'TC-IDM-8.1', 'TC-OPCREDS-3.1', 'TC-OPCREDS-3.2', 'TC-OPCREDS-3.4', 'TC-OPCREDS-3.5', 'TC-OPCREDS-3.6', 'TC-OPCREDS-3.7', 'TC-SC-3.6', 'TC-SC-4.7', 'TC-SC-4.9', 'TC-SC-5.1', 'TC-SC-5.2', 'TC-SU-2.2', 'TC-SU-2.5', 'TC-SU-2.6', 'TC-SU-2.7', 'TC-SU-4.1']
INFO     | 2025-05-05 13:58:43.234 | app.pics_applicable_test_cases:__handle_platform_certification:133 | Listing test cases removed due to dmp: ['TC-ACE-1.1', 'TC-ACE-1.2', 'TC-ACE-1.3', 'TC-ACE-1.4', 'TC-ACE-1.5', 'TC-ACE-1.6', 'TC-ACL-2.1', 'TC-ACL-2.10 (Semi-automated)', 'TC-ACL-2.3', 'TC-ACL-2.4', 'TC-ACL-2.5', 'TC-ACL-2.6', 'TC-ACL-2.7', 'TC-ACL-2.8', 'TC-ACL-2.9 (Semi-automated)', 'TC-BDX-1.2', 'TC-BDX-2.2', 'TC-CADMIN-1.11', 'TC-CADMIN-1.15', 'TC-CADMIN-1.19', 'TC-CADMIN-1.22', 'TC-CADMIN-1.24', 'TC-CADMIN-1.25', 'TC-CADMIN-1.3', 'TC-CADMIN-1.4', 'TC-CADMIN-1.5', 'TC-CADMIN-1.9', 'TC-CGEN-2.1', 'TC-CGEN-2.2', 'TC-CGEN-2.4', 'TC-CNET-1.4', 'TC-CNET-4.1 (Semi-automated)', 'TC-CNET-4.11 (Semi-automated)', 'TC-CNET-4.13', 'TC-CNET-4.15 (Semi-automated)', 'TC-CNET-4.4', 'TC-CNET-4.5', 'TC-CNET-4.9 (Semi-automated)', 'TC-DA-1.2', 'TC-DA-1.5', 'TC-DD-3.1', 'TC-DD-3.19', 'TC-DGGEN-2.1 (Semi-automated)', 'TC-DGGEN-2.2', 'TC-DGGEN-2.3', 'TC-DGGEN-2.4', 'TC-DGGEN-3.1', 'TC-DGGEN-3.2', 'TC-DGSW-2.1', 'TC-DGSW-2.2', 'TC-DGSW-2.3', 'TC-DGWIFI-2.1', 'TC-DGWIFI-2.2', 'TC-DGWIFI-2.3', 'TC-G-2.1', 'TC-G-2.2', 'TC-G-2.3', 'TC-GRPKEY-2.1', 'TC-GRPKEY-2.2 (Semi-automated)', 'TC-GRPKEY-5.4', 'TC-ICDM-2.1', 'TC-IDM-1.2', 'TC-IDM-1.4', 'TC-IDM-2.2', 'TC-IDM-3.2', 'TC-IDM-5.2', 'TC-IDM-7.1', 'TC-IDM-8.1', 'TC-OPCREDS-3.1', 'TC-OPCREDS-3.2', 'TC-OPCREDS-3.4', 'TC-OPCREDS-3.5', 'TC-OPCREDS-3.6', 'TC-OPCREDS-3.7 (Steps Disabled)', 'TC-SC-3.6', 'TC-SC-5.1', 'TC-SC-5.2 (Semi-automated)', 'TC-SU-2.2', 'TC-SU-2.5', 'TC-SU-2.6', 'TC-SU-2.7', 'TC-SU-4.1']
INFO     | 2025-05-05 13:58:58.068 | app.pics_applicable_test_cases:__handle_platform_certification:135 | Listing applicable tests cases for execution: ['TC-ACE-2.1', 'TC-ACE-2.2', 'TC-ACE-2.3', 'TC-ACL-2.2', 'TC-BDX-2.3', 'TC-BRBINFO-4.1', 'TC-CC-2.2', 'TC-CCTRL-2.1', 'TC-CCTRL-2.2', 'TC-CCTRL-2.3', 'TC-DA-1.1', 'TC-DA-1.7', 'TC-DD-1.1', 'TC-DD-1.15', 'TC-DD-1.2', 'TC-DD-1.6', 'TC-DD-1.7', 'TC-DD-2.1', 'TC-DESC-2.1', 'TC-DESC-2.2', 'TC-DESC-2.3', 'TC-DRLK-2.1 (Semi-automated)', 'TC-DRLK-2.10', 'TC-DRLK-2.12', 'TC-DRLK-2.2', 'TC-DRLK-2.3', 'TC-DRLK-2.4', 'TC-DRLK-2.5', 'TC-DRLK-2.6', 'TC-DRLK-2.7', 'TC-DRLK-2.8', 'TC-DRLK-2.9', 'TC-DT-1.1', 'TC-ECOINFO-2.1', 'TC-ECOINFO-2.2', 'TC-I-2.1', 'TC-I-2.2 (Semi-automated)', 'TC-I-2.4', 'TC-IDM-10.1', 'TC-IDM-10.2', 'TC-IDM-10.3', 'TC-IDM-10.4', 'TC-IDM-10.5', 'TC-IDM-10.6', 'TC-IDM-11.1', 'TC-IDM-12.1', 'TC-IDM-13.1', 'TC-IDM-4.2', 'TC-IDM-4.3', 'TC-IDM-6.1', 'TC-IDM-6.2', 'TC-LCFG-2.1', 'TC-LUNIT-3.1', 'TC-LVL-2.3', 'TC-MCORE-FS.1.1', 'TC-MCORE-FS.1.2', 'TC-MCORE-FS.1.3', 'TC-MCORE-FS.1.4', 'TC-MCORE-FS.1.5', 'TC-OPCREDS-3.8', 'TC-PS-3.1', 'TC-RR-1.1', 'TC-RVCOPSTATE-2.1', 'TC-SC-1.1', 'TC-SC-1.2', 'TC-SC-1.3', 'TC-SC-1.4', 'TC-SC-2.1', 'TC-SC-2.2', 'TC-SC-2.3', 'TC-SC-3.1', 'TC-SC-3.2', 'TC-SC-3.4', 'TC-SC-4.1 (Semi-automated)', 'TC-SC-4.3', 'TC-SC-7.1', 'TC-SEAR-1.2', 'TC-SEAR-1.3', 'TC-SEAR-1.4', 'TC-SEAR-1.5', 'TC-SEAR-1.6', 'TC-SM-1.1', 'TC-SM-1.2', 'TC-SU-2.1', 'TC-SU-2.3', 'TC-SU-2.4', 'TC-SU-2.8', 'TC-SWTCH-2.2', 'TC-SWTCH-2.3', 'TC-SWTCH-2.4', 'TC-SWTCH-2.5', 'TC-SWTCH-2.6', 'TC-TIMESYNC-2.1', 'TC-TSTAT-2.2', 'TC-TestAttrAvail', 'TC-ULABEL-2.1', 'TC-ULABEL-2.2', 'TC-ULABEL-2.3', 'TC-ULABEL-2.4', 'TC-WebRTCProvider-2.1', 'TC-WebRTCProvider-2.2', 'TC-WebRTCProvider-2.3', 'TC-WebRTCProvider-2.4']

- Logs for platform Certification:
NFO     | 2025-05-05 14:01:33.254 | app.pics_applicable_test_cases:__handle_platform_certification:104 | Listing platform-test.json test cases: ['TC-ACE-1.1', 'TC-ACE-1.2', 'TC-ACE-1.3', 'TC-ACE-1.4', 'TC-ACE-1.5', 'TC-ACE-1.6', 'TC-ACL-2.1', 'TC-ACL-2.10', 'TC-ACL-2.3', 'TC-ACL-2.4', 'TC-ACL-2.5', 'TC-ACL-2.6', 'TC-ACL-2.7', 'TC-ACL-2.8', 'TC-ACL-2.9', 'TC-BDX-1.2', 'TC-BDX-1.4', 'TC-BDX-2.1', 'TC-BDX-2.2', 'TC-CADMIN-1.11', 'TC-CADMIN-1.15', 'TC-CADMIN-1.19', 'TC-CADMIN-1.21', 'TC-CADMIN-1.22', 'TC-CADMIN-1.23', 'TC-CADMIN-1.24', 'TC-CADMIN-1.25', 'TC-CADMIN-1.26', 'TC-CADMIN-1.3', 'TC-CADMIN-1.4', 'TC-CADMIN-1.5', 'TC-CADMIN-1.6', 'TC-CADMIN-1.9', 'TC-CGEN-2.1', 'TC-CGEN-2.2', 'TC-CGEN-2.4', 'TC-CNET-1.4', 'TC-CNET-4.1', 'TC-CNET-4.11', 'TC-CNET-4.13', 'TC-CNET-4.15', 'TC-CNET-4.4', 'TC-CNET-4.5', 'TC-CNET-4.9', 'TC-DA-1.1', 'TC-DA-1.2', 'TC-DA-1.5', 'TC-DD-1.5', 'TC-DD-2.1', 'TC-DD-3.19', 'TC-DD-3.3', 'TC-DD-3.9', 'TC-DGGEN-2.1', 'TC-DGGEN-2.2', 'TC-DGGEN-2.3', 'TC-DGGEN-2.4', 'TC-DGGEN-3.1', 'TC-DGGEN-3.2', 'TC-DGSW-2.1', 'TC-DGSW-2.2', 'TC-DGSW-2.3', 'TC-DGWIFI-2.1', 'TC-DGWIFI-2.2', 'TC-DGWIFI-2.3', 'TC-DLOG-2.1', 'TC-G-2.1', 'TC-G-2.2', 'TC-G-2.3', 'TC-G-2.4', 'TC-GRPKEY-2.1', 'TC-GRPKEY-2.2', 'TC-GRPKEY-5.4', 'TC-ICDB-1.1', 'TC-ICDB-1.3', 'TC-ICDB-2.1', 'TC-ICDB-2.2', 'TC-ICDB-2.3', 'TC-ICDB-2.4', 'TC-ICDB-2.5', 'TC-ICDM-2.1', 'TC-ICDM-3.1', 'TC-ICDM-3.2', 'TC-ICDM-3.3', 'TC-ICDM-3.4', 'TC-ICDM-4.1', 'TC-ICDM-5.1', 'TC-ICDM-5.2', 'TC-IDM-1.2', 'TC-IDM-1.4', 'TC-IDM-10.1', 'TC-IDM-10.2', 'TC-IDM-10.3', 'TC-IDM-10.4', 'TC-IDM-11.1', 'TC-IDM-2.2', 'TC-IDM-3.2', 'TC-IDM-4.2', 'TC-IDM-4.3', 'TC-IDM-4.4', 'TC-IDM-5.2', 'TC-IDM-6.1', 'TC-IDM-6.2', 'TC-IDM-7.1', 'TC-IDM-8.1', 'TC-LCFG-2.1', 'TC-OPCREDS-3.1', 'TC-OPCREDS-3.2', 'TC-OPCREDS-3.4', 'TC-OPCREDS-3.5', 'TC-OPCREDS-3.6', 'TC-OPCREDS-3.7', 'TC-RR-1.1', 'TC-SC-3.2', 'TC-SC-3.6', 'TC-SC-4.7', 'TC-SC-4.9', 'TC-SC-5.1', 'TC-SC-5.2', 'TC-SU-2.1', 'TC-SU-2.2', 'TC-SU-2.3', 'TC-SU-2.4', 'TC-SU-2.5', 'TC-SU-2.6', 'TC-SU-2.7', 'TC-SU-2.8']
INFO     | 2025-05-05 14:01:33.330 | app.pics_applicable_test_cases:__handle_platform_certification:135 | Listing 
applicable tests cases for execution: ['TC-ACE-1.1', 'TC-ACE-1.2', 'TC-ACE-1.3', 'TC-ACE-1.4', 'TC-ACE-1.5', 'TC-ACE-1.6', 'TC-ACE-2.1', 'TC-ACE-2.2', 'TC-ACE-2.3', 'TC-ACL-2.1', 'TC-ACL-2.10 (Semi-automated)', 'TC-ACL-2.2', 'TC-ACL-2.3', 'TC-ACL-2.4', 'TC-ACL-2.5', 'TC-ACL-2.6', 'TC-ACL-2.7', 'TC-ACL-2.8', 'TC-ACL-2.9 (Semi-automated)', 'TC-BDX-1.2', 'TC-BDX-1.4', 'TC-BDX-2.1', 'TC-BDX-2.2', 'TC-BDX-2.3', 'TC-BRBINFO-4.1', 'TC-CADMIN-1.11', 'TC-CADMIN-1.15', 'TC-CADMIN-1.19', 'TC-CADMIN-1.21', 'TC-CADMIN-1.22', 'TC-CADMIN-1.23', 'TC-CADMIN-1.24', 'TC-CADMIN-1.25', 'TC-CADMIN-1.26', 'TC-CADMIN-1.3', 'TC-CADMIN-1.4', 'TC-CADMIN-1.5', 'TC-CADMIN-1.6', 'TC-CADMIN-1.9', 'TC-CC-2.2', 'TC-CCTRL-2.1', 'TC-CCTRL-2.2', 'TC-CCTRL-2.3', 'TC-CGEN-2.1', 'TC-CGEN-2.2', 'TC-CGEN-2.4', 'TC-CNET-1.4', 'TC-CNET-4.1 (Semi-automated)', 'TC-CNET-4.11 (Semi-automated)', 'TC-CNET-4.13', 'TC-CNET-4.15 (Semi-automated)', 'TC-CNET-4.4', 'TC-CNET-4.5', 'TC-CNET-4.9 (Semi-automated)', 'TC-DA-1.1', 'TC-DA-1.2', 'TC-DA-1.5', 'TC-DA-1.7', 'TC-DD-1.1', 'TC-DD-1.15', 'TC-DD-1.2', 'TC-DD-1.5', 'TC-DD-1.6', 'TC-DD-1.7', 'TC-DD-2.1', 'TC-DD-3.1', 'TC-DD-3.19', 'TC-DD-3.3', 'TC-DD-3.9', 'TC-DESC-2.1', 'TC-DESC-2.2', 'TC-DESC-2.3', 'TC-DGGEN-2.1 (Semi-automated)', 'TC-DGGEN-2.2', 'TC-DGGEN-2.3', 'TC-DGGEN-2.4', 'TC-DGGEN-3.1', 'TC-DGGEN-3.2', 'TC-DGSW-2.1', 'TC-DGSW-2.2', 'TC-DGSW-2.3', 'TC-DGWIFI-2.1', 'TC-DGWIFI-2.2', 'TC-DGWIFI-2.3', 'TC-DLOG-2.1', 'TC-DT-1.1', 'TC-ECOINFO-2.1', 'TC-ECOINFO-2.2', 'TC-G-2.1', 'TC-G-2.2', 'TC-G-2.3', 'TC-G-2.4', 'TC-GRPKEY-2.1', 'TC-GRPKEY-2.2 (Semi-automated)', 'TC-GRPKEY-5.4', 'TC-ICDB-1.1', 'TC-ICDB-1.3', 'TC-ICDB-2.1', 'TC-ICDB-2.2', 'TC-ICDB-2.3', 'TC-ICDB-2.4', 'TC-ICDB-2.5', 'TC-ICDM-2.1', 'TC-ICDM-3.1', 'TC-ICDM-3.2', 'TC-ICDM-3.3', 'TC-ICDM-3.4', 'TC-ICDM-4.1', 'TC-ICDM-5.1', 'TC-ICDM-5.2', 'TC-IDM-1.2', 'TC-IDM-1.4', 'TC-IDM-10.1', 'TC-IDM-10.2', 'TC-IDM-10.3', 'TC-IDM-10.4', 'TC-IDM-10.5', 'TC-IDM-10.6', 'TC-IDM-11.1', 'TC-IDM-12.1', 'TC-IDM-13.1', 'TC-IDM-2.2', 'TC-IDM-3.2', 'TC-IDM-4.2', 'TC-IDM-4.3', 'TC-IDM-4.4', 'TC-IDM-5.2', 'TC-IDM-6.1', 'TC-IDM-6.2', 'TC-IDM-7.1', 'TC-IDM-8.1', 'TC-LCFG-2.1', 'TC-LUNIT-3.1', 'TC-LVL-2.3', 'TC-MCORE-FS.1.1', 'TC-MCORE-FS.1.2', 'TC-MCORE-FS.1.3', 'TC-MCORE-FS.1.4', 'TC-MCORE-FS.1.5', 'TC-OPCREDS-3.1', 'TC-OPCREDS-3.2', 'TC-OPCREDS-3.4', 'TC-OPCREDS-3.5', 'TC-OPCREDS-3.6', 'TC-OPCREDS-3.7 (Steps Disabled)', 'TC-OPCREDS-3.8', 'TC-PS-3.1', 'TC-RR-1.1', 'TC-RVCOPSTATE-2.1', 'TC-SC-1.1', 'TC-SC-1.2', 'TC-SC-1.3', 'TC-SC-1.4', 'TC-SC-2.1', 'TC-SC-2.2', 'TC-SC-2.3', 'TC-SC-3.1', 'TC-SC-3.2', 'TC-SC-3.4', 'TC-SC-3.6', 'TC-SC-4.1 (Semi-automated)', 'TC-SC-4.3', 'TC-SC-4.7', 'TC-SC-4.9', 'TC-SC-5.1', 'TC-SC-5.2 (Semi-automated)', 'TC-SC-7.1', 'TC-SEAR-1.2', 'TC-SEAR-1.3', 'TC-SEAR-1.4', 'TC-SEAR-1.5', 'TC-SEAR-1.6', 'TC-SM-1.1', 'TC-SM-1.2', 'TC-SU-2.1', 'TC-SU-2.2', 'TC-SU-2.3', 'TC-SU-2.4', 'TC-SU-2.5', 'TC-SU-2.6', 'TC-SU-2.7', 'TC-SU-2.8', 'TC-SU-4.1', 'TC-SWTCH-2.2', 'TC-SWTCH-2.3', 'TC-SWTCH-2.4', 'TC-SWTCH-2.5', 'TC-SWTCH-2.6', 'TC-TIMESYNC-2.1', 'TC-TSTAT-2.2', 'TC-TestAttrAvail', 'TC-ULABEL-2.1', 'TC-ULABEL-2.2', 'TC-ULABEL-2.3', 'TC-ULABEL-2.4', 'TC-WebRTCProvider-2.1', 'TC-WebRTCProvider-2.2', 'TC-WebRTCProvider-2.3', 'TC-WebRTCProvider-2.4']