### PR TITLE
[FIX] Fix logic for platform tests selection

### DIFF
--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -95,7 +95,7 @@ def applicable_test_cases_set(
     Returns:
         PICSApplicableTestCases: List of test cases that are applicable
           for this Project
-    
+
     Raises:
         PlatformTestError: If both PICS_PLAT_CERT and PICS_PLAT_CERT_DERIVED are enabled
     """
@@ -122,9 +122,7 @@ def applicable_test_cases_set(
     #  If PICS_PLAT_CERT is enabled, process platform tests
     if PICS_PLAT_CERT in enabled_pics:
         __process_platform_tests(
-            applicable_tests_combined,
-            test_collections_copy,
-            enabled_pics
+            applicable_tests_combined, test_collections_copy, enabled_pics
         )
     else:
         # If PICS_PLAT_CERT is not enabled, process mandatory and remaining tests
@@ -152,7 +150,7 @@ def __applicable_test_cases(
     test_collections: Dict[str, TestCollectionDeclaration],
     enabled_pics: set[str],
     mandatory: bool,
-    tests_to_consider: list[str] = None
+    tests_to_consider: list[str] = None,
 ) -> set:
     """
     Get applicable test cases based on PICS configuration and optional test list.
@@ -176,7 +174,10 @@ def __applicable_test_cases(
             for test_suite in test_collection.test_suites.values():
                 for test_case in test_suite.test_cases.values():
                     # Skip if test is not in the list of tests to consider
-                    if tests_to_consider and test_case.metadata["title"] not in tests_to_consider:
+                    if (
+                        tests_to_consider
+                        and test_case.metadata["title"] not in tests_to_consider
+                    ):
                         continue
 
                     if not test_case.pics:
@@ -212,7 +213,7 @@ def __retrieve_pics(test_case: TestCaseDeclaration) -> Tuple[set, set]:
 def __process_platform_tests(
     applicable_tests_combined: set[str],
     test_collections_copy: Dict[str, TestCollectionDeclaration],
-    enabled_pics: set[str]
+    enabled_pics: set[str],
 ) -> None:
     """
     Process platform tests and add them to applicable tests
@@ -234,7 +235,7 @@ def __process_platform_tests(
             test_collections_copy, enabled_pics, True, platform_tests
         )
     )
-    
+
     # Include each platform test along with some suffixes: 'Semi-automated'
     # and 'Steps Disabled'
     for test in platform_tests:

--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -15,7 +15,7 @@
 #
 import json
 from pathlib import Path
-from typing import Dict, Tuple, Optional
+from typing import Dict, Optional, Tuple
 
 from loguru import logger
 
@@ -159,7 +159,7 @@ def __applicable_test_cases(
         test_collections: Dictionary of test collections
         enabled_pics: Set of enabled PICS
         mandatory: Whether to consider mandatory tests
-        tests_to_consider: Optional list of test IDs to consider. 
+        tests_to_consider: Optional list of test IDs to consider.
                            If None or empty, all tests are considered.
 
     Returns:

--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -15,7 +15,7 @@
 #
 import json
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional
 
 from loguru import logger
 
@@ -150,7 +150,7 @@ def __applicable_test_cases(
     test_collections: Dict[str, TestCollectionDeclaration],
     enabled_pics: set[str],
     mandatory: bool,
-    tests_to_consider: list[str] = None,
+    tests_to_consider: Optional[set[str]] = None,
 ) -> set:
     """
     Get applicable test cases based on PICS configuration and optional test list.
@@ -159,7 +159,8 @@ def __applicable_test_cases(
         test_collections: Dictionary of test collections
         enabled_pics: Set of enabled PICS
         mandatory: Whether to consider mandatory tests
-        tests_to_consider: Optional list of test IDs to consider. If None or empty, all tests are considered.
+        tests_to_consider: Optional list of test IDs to consider. 
+                           If None or empty, all tests are considered.
 
     Returns:
         Set of applicable test case IDs

--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -84,37 +84,6 @@ def __read_platform_test_cases(platform_json_filename: str) -> set[str]:
         raise InvalidJSONError(f"Invalid JSON format in {platform_tests_file}")
 
 
-def __handle_platform_certification(
-    enabled_pics: set[str], applicable_tests_combined: set[str], dmp_test_skip: list
-) -> None:
-    """
-    Handle platform certification test cases based on PICS configuration.
-
-    Args:
-        enabled_pics: Set of enabled PICS
-        applicable_tests_combined: Current set of applicable test cases
-        dmp_test_skip: List of test cases to skip
-
-    Raises:
-        PlatformTestError: If both PICS_PLAT_CERT and PICS_PLAT_CERT_DERIVED are enabled
-    """
-    if PICS_PLAT_CERT in enabled_pics and PICS_PLAT_CERT_DERIVED in enabled_pics:
-        raise PlatformTestError(
-            "Invalid configuration: PICS_PLAT_CERT and PICS_PLAT_CERT_DERIVED are "
-            "mutually exclusive. Please enable only one of them"
-        )
-
-    if PICS_PLAT_CERT in enabled_pics:
-        __process_platform_tests(applicable_tests_combined)
-    elif PICS_PLAT_CERT_DERIVED in enabled_pics:
-        __process_platform_cert_derived(dmp_test_skip, applicable_tests_combined)
-
-    logger.info(
-        "Listing applicable tests cases "
-        f"for execution: {sorted(applicable_tests_combined)}"
-    )
-
-
 def applicable_test_cases_set(
     pics: PICS, dmp_test_skip: list
 ) -> PICSApplicableTestCases:
@@ -126,8 +95,12 @@ def applicable_test_cases_set(
     Returns:
         PICSApplicableTestCases: List of test cases that are applicable
           for this Project
+    
+    Raises:
+        PlatformTestError: If both PICS_PLAT_CERT and PICS_PLAT_CERT_DERIVED are enabled
     """
     applicable_tests: set = set()
+    applicable_tests_combined: set = set()
 
     if not pics.clusters:
         # If the user has not uploaded any PICS
@@ -139,22 +112,37 @@ def applicable_test_cases_set(
     test_collections_copy = test_script_manager.test_collections.copy()
     enabled_pics = set([item.number for item in pics.all_enabled_items()])
 
-    applicable_mandatories_tests = __applicable_test_cases(
-        test_collections_copy, enabled_pics, True
-    )
-    applicable_remaining_tests = __applicable_test_cases(
-        test_collections_copy, enabled_pics, False
-    )
+    # Check if both PICS_PLAT_CERT and PICS_PLAT_CERT_DERIVED are enabled
+    if PICS_PLAT_CERT in enabled_pics and PICS_PLAT_CERT_DERIVED in enabled_pics:
+        raise PlatformTestError(
+            "Invalid configuration: PICS_PLAT_CERT and PICS_PLAT_CERT_DERIVED are "
+            "mutually exclusive. Please enable only one of them"
+        )
 
-    # Combine all applicable tests
-    applicable_tests_combined = (
-        applicable_mandatories_tests | applicable_remaining_tests
-    )
+    #  If PICS_PLAT_CERT is enabled, process platform tests
+    if PICS_PLAT_CERT in enabled_pics:
+        __process_platform_tests(
+            applicable_tests_combined,
+            test_collections_copy,
+            enabled_pics
+        )
+    else:
+        # If PICS_PLAT_CERT is not enabled, process mandatory and remaining tests
+        applicable_mandatories_tests = __applicable_test_cases(
+            test_collections_copy, enabled_pics, True
+        )
+        applicable_remaining_tests = __applicable_test_cases(
+            test_collections_copy, enabled_pics, False
+        )
 
-    # Handle platform certification test cases
-    __handle_platform_certification(
-        enabled_pics, applicable_tests_combined, dmp_test_skip
-    )
+        # Combine all applicable tests
+        applicable_tests_combined = (
+            applicable_mandatories_tests | applicable_remaining_tests
+        )
+
+        # Check ff PICS_PLAT_CERT_DERIVED is enabled, skip the tests in the DMP file
+        if PICS_PLAT_CERT_DERIVED in enabled_pics:
+            __process_platform_cert_derived(dmp_test_skip, applicable_tests_combined)
 
     logger.debug(f"Applicable test cases: {applicable_tests_combined}")
     return PICSApplicableTestCases(test_cases=list(applicable_tests_combined))
@@ -164,18 +152,33 @@ def __applicable_test_cases(
     test_collections: Dict[str, TestCollectionDeclaration],
     enabled_pics: set[str],
     mandatory: bool,
+    tests_to_consider: list[str] = None
 ) -> set:
+    """
+    Get applicable test cases based on PICS configuration and optional test list.
+
+    Args:
+        test_collections: Dictionary of test collections
+        enabled_pics: Set of enabled PICS
+        mandatory: Whether to consider mandatory tests
+        tests_to_consider: Optional list of test IDs to consider. If None or empty, all tests are considered.
+
+    Returns:
+        Set of applicable test case IDs
+    """
     applicable_tests: set = set()
 
     # The 'Performance Tests' Collection should not be considered for the PICS tests.
-    # NOTE: The second parameter for the dictionary's "pop" method is provided so we may
-    # prevent a conditional exception when the following key is not present.
     test_collections.pop(STRESS_TEST_COLLECTION, None)
 
     for test_collection in test_collections.values():
         if test_collection.mandatory == mandatory:
             for test_suite in test_collection.test_suites.values():
                 for test_case in test_suite.test_cases.values():
+                    # Skip if test is not in the list of tests to consider
+                    if tests_to_consider and test_case.metadata["title"] not in tests_to_consider:
+                        continue
+
                     if not test_case.pics:
                         # Test cases without PICS are always applicable
                         applicable_tests.add(test_case.metadata["title"])
@@ -206,12 +209,18 @@ def __retrieve_pics(test_case: TestCaseDeclaration) -> Tuple[set, set]:
     return enabled_pics, disabled_pics
 
 
-def __process_platform_tests(applicable_tests_combined: set[str]) -> None:
+def __process_platform_tests(
+    applicable_tests_combined: set[str],
+    test_collections_copy: Dict[str, TestCollectionDeclaration],
+    enabled_pics: set[str]
+) -> None:
     """
     Process platform tests and add them to applicable tests
 
     Args:
         applicable_tests_combined: Current set of applicable test cases
+        test_collections_copy: Dictionary of test collections
+        enabled_pics: Set of enabled PICS
     """
     # Read platform test list file
     platform_tests = __read_platform_test_cases(PLATFORM_TESTS_FILE_NAME)
@@ -219,6 +228,13 @@ def __process_platform_tests(applicable_tests_combined: set[str]) -> None:
         f"Listing {PLATFORM_TESTS_FILE_NAME} test cases: {sorted(platform_tests)}"
     )
 
+    # Get applicable tests from collections based on platform tests
+    applicable_tests_combined.update(
+        __applicable_test_cases(
+            test_collections_copy, enabled_pics, True, platform_tests
+        )
+    )
+    
     # Include each platform test along with some suffixes: 'Semi-automated'
     # and 'Steps Disabled'
     for test in platform_tests:

--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -29,8 +29,8 @@ from test_collections.matter.sdk_tests.support.performance_tests.utils import (
     STRESS_TEST_COLLECTION,
 )
 
-PICS_PLAT_CERT = "MCORE.PLAT_CERT"
-PICS_PLAT_CERT_DERIVED = "MCORE.PLAT_CERT_DONE"
+PICS_PLAT_CERT = "PLAT.CERT"
+PICS_PLAT_CERT_DERIVED = "PLAT.CERT.TESTS.DONE"
 
 PLATFORM_TESTS_FILE_NAME = "generated-platform-cert-test-list.json"
 

--- a/app/tests/pics/test_applicable_test_cases_list.py
+++ b/app/tests/pics/test_applicable_test_cases_list.py
@@ -23,6 +23,8 @@ from unittest.mock import MagicMock, mock_open, patch
 import pytest
 
 from app.pics_applicable_test_cases import (
+    PICS_PLAT_CERT,
+    PICS_PLAT_CERT_DERIVED,
     FileNotFoundError,
     InvalidJSONError,
     PlatformTestError,
@@ -72,7 +74,7 @@ def test_applicable_test_cases_set_with_platform_cert(mock_file) -> None:
     # Create PICS with platform certification enabled
     pics = PICS()
     cluster = PICSCluster(name="Platform")
-    cluster.items["MCORE.PLAT_CERT"] = PICSItem(number="MCORE.PLAT_CERT", enabled=True)
+    cluster.items[PICS_PLAT_CERT] = PICSItem(number=PICS_PLAT_CERT, enabled=True)
     pics.clusters["Platform"] = cluster
 
     applicable_test_cases = applicable_test_cases_set(pics, [])
@@ -95,7 +97,7 @@ def test_applicable_test_cases_set_with_platform_cert_file_not_found(mock_file) 
     # Create PICS with platform certification enabled
     pics = PICS()
     cluster = PICSCluster(name="Platform")
-    cluster.items["MCORE.PLAT_CERT"] = PICSItem(number="MCORE.PLAT_CERT", enabled=True)
+    cluster.items[PICS_PLAT_CERT] = PICSItem(number=PICS_PLAT_CERT, enabled=True)
     pics.clusters["Platform"] = cluster
 
     # Mock file not found error
@@ -111,7 +113,7 @@ def test_applicable_test_cases_set_with_platform_cert_invalid_json(mock_file) ->
     # Create PICS with platform certification enabled
     pics = PICS()
     cluster = PICSCluster(name="Platform")
-    cluster.items["MCORE.PLAT_CERT"] = PICSItem(number="MCORE.PLAT_CERT", enabled=True)
+    cluster.items[PICS_PLAT_CERT] = PICSItem(number=PICS_PLAT_CERT, enabled=True)
     pics.clusters["Platform"] = cluster
 
     # Verify that InvalidJSONError is raised
@@ -123,8 +125,8 @@ def test_applicable_test_cases_set_with_platform_cert_derived_enabled() -> None:
     # Create PICS with platform certification derived enabled
     pics = PICS()
     cluster = PICSCluster(name="Platform")
-    cluster.items["MCORE.PLAT_CERT_DONE"] = PICSItem(
-        number="MCORE.PLAT_CERT_DONE", enabled=True
+    cluster.items[PICS_PLAT_CERT_DERIVED] = PICSItem(
+        number=PICS_PLAT_CERT_DERIVED, enabled=True
     )
     pics.clusters["Platform"] = cluster
 
@@ -144,8 +146,8 @@ def test_applicable_test_cases_set_with_platform_cert_derived_enabled_remove_tes
     # Create PICS with platform certification derived enabled
     pics = PICS()
     cluster = PICSCluster(name="Platform")
-    cluster.items["MCORE.PLAT_CERT_DONE"] = PICSItem(
-        number="MCORE.PLAT_CERT_DONE", enabled=True
+    cluster.items[PICS_PLAT_CERT_DERIVED] = PICSItem(
+        number=PICS_PLAT_CERT_DERIVED, enabled=True
     )
     pics.clusters["Platform"] = cluster
 
@@ -168,7 +170,7 @@ def test_applicable_test_cases_set_with_platform_cert_enabled(mock_file) -> None
     # Create PICS with platform certification enabled
     pics = PICS()
     cluster = PICSCluster(name="Platform")
-    cluster.items["MCORE.PLAT_CERT"] = PICSItem(number="MCORE.PLAT_CERT", enabled=True)
+    cluster.items[PICS_PLAT_CERT] = PICSItem(number=PICS_PLAT_CERT, enabled=True)
     pics.clusters["Platform"] = cluster
 
     # Create a set of applicable test cases
@@ -193,9 +195,9 @@ def test_applicable_test_cases_set_with_both_platform_certs_enabled() -> None:
     # Create PICS with both platform certifications enabled
     pics = PICS()
     cluster = PICSCluster(name="Platform")
-    cluster.items["MCORE.PLAT_CERT"] = PICSItem(number="MCORE.PLAT_CERT", enabled=True)
-    cluster.items["MCORE.PLAT_CERT_DONE"] = PICSItem(
-        number="MCORE.PLAT_CERT_DONE", enabled=True
+    cluster.items[PICS_PLAT_CERT] = PICSItem(number=PICS_PLAT_CERT, enabled=True)
+    cluster.items[PICS_PLAT_CERT_DERIVED] = PICSItem(
+        number=PICS_PLAT_CERT_DERIVED, enabled=True
     )
     pics.clusters["Platform"] = cluster
 
@@ -263,8 +265,8 @@ def test_applicable_test_cases_set_with_dmp_cert_test_removed(mock_manager) -> N
     # # Create PICS with platform certification derived enabled
     # pics = PICS()
     cluster = PICSCluster(name="Platform")
-    cluster.items["MCORE.PLAT_CERT_DONE"] = PICSItem(
-        number="MCORE.PLAT_CERT_DONE", enabled=True
+    cluster.items[PICS_PLAT_CERT_DERIVED] = PICSItem(
+        number=PICS_PLAT_CERT_DERIVED, enabled=True
     )
     pics.clusters["Platform"] = cluster
 
@@ -346,8 +348,8 @@ def test_applicable_test_cases_set_with_mocked_internal_calls(
     # Create PICS with platform certification derived enabled
     pics = PICS()
     cluster = PICSCluster(name="Platform")
-    cluster.items["MCORE.PLAT_CERT_DONE"] = PICSItem(
-        number="MCORE.PLAT_CERT_DONE", enabled=True
+    cluster.items[PICS_PLAT_CERT_DERIVED] = PICSItem(
+        number=PICS_PLAT_CERT_DERIVED, enabled=True
     )
     pics.clusters["Platform"] = cluster
 


### PR DESCRIPTION
### What Changed
The goal of this PR is to fix the test selection logic for platform certification execution.
Only the tests listed in the platform test list file should be considered when the PLAT.CERT PICS PICS is set.

### Related Issue
https://github.com/project-chip/certification-tool/issues/625

### Testing 
Unit tests updated and passing
<img width="467" alt="Screenshot 2025-06-05 at 19 42 36" src="https://github.com/user-attachments/assets/94a6c2dd-88b6-4c7a-9053-936b87be31b9" />
