### PR TITLE
Suppress websocket broadcast runtime errors blocking test updates

### DIFF
--- a/app/socket_connection_manager.py
+++ b/app/socket_connection_manager.py
@@ -98,11 +98,11 @@ class SocketConnectionManager(object, metaclass=Singleton):
                         f' to websocket: "{websocket}", connection closed."'
                     )
                 except RuntimeError as e:
+                    # TODO: Determine / resolve underlying cause of mismanaged connections resulting in RuntimeErrors
                     logger.warning(
                         f'Failed to send: "{message}" to websocket: "{websocket}."'
                         f' error: "{e}"',
                     )
-                    # raise e
 
     async def received_message(self, websocket: WebSocket, message: str) -> None:
         try:

--- a/app/socket_connection_manager.py
+++ b/app/socket_connection_manager.py
@@ -98,7 +98,8 @@ class SocketConnectionManager(object, metaclass=Singleton):
                         f' to websocket: "{websocket}", connection closed."'
                     )
                 except RuntimeError as e:
-                    # TODO: Determine / resolve underlying cause of mismanaged connections resulting in RuntimeErrors
+                    # TODO: Determine / resolve underlying cause of mismanaged
+                    # connections resulting in RuntimeErrors
                     logger.warning(
                         f'Failed to send: "{message}" to websocket: "{websocket}."'
                         f' error: "{e}"',

--- a/app/socket_connection_manager.py
+++ b/app/socket_connection_manager.py
@@ -99,10 +99,10 @@ class SocketConnectionManager(object, metaclass=Singleton):
                     )
                 except RuntimeError as e:
                     logger.warning(
-                        f'Failed to send: "{message}" to websocket: "{websocket}."',
-                        'Error:"{e}"',
+                        f'Failed to send: "{message}" to websocket: "{websocket}."'
+                        f' error: "{e}"',
                     )
-                    raise e
+                    # raise e
 
     async def received_message(self, websocket: WebSocket, message: str) -> None:
         try:

--- a/app/tests/socket_connection_manager/test_socket_connection_manager.py
+++ b/app/tests/socket_connection_manager/test_socket_connection_manager.py
@@ -215,7 +215,6 @@ async def test_broadcast_with_failed_connection() -> None:
     2. Message is sent successfully on the working connection
     """
     test_message = "Test"
-    expected_parameter = {"type": "websocket.send", "text": test_message}
     socket_connection_manager.active_connections.clear()
 
     # Add a closed socket to the active connection list
@@ -235,8 +234,8 @@ async def test_broadcast_with_failed_connection() -> None:
     assert len(socket_connection_manager.active_connections) == 2
 
     await socket_connection_manager.broadcast(message=test_message)
-    socket_bad.send_text.assert_called_with(expected_parameter)
-    socket_good.send_text.assert_called_with(expected_parameter)
+    socket_bad.send_text.assert_called_with(test_message)
+    socket_good.send_text.assert_called_with(test_message)
 
     # Cleanup
     socket_connection_manager.active_connections.clear()

--- a/app/tests/socket_connection_manager/test_socket_connection_manager.py
+++ b/app/tests/socket_connection_manager/test_socket_connection_manager.py
@@ -204,6 +204,42 @@ async def test_broadcast_failed_for_ConnectionClosed() -> None:
     socket_connection_manager.active_connections.clear()
 
 @pytest.mark.asyncio
+async def test_broadcast_with_failed_connection() -> None:
+    """
+    Tests if broadcast() is able to output to multiple connections, where one is closed / failed.
+
+    Expected results:
+    1. Broadcast runs without an error, skipping over the bad connection
+    2. Message is sent successfully on the working connection
+    """
+    test_message = "Test"
+    expected_parameter = {"type": "websocket.send", "text": test_message}
+    socket_connection_manager.active_connections.clear()
+
+    # Add a closed socket to the active connection list
+    socket_bad = mock.MagicMock(spec=WebSocket)
+    connection = WebSocketConnection(socket_bad, WebSocketTypeEnum.MAIN)
+    socket_connection_manager.active_connections.append(connection)
+    assert len(socket_connection_manager.active_connections) == 1
+    # Force a connection closed exception
+    socket_bad.send_text.side_effect = RuntimeError(
+        'Cannot call "receive" once a disconnect message has been received.'
+    )
+
+    # Add a working socket to the active connection list
+    socket_good = mock.MagicMock(spec=WebSocket)
+    connection = WebSocketConnection(socket_good, WebSocketTypeEnum.MAIN)
+    socket_connection_manager.active_connections.append(connection)
+    assert len(socket_connection_manager.active_connections) == 2
+
+    await socket_connection_manager.broadcast(message=test_message)
+    socket_bad.send_text.assert_called_with(expected_parameter)
+    socket_good.send_text.assert_called_with(expected_parameter)
+
+    # Cleanup
+    socket_connection_manager.active_connections.clear()
+
+@pytest.mark.asyncio
 async def test_received_message_valid_json() -> None:
     """
     Tests if received_message() is able to handle a message with valid

--- a/app/tests/socket_connection_manager/test_socket_connection_manager.py
+++ b/app/tests/socket_connection_manager/test_socket_connection_manager.py
@@ -203,39 +203,6 @@ async def test_broadcast_failed_for_ConnectionClosed() -> None:
     # Cleanup
     socket_connection_manager.active_connections.clear()
 
-
-@pytest.mark.asyncio
-async def test_broadcast_failed_for_RuntimeError() -> None:
-    """
-    Tests if broadcast() is able to handle run time errors.
-
-    Expected results:
-    1. RuntimeError is raised
-    2. "Send" is called in an attempt to broadcast
-    """
-    test_message = "Test"
-    expected_parameter = {"type": "websocket.send", "text": test_message}
-
-    # Add a websocket object to the "active_connections" list to imitate
-    # an existing active connection
-    socket_connection_manager.active_connections.clear()
-    socket = mock.MagicMock(spec=WebSocket)
-    connection = WebSocketConnection(socket, WebSocketTypeEnum.MAIN)
-    socket_connection_manager.active_connections.append(connection)
-    assert len(socket_connection_manager.active_connections) == 1
-
-    socket.send_text.side_effect = RuntimeError(
-        'Cannot call "receive" once a disconnect message has been received.'
-    )
-
-    with pytest.raises(RuntimeError):
-        await socket_connection_manager.broadcast(message=test_message)
-        socket.send_text.assert_called_with(expected_parameter)
-
-    # Cleanup
-    socket_connection_manager.active_connections.clear()
-
-
 @pytest.mark.asyncio
 async def test_received_message_valid_json() -> None:
     """

--- a/app/tests/socket_connection_manager/test_socket_connection_manager.py
+++ b/app/tests/socket_connection_manager/test_socket_connection_manager.py
@@ -203,10 +203,12 @@ async def test_broadcast_failed_for_ConnectionClosed() -> None:
     # Cleanup
     socket_connection_manager.active_connections.clear()
 
+
 @pytest.mark.asyncio
 async def test_broadcast_with_failed_connection() -> None:
     """
-    Tests if broadcast() is able to output to multiple connections, where one is closed / failed.
+    Tests if broadcast() is able to output to multiple connections,
+    where one is closed / failed.
 
     Expected results:
     1. Broadcast runs without an error, skipping over the bad connection
@@ -238,6 +240,7 @@ async def test_broadcast_with_failed_connection() -> None:
 
     # Cleanup
     socket_connection_manager.active_connections.clear()
+
 
 @pytest.mark.asyncio
 async def test_received_message_valid_json() -> None:


### PR DESCRIPTION
There can be a state where frontend websocket disconnection appears to hang - if the connection is not properly closed by the upstream browser, or if the connection is closed while the backend is busy and the connection close is ignored. In this case, stale connections end up in the `active_connections` table that cannot be used and generate RuntimeErrors. The most obvious way to reproduce this is to run a test, and while the test harness is performing auto-commissioning, reload the page. It should take a while to reload since the worker is busy, but when it does service the page, it hooks the new websocket but will often fail to properly shutdown the stale one.

I think it's likely that the handling of this should be similar to how ConnectionClosedOK is handled, however in this case, starlette just sends a generic RuntimeError (`raise RuntimeError('Cannot call "send" once a close message has been sent.')`). Additionally, it should be root caused why websockets are not properly cleared out of active_connections in the first place. However, as a short-term fix, I suppress the RuntimeErrors rather than propagating them, as to allow some future websocket connection to receive and handle the outgoing prompt.

Also corrects a typo in the logger invoke that was causing a loguru error (error was sent as a second argument, instead of a string concat as done in the previous log line.)