### PR TITLE
Revert "[FIX] Make python script test name more flexible (#233)"

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_test_parser.py
@@ -28,8 +28,7 @@ ARG_STEP_DESCRIPTION_INDEX = 1
 KEYWORD_IS_COMISSIONING_INDEX = 0
 
 TC_FUNCTION_PATTERN = re.compile(r"[\S]+_TC_[\S]+")
-# This is used for the function name. It must start with test_
-TC_TEST_FUNCTION_PATTERN = re.compile(r"test_(?P<title>(?:TC_)?[\S]+)")
+TC_TEST_FUNCTION_PATTERN = re.compile(r"test_(?P<title>TC_[\S]+)")
 
 
 FunctionDefType = Union[ast.FunctionDef, ast.AsyncFunctionDef]


### PR DESCRIPTION
This reverts commit d1e207e64518ed9b962074a04b3318706be6074d.