### PR TITLE
[FIX] Adding Step Manual Missing Parameter

### DIFF
--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_test.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_test.py
@@ -170,7 +170,7 @@ class ChipTest(TestCase, UserPromptSupport, TestRunnerHooks, TestParserHooks):
     def step_unknown(self) -> None:
         self.__runned += 1
 
-    async def step_manual(self) -> None:
+    async def step_manual(self, request: Optional[TestStep] = None) -> None:
         step = self.current_test_step
         if not isinstance(step, ManualVerificationTestStep):
             raise TestError(f"Unexpected user prompt found in test step: {step.name}")


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/592

---

Adding the missing parameter to avoid the python's posicional argument error as described in the `[issue#592](https://github.com/project-chip/certification-tool/issues/592)`:
> Test Step Error: Error occurred during execution of test case TC-DGETH-2.2. ChipTest.step_manual() takes 1 positional argument but 2 were given.