### PR TITLE
[FIX] Make python script test name more flexible

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
@@ -28,7 +28,7 @@ ARG_STEP_DESCRIPTION_INDEX = 1
 KEYWORD_IS_COMISSIONING_INDEX = 0
 
 TC_FUNCTION_PATTERN = re.compile(r"[\S]+_TC_[\S]+")
-TC_TEST_FUNCTION_PATTERN = re.compile(r"test_(?P<title>TC_[\S]+)")
+TC_TEST_FUNCTION_PATTERN = re.compile(r"test_(?P<title>(?:TC_)?[\S]+)")
 
 
 FunctionDefType = Union[ast.FunctionDef, ast.AsyncFunctionDef]

--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
@@ -28,6 +28,7 @@ ARG_STEP_DESCRIPTION_INDEX = 1
 KEYWORD_IS_COMISSIONING_INDEX = 0
 
 TC_FUNCTION_PATTERN = re.compile(r"[\S]+_TC_[\S]+")
+# This is used for the function name. It must start with test_
 TC_TEST_FUNCTION_PATTERN = re.compile(r"test_(?P<title>(?:TC_)?[\S]+)")
 
 


### PR DESCRIPTION
### What changed
The goal of this PR is to make python script test name more flexible, so the user may define the test script using `TC_` or not.

### Related Issue 
https://github.com/project-chip/certification-tool/issues/624

### Testing
Unit Test passing
<img width="593" alt="Screenshot 2025-06-10 at 09 16 26" src="https://github.com/user-attachments/assets/6703e174-6fdb-485c-8df2-b0934d2a9b13" />



TC-MOD-1.2 is not listed inside SDK Python Tests collection
![Screenshot 2025-06-10 at 09 16 05](https://github.com/user-attachments/assets/e09d2f49-70a8-403b-8b34-7308a4b7b519)
