### PR TITLE
[Fix] - Fix import test harness client

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
@@ -141,7 +141,7 @@ def configure_iterations(args) -> []:
 
 
 def run_test(script_path: str, class_name: str, config: MatterTestConfig) -> None:
-    manual_execution = 1  # false
+    manual_execution = 0  # false
 
     try:
         manual_execution = sys.argv.index("--cmd-line")


### PR DESCRIPTION
### What changed
The goal of this PR is to update the import for CommissionDeviceTest since its changed after refactoring 

### Related Issues
https://github.com/project-chip/certification-tool/issues/652

### Testing
Running the following command successfully is still working:
python3 /root/python_testing/scripts/sdk/TC_CADMIN_1_11.py --commissioning-method on-network --trace-to json:log --discriminator 3840 --passcode 20202021

Running using TH client successfully (Commissioning):
python3 /root/python_testing/scripts/sdk/matter_testing_infrastructure/chip/testing/test_harness_client.py commission --trace-to json:log --commissioning-method on-network --discriminator 3840 --passcode 20202021 --storage_path /root/python_testing/admin_storage2.json

Running using TH client successfully (Test Execution):
python3 /root/python_testing/scripts/sdk/matter_testing_infrastructure/chip/testing/test_harness_client.py sdk/TC_ACE_1_3 TC_ACE_1_3 --tests test_TC_ACE_1_3 --trace-to json:log --in-test-commissioning-method on-network --discriminator 3840 --passcode 20202021