### PR TITLE
Ensure chip-tool output is read in the background to avoid blocking stdout

### DIFF
--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -15,11 +15,11 @@
 #
 from __future__ import annotations
 
+import asyncio
 import json
 import subprocess
-import asyncio
 from pathlib import Path
-from typing import Any, Optional, Union, Generator
+from typing import Any, Generator, Optional, Union
 
 import loguru
 from matter.yamltests.definitions import SpecDefinitionsFromPaths

--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import json
 import subprocess
-import threading
+import asyncio
 from pathlib import Path
 from typing import Any, Optional, Union
 
@@ -124,13 +124,12 @@ class MatterYAMLRunner(metaclass=Singleton):
                         f.write(data)
             except Exception as e:
                 self.logger.error(f"Error in chip-tool log reader thread: {e}")
-        self.__chip_tool_log_reader = threading.Thread(target=read_chip_log, args=(self.__chip_tool_log,))
-        self.__chip_tool_log_reader.start()
+        loop = asyncio.get_running_loop()
+        loop.run_in_executor(None, read_chip_log, self.__chip_tool_log)
 
     async def stop(self) -> None:
         await self.stop_runner()
         await self.chip_server.stop()
-        self.__chip_tool_log_reader.join()
 
     def __get_gateway_ip(self) -> str:
         """

--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -19,7 +19,7 @@ import json
 import subprocess
 import asyncio
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, Generator
 
 import loguru
 from matter.yamltests.definitions import SpecDefinitionsFromPaths
@@ -117,13 +117,15 @@ class MatterYAMLRunner(metaclass=Singleton):
         self.__test_harness_runner = WebSocketRunner(config=web_socket_config)
 
         self.__chip_tool_log = await self.chip_server.start(server_type, use_paa_certs)
-        def read_chip_log(gen):
+
+        def read_chip_log(gen: Generator) -> None:
             try:
                 with open(YAML_TESTS_PATH_BASE / "chip_output.log", "wb") as f:
                     for data in gen:
                         f.write(data)
             except Exception as e:
                 self.logger.error(f"Error in chip-tool log reader thread: {e}")
+
         loop = asyncio.get_running_loop()
         loop.run_in_executor(None, read_chip_log, self.__chip_tool_log)
 

--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -118,9 +118,12 @@ class MatterYAMLRunner(metaclass=Singleton):
 
         self.__chip_tool_log = await self.chip_server.start(server_type, use_paa_certs)
         def read_chip_log(gen):
-            with open(YAML_TESTS_PATH_BASE / "chip_output.log", "wb") as f:
-                for data in gen:
-                    f.write(data)
+            try:
+                with open(YAML_TESTS_PATH_BASE / "chip_output.log", "wb") as f:
+                    for data in gen:
+                        f.write(data)
+            except Exception as e:
+                self.logger.error(f"Error in chip-tool log reader thread: {e}")
         self.__chip_tool_log_reader = threading.Thread(target=read_chip_log, args=(self.__chip_tool_log,))
         self.__chip_tool_log_reader.start()
 


### PR DESCRIPTION
Closes #245 -- Previously, when using the YAML runner, we spawn a chip-tool process but then nothing reads its stdout stream (aside from briefly to wait for startup). This is inconvenient because
1. If there's an error in the chip-tool process itself, it is not readily visible to the user anywhere, since the saved logs only includes logs decoded from the chip-tool websocket.
2. chip-tool will fill up the system stdout buffer eventually and block / crash, since nothing is draining it out.

A quick solution to work around this is included - simply spawning a thread in the background to read out the chip-tool stdout and save it to a file. This is [similar to the hack used for copying the output from the python test executor](https://github.com/project-chip/certification-tool-backend/blob/deb46e6e02c58230737904a022ac999c12124f3e/test_collections/matter/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py#L103-L110) where we just drop the output into a file adjacent to the test cases (and, when ran in docker, mounted externally on the host). While not a very comprehensive workaround, the intent is that its a quick fix to improve the robustness of the YAML runner while it is still being deprecated