### PR TITLE
Added support to project_id in test_run_executions POST /cli

### DIFF
--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -130,15 +130,15 @@ def create_cli_test_run_execution(
     test_run_execution_in: schemas.TestRunExecutionCreate,
     selected_tests: schemas.TestSelection,
     config: dict = {},
-    pics: dict = {}
+    pics: dict = {},
 ) -> TestRunExecution:
     """Creates a new test run execution on CLI request.
-    
+
     Args:
         test_run_execution_in: Test run execution data
         selected_tests: Selected tests to run
         config: Configuration parameters (optional)
-        pics: PICS configuration (optional)  
+        pics: PICS configuration (optional)
     """
     if not config:
         config = default_environment_config.__dict__
@@ -179,7 +179,9 @@ def create_cli_test_run_execution(
             project_update = schemas.ProjectUpdate(config=config)
             if pics_obj:
                 project_update.pics = pics_obj
-            project = crud.project.update(db=db, db_obj=cli_project, obj_in=project_update)
+            project = crud.project.update(
+                db=db, db_obj=cli_project, obj_in=project_update
+            )
 
     # TODO: Remove test_run_config completely from the project
     test_run_execution_in.project_id = project.id

--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -155,7 +155,7 @@ def create_cli_test_run_execution(
         )
 
     # Use provided project_id or default CLI project
-    if test_run_execution_in.project_id:
+    if test_run_execution_in.project_id is not None:
         # Use the specified project_id
         project = crud.project.get(db=db, id=test_run_execution_in.project_id)
         if not project:

--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -183,7 +183,6 @@ def create_cli_test_run_execution(
             )
         test_run_execution_in.project_id = project.id
 
-    # TODO: Remove test_run_config completely from the project
     test_run_execution_in.certification_mode = False
 
     test_run_execution = crud.test_run_execution.create(

--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -130,9 +130,16 @@ def create_cli_test_run_execution(
     test_run_execution_in: schemas.TestRunExecutionCreate,
     selected_tests: schemas.TestSelection,
     config: dict = {},
-    pics: dict = {},
+    pics: dict = {}
 ) -> TestRunExecution:
-    """Creates a new test run execution on CLI request."""
+    """Creates a new test run execution on CLI request.
+    
+    Args:
+        test_run_execution_in: Test run execution data
+        selected_tests: Selected tests to run
+        config: Configuration parameters (optional)
+        pics: PICS configuration (optional)  
+    """
     if not config:
         config = default_environment_config.__dict__
 
@@ -147,22 +154,32 @@ def create_cli_test_run_execution(
             detail="Invalid PICS data provided. Please check the format.",
         )
 
-    # Retrieve the default CLI project
-    cli_project = crud.project.get_by_name(db=db, name=DEFAULT_CLI_PROJECT_NAME)
-
-    # If the default CLI project does not exist, create it
-    if not cli_project:
-        project = schemas.ProjectCreate(name=DEFAULT_CLI_PROJECT_NAME)
-        project.config = config
-        if pics_obj:
-            project.pics = pics_obj
-        project = crud.project.create(db=db, obj_in=project)
+    # Use provided project_id or default CLI project
+    if test_run_execution_in.project_id:
+        # Use the specified project_id
+        project = crud.project.get(db=db, id=test_run_execution_in.project_id)
+        if not project:
+            raise HTTPException(
+                status_code=HTTPStatus.NOT_FOUND,
+                detail=f"Project with id {test_run_execution_in.project_id} not found.",
+            )
     else:
-        # Update the default CLI project with the cli config argument and pics
-        project_update = schemas.ProjectUpdate(config=config)
-        if pics_obj:
-            project_update.pics = pics_obj
-        project = crud.project.update(db=db, db_obj=cli_project, obj_in=project_update)
+        # Retrieve the default CLI project
+        cli_project = crud.project.get_by_name(db=db, name=DEFAULT_CLI_PROJECT_NAME)
+
+        # If the default CLI project does not exist, create it
+        if not cli_project:
+            project = schemas.ProjectCreate(name=DEFAULT_CLI_PROJECT_NAME)
+            project.config = config
+            if pics_obj:
+                project.pics = pics_obj
+            project = crud.project.create(db=db, obj_in=project)
+        else:
+            # Update the default CLI project with the cli config argument and pics
+            project_update = schemas.ProjectUpdate(config=config)
+            if pics_obj:
+                project_update.pics = pics_obj
+            project = crud.project.update(db=db, db_obj=cli_project, obj_in=project_update)
 
     # TODO: Remove test_run_config completely from the project
     test_run_execution_in.project_id = project.id

--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -157,8 +157,7 @@ def create_cli_test_run_execution(
     # Use provided project_id or default CLI project
     if test_run_execution_in.project_id is not None:
         # Use the specified project_id
-        project = crud.project.get(db=db, id=test_run_execution_in.project_id)
-        if not project:
+        if not crud.project.get(db=db, id=test_run_execution_in.project_id):
             raise HTTPException(
                 status_code=HTTPStatus.NOT_FOUND,
                 detail=f"Project with id {test_run_execution_in.project_id} not found.",
@@ -182,9 +181,9 @@ def create_cli_test_run_execution(
             project = crud.project.update(
                 db=db, db_obj=cli_project, obj_in=project_update
             )
+        test_run_execution_in.project_id = project.id
 
     # TODO: Remove test_run_config completely from the project
-    test_run_execution_in.project_id = project.id
     test_run_execution_in.certification_mode = False
 
     test_run_execution = crud.test_run_execution.create(

--- a/app/tests/api/api_v1/test_test_run_executions.py
+++ b/app/tests/api/api_v1/test_test_run_executions.py
@@ -1444,3 +1444,235 @@ def test_operations_missing_test_run(client: TestClient, db: Session) -> None:
         expected_status_code=HTTPStatus.NOT_FOUND,
         expected_keys=["detail"],
     )
+
+
+def test_create_cli_test_run_execution_with_valid_project_id_in_execution(
+    mock_db, test_run_execution_create, test_selection, default_config
+):
+    """Test creating a CLI test run execution with a valid project_id in test_run_execution_in"""
+    # Set project_id in the test_run_execution_create object
+    test_run_execution_create.project_id = 123
+    
+    # Mock existing project with specific ID
+    mock_project = Project(
+        id=123,
+        name="Specific Test Project",
+        config={},
+    )
+    
+    # Mock test run execution
+    mock_test_run = TestRunExecution(
+        id=1,
+        title=test_run_execution_create.title,
+        description=test_run_execution_create.description,
+        project_id=123,
+        operator_id=1,
+    )
+    
+    # Configure mocks
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_project
+    mock_db.add.return_value = None
+    mock_db.commit.return_value = None
+    mock_db.refresh.return_value = None
+    
+    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
+         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get", return_value=mock_project), \
+         patch("app.api.api_v1.endpoints.test_run_executions.create_test_run_execution", return_value=mock_test_run):
+        
+        response = client.post(
+            f"{settings.API_V1_STR}/test_run_executions/cli",
+            json={
+                "test_run_execution_in": test_run_execution_create.dict(),
+                "selected_tests": test_selection,
+                "config": default_config,
+                "pics": {},
+            },
+        )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == test_run_execution_create.title
+    assert data["project_id"] == 123
+
+
+def test_create_cli_test_run_execution_with_invalid_project_id_in_execution(
+    mock_db, test_run_execution_create, test_selection, default_config
+):
+    """Test creating a CLI test run execution with an invalid project_id in test_run_execution_in"""
+    # Set invalid project_id in the test_run_execution_create object
+    test_run_execution_create.project_id = 999
+    
+    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
+         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get", return_value=None):
+        
+        response = client.post(
+            f"{settings.API_V1_STR}/test_run_executions/cli",
+            json={
+                "test_run_execution_in": test_run_execution_create.dict(),
+                "selected_tests": test_selection,
+                "config": default_config,
+                "pics": {},
+            },
+        )
+    
+    assert response.status_code == HTTPStatus.NOT_FOUND
+    data = response.json()
+    assert "Project with id 999 not found" in data["detail"]
+
+
+def test_create_cli_test_run_execution_without_project_id_in_execution_uses_default(
+    mock_db, test_run_execution_create, test_selection, default_config
+):
+    """Test creating a CLI test run execution without project_id in test_run_execution_in uses default CLI project"""
+    # Ensure project_id is None in test_run_execution_create
+    test_run_execution_create.project_id = None
+    
+    # Mock default CLI project
+    mock_cli_project = Project(
+        id=1,
+        name=DEFAULT_CLI_PROJECT_NAME,
+        config={},
+    )
+    
+    mock_test_run = TestRunExecution(
+        id=1,
+        title=test_run_execution_create.title,
+        description=test_run_execution_create.description,
+        project_id=1,
+        operator_id=1,
+        certification_mode=False,
+        state=TestStateEnum.PENDING,
+        started_at=None,
+        completed_at=None,
+        imported_at=None,
+        archived_at=None,
+    )
+    
+    # Configure mocks
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_cli_project
+    mock_db.add.return_value = None
+    mock_db.commit.return_value = None
+    mock_db.refresh.return_value = None
+    
+    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
+         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name", return_value=mock_cli_project), \
+         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.update", return_value=mock_cli_project), \
+         patch("app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create", return_value=mock_test_run):
+        
+        response = client.post(
+            f"{settings.API_V1_STR}/test_run_executions/cli",
+            json={
+                "test_run_execution_in": test_run_execution_create.dict(),
+                "selected_tests": test_selection,
+                "config": default_config,
+                "pics": {},
+            },
+        )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == test_run_execution_create.title
+    assert data["project_id"] == 1  # Default CLI project ID
+
+
+def test_create_cli_test_run_execution_creates_default_project_when_missing_new_flow(
+    mock_db, test_run_execution_create, test_selection, default_config
+):
+    """Test creating a CLI test run execution creates default CLI project if it doesn't exist (new flow)"""
+    # Ensure project_id is None in test_run_execution_create
+    test_run_execution_create.project_id = None
+    
+    mock_new_project = Project(
+        id=1,
+        name=DEFAULT_CLI_PROJECT_NAME,
+        config=default_config,
+    )
+    
+    mock_test_run = TestRunExecution(
+        id=1,
+        title=test_run_execution_create.title,
+        description=test_run_execution_create.description,
+        project_id=1,
+        operator_id=1,
+    )
+    
+    # Configure mocks: first call returns None (project not found), subsequent calls return the created project
+    mock_db.query.return_value.filter.return_value.first.side_effect = [None, mock_new_project, mock_test_run]
+    mock_db.add.return_value = None
+    mock_db.commit.return_value = None
+    mock_db.refresh.return_value = None
+    
+    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
+         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name", return_value=None), \
+         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.create", return_value=mock_new_project), \
+         patch("app.api.api_v1.endpoints.test_run_executions.create_test_run_execution", return_value=mock_test_run):
+        
+        response = client.post(
+            f"{settings.API_V1_STR}/test_run_executions/cli",
+            json={
+                "test_run_execution_in": test_run_execution_create.dict(),
+                "selected_tests": test_selection,
+                "config": default_config,
+                "pics": {},
+            },
+        )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == test_run_execution_create.title
+    assert data["project_id"] == 1
+
+
+def test_create_cli_test_run_execution_project_id_zero_uses_default(
+    mock_db, test_run_execution_create, test_selection, default_config
+):
+    """Test creating a CLI test run execution with project_id=0 (falsy) uses default CLI project"""
+    # Set project_id to 0 (falsy value) in test_run_execution_create
+    test_run_execution_create.project_id = 0
+    
+    # Mock default CLI project
+    mock_cli_project = Project(
+        id=1,
+        name=DEFAULT_CLI_PROJECT_NAME,
+        config={},
+    )
+    
+    mock_test_run = TestRunExecution(
+        id=1,
+        title=test_run_execution_create.title,
+        description=test_run_execution_create.description,
+        project_id=1,
+        operator_id=1,
+        certification_mode=False,
+        state=TestStateEnum.PENDING,
+        started_at=None,
+        completed_at=None,
+        imported_at=None,
+        archived_at=None,
+    )
+    
+    # Configure mocks
+    mock_db.query.return_value.filter.return_value.first.return_value = mock_cli_project
+    mock_db.add.return_value = None
+    mock_db.commit.return_value = None
+    mock_db.refresh.return_value = None
+    
+    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
+         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name", return_value=mock_cli_project), \
+         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.update", return_value=mock_cli_project), \
+         patch("app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create", return_value=mock_test_run):
+        
+        response = client.post(
+            f"{settings.API_V1_STR}/test_run_executions/cli",
+            json={
+                "test_run_execution_in": test_run_execution_create.dict(),
+                "selected_tests": test_selection,
+                "config": default_config,
+                "pics": {},
+            },
+        )
+    
+    assert response.status_code == 200
+    data = response.json()
+    assert data["title"] == test_run_execution_create.title
+    assert data["project_id"] == 1  # Default CLI project ID

--- a/app/tests/api/api_v1/test_test_run_executions.py
+++ b/app/tests/api/api_v1/test_test_run_executions.py
@@ -1449,7 +1449,8 @@ def test_operations_missing_test_run(client: TestClient, db: Session) -> None:
 def test_create_cli_test_run_execution_with_valid_project_id_in_execution(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test creating a CLI test run execution with a valid project_id in test_run_execution_in"""
+    """Test creating a CLI test run execution with a valid project_id in
+    test_run_execution_in"""
     # Set project_id in the test_run_execution_create object
     test_run_execution_create.project_id = 123
 
@@ -1503,7 +1504,8 @@ def test_create_cli_test_run_execution_with_valid_project_id_in_execution(
 def test_create_cli_test_run_execution_with_invalid_project_id_in_execution(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test creating a CLI test run execution with an invalid project_id in test_run_execution_in"""
+    """Test creating a CLI test run execution with an invalid project_id in
+    test_run_execution_in"""
     # Set invalid project_id in the test_run_execution_create object
     test_run_execution_create.project_id = 999
 
@@ -1531,7 +1533,8 @@ def test_create_cli_test_run_execution_with_invalid_project_id_in_execution(
 def test_create_cli_test_run_execution_without_project_id_in_execution_uses_default(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test creating a CLI test run execution without project_id in test_run_execution_in uses default CLI project"""
+    """Test creating a CLI test run execution without project_id in
+    test_run_execution_in uses default CLI project"""
     # Ensure project_id is None in test_run_execution_create
     test_run_execution_create.project_id = None
 
@@ -1593,7 +1596,8 @@ def test_create_cli_test_run_execution_without_project_id_in_execution_uses_defa
 def test_create_cli_test_run_execution_creates_default_project_when_missing_new_flow(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test creating a CLI test run execution creates default CLI project if it doesn't exist (new flow)"""
+    """Test creating a CLI test run execution creates default CLI project if it doesn't
+    exist (new flow)"""
     # Ensure project_id is None in test_run_execution_create
     test_run_execution_create.project_id = None
 
@@ -1611,7 +1615,8 @@ def test_create_cli_test_run_execution_creates_default_project_when_missing_new_
         operator_id=1,
     )
 
-    # Configure mocks: first call returns None (project not found), subsequent calls return the created project
+    # Configure mocks: first call returns None (project not found), subsequent calls
+    # return the created project
     mock_db.query.return_value.filter.return_value.first.side_effect = [
         None,
         mock_new_project,
@@ -1652,7 +1657,8 @@ def test_create_cli_test_run_execution_creates_default_project_when_missing_new_
 def test_create_cli_test_run_execution_project_id_zero_uses_default(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test creating a CLI test run execution with project_id=0 (falsy) uses default CLI project"""
+    """Test creating a CLI test run execution with project_id=0 (falsy) uses default
+    CLI project"""
     # Set project_id to 0 (falsy value) in test_run_execution_create
     test_run_execution_create.project_id = 0
 

--- a/app/tests/api/api_v1/test_test_run_executions.py
+++ b/app/tests/api/api_v1/test_test_run_executions.py
@@ -1449,17 +1449,18 @@ def test_operations_missing_test_run(client: TestClient, db: Session) -> None:
 def test_create_cli_test_run_execution_with_valid_project_id_in_execution(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test creating a CLI test run execution with a valid project_id in test_run_execution_in"""
+    """Test creating a CLI test run execution with a valid project_id in
+    test_run_execution_in"""
     # Set project_id in the test_run_execution_create object
     test_run_execution_create.project_id = 123
-    
+
     # Mock existing project with specific ID
     mock_project = Project(
         id=123,
         name="Specific Test Project",
         config={},
     )
-    
+
     # Mock test run execution
     mock_test_run = TestRunExecution(
         id=1,
@@ -1474,17 +1475,22 @@ def test_create_cli_test_run_execution_with_valid_project_id_in_execution(
         imported_at=None,
         archived_at=None,
     )
-    
+
     # Configure mocks
     mock_db.query.return_value.filter.return_value.first.return_value = mock_project
     mock_db.add.return_value = None
     mock_db.commit.return_value = None
     mock_db.refresh.return_value = None
-    
-    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get", return_value=mock_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create", return_value=mock_test_run):
-        
+
+    with patch(
+        "app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.get",
+        return_value=mock_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create",
+        return_value=mock_test_run,
+    ):
         response = client.post(
             f"{settings.API_V1_STR}/test_run_executions/cli",
             json={
@@ -1494,7 +1500,7 @@ def test_create_cli_test_run_execution_with_valid_project_id_in_execution(
                 "pics": {},
             },
         )
-    
+
     assert response.status_code == 200
     data = response.json()
     assert data["title"] == test_run_execution_create.title
@@ -1504,13 +1510,17 @@ def test_create_cli_test_run_execution_with_valid_project_id_in_execution(
 def test_create_cli_test_run_execution_with_invalid_project_id_in_execution(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test creating a CLI test run execution with an invalid project_id in test_run_execution_in"""
+    """Test creating a CLI test run execution with an invalid project_id in
+    test_run_execution_in"""
     # Set invalid project_id in the test_run_execution_create object
     test_run_execution_create.project_id = 999
-    
-    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get", return_value=None):
-        
+
+    with patch(
+        "app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.get",
+        return_value=None,
+    ):
         response = client.post(
             f"{settings.API_V1_STR}/test_run_executions/cli",
             json={
@@ -1520,7 +1530,7 @@ def test_create_cli_test_run_execution_with_invalid_project_id_in_execution(
                 "pics": {},
             },
         )
-    
+
     assert response.status_code == HTTPStatus.NOT_FOUND
     data = response.json()
     assert "Project with id 999 not found" in data["detail"]
@@ -1529,17 +1539,18 @@ def test_create_cli_test_run_execution_with_invalid_project_id_in_execution(
 def test_create_cli_test_run_execution_without_project_id_in_execution_uses_default(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test creating a CLI test run execution without project_id in test_run_execution_in uses default CLI project"""
+    """Test creating a CLI test run execution without project_id in
+    test_run_execution_in uses default CLI project"""
     # Ensure project_id is None in test_run_execution_create
     test_run_execution_create.project_id = None
-    
+
     # Mock default CLI project
     mock_cli_project = Project(
         id=1,
         name=DEFAULT_CLI_PROJECT_NAME,
         config={},
     )
-    
+
     mock_test_run = TestRunExecution(
         id=1,
         title=test_run_execution_create.title,
@@ -1553,25 +1564,36 @@ def test_create_cli_test_run_execution_without_project_id_in_execution_uses_defa
         imported_at=None,
         archived_at=None,
     )
-    
+
     # Configure mocks
     mock_db.query.return_value.filter.return_value.first.return_value = mock_cli_project
     mock_db.add.return_value = None
     mock_db.commit.return_value = None
     mock_db.refresh.return_value = None
-    
+
     # Comprehensive mocking for all possible paths in the CLI project flow
-    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name", return_value=mock_cli_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.update", return_value=mock_cli_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.create", return_value=mock_cli_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create", return_value=mock_test_run), \
-         patch("app.api.api_v1.endpoints.test_run_executions.__convert_pics_dict_to_object") as mock_pics:
-        
+    with patch(
+        "app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name",
+        return_value=mock_cli_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.update",
+        return_value=mock_cli_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.create",
+        return_value=mock_cli_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create",
+        return_value=mock_test_run,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.__convert_pics_dict_to_object"
+    ) as mock_pics:
         # Mock PICS conversion to return a valid PICS object
         from app import schemas
+
         mock_pics.return_value = schemas.PICS(clusters={})
-        
+
         response = client.post(
             f"{settings.API_V1_STR}/test_run_executions/cli",
             json={
@@ -1581,7 +1603,7 @@ def test_create_cli_test_run_execution_without_project_id_in_execution_uses_defa
                 "pics": {},
             },
         )
-    
+
     assert response.status_code == 200
     data = response.json()
     assert data["title"] == test_run_execution_create.title
@@ -1591,16 +1613,17 @@ def test_create_cli_test_run_execution_without_project_id_in_execution_uses_defa
 def test_create_cli_test_run_execution_creates_default_project_when_missing_new_flow(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test creating a CLI test run execution creates default CLI project if it doesn't exist (new flow)"""
+    """Test creating a CLI test run execution creates default CLI project if it doesn't
+    exist (new flow)"""
     # Ensure project_id is None in test_run_execution_create
     test_run_execution_create.project_id = None
-    
+
     mock_new_project = Project(
         id=1,
         name=DEFAULT_CLI_PROJECT_NAME,
         config=default_config,
     )
-    
+
     mock_test_run = TestRunExecution(
         id=1,
         title=test_run_execution_create.title,
@@ -1608,18 +1631,30 @@ def test_create_cli_test_run_execution_creates_default_project_when_missing_new_
         project_id=1,
         operator_id=1,
     )
-    
-    # Configure mocks: first call returns None (project not found), subsequent calls return the created project
-    mock_db.query.return_value.filter.return_value.first.side_effect = [None, mock_new_project, mock_test_run]
+
+    # Configure mocks: first call returns None (project not found), subsequent calls
+    # return the created project
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        None,
+        mock_new_project,
+        mock_test_run,
+    ]
     mock_db.add.return_value = None
     mock_db.commit.return_value = None
     mock_db.refresh.return_value = None
-    
-    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name", return_value=None), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.create", return_value=mock_new_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.create_test_run_execution", return_value=mock_test_run):
-        
+
+    with patch(
+        "app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name",
+        return_value=None,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.create",
+        return_value=mock_new_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.create_test_run_execution",
+        return_value=mock_test_run,
+    ):
         response = client.post(
             f"{settings.API_V1_STR}/test_run_executions/cli",
             json={
@@ -1629,7 +1664,7 @@ def test_create_cli_test_run_execution_creates_default_project_when_missing_new_
                 "pics": {},
             },
         )
-    
+
     assert response.status_code == 200
     data = response.json()
     assert data["title"] == test_run_execution_create.title
@@ -1639,19 +1674,20 @@ def test_create_cli_test_run_execution_creates_default_project_when_missing_new_
 def test_create_cli_test_run_execution_project_id_zero_uses_default(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test creating a CLI test run execution with project_id=0 (falsy) uses default CLI project"""
+    """Test creating a CLI test run execution with project_id=0 (falsy) uses default
+    CLI project"""
     # Set project_id to None (explicitly falsy) in test_run_execution_create
     # Note: We test None here instead of 0 because they both evaluate to falsy
     # and should follow the same code path
     test_run_execution_create.project_id = None
-    
+
     # Mock default CLI project
     mock_cli_project = Project(
         id=1,
         name=DEFAULT_CLI_PROJECT_NAME,
         config={},
     )
-    
+
     mock_test_run = TestRunExecution(
         id=1,
         title=test_run_execution_create.title,
@@ -1665,25 +1701,36 @@ def test_create_cli_test_run_execution_project_id_zero_uses_default(
         imported_at=None,
         archived_at=None,
     )
-    
+
     # Configure mocks to ensure all code paths are covered
     mock_db.query.return_value.filter.return_value.first.return_value = mock_cli_project
     mock_db.add.return_value = None
     mock_db.commit.return_value = None
     mock_db.refresh.return_value = None
-    
+
     # Comprehensive mocking for all possible paths in the CLI project flow
-    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name", return_value=mock_cli_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.update", return_value=mock_cli_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.create", return_value=mock_cli_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create", return_value=mock_test_run), \
-         patch("app.api.api_v1.endpoints.test_run_executions.__convert_pics_dict_to_object") as mock_pics:
-        
+    with patch(
+        "app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name",
+        return_value=mock_cli_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.update",
+        return_value=mock_cli_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.create",
+        return_value=mock_cli_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create",
+        return_value=mock_test_run,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.__convert_pics_dict_to_object"
+    ) as mock_pics:
         # Mock PICS conversion to return a valid PICS object
         from app import schemas
+
         mock_pics.return_value = schemas.PICS(clusters={})
-        
+
         response = client.post(
             f"{settings.API_V1_STR}/test_run_executions/cli",
             json={
@@ -1693,7 +1740,7 @@ def test_create_cli_test_run_execution_project_id_zero_uses_default(
                 "pics": {},
             },
         )
-    
+
     assert response.status_code == 200
     data = response.json()
     assert data["title"] == test_run_execution_create.title

--- a/app/tests/api/api_v1/test_test_run_executions.py
+++ b/app/tests/api/api_v1/test_test_run_executions.py
@@ -1452,14 +1452,14 @@ def test_create_cli_test_run_execution_with_valid_project_id_in_execution(
     """Test creating a CLI test run execution with a valid project_id in test_run_execution_in"""
     # Set project_id in the test_run_execution_create object
     test_run_execution_create.project_id = 123
-    
+
     # Mock existing project with specific ID
     mock_project = Project(
         id=123,
         name="Specific Test Project",
         config={},
     )
-    
+
     # Mock test run execution
     mock_test_run = TestRunExecution(
         id=1,
@@ -1468,17 +1468,22 @@ def test_create_cli_test_run_execution_with_valid_project_id_in_execution(
         project_id=123,
         operator_id=1,
     )
-    
+
     # Configure mocks
     mock_db.query.return_value.filter.return_value.first.return_value = mock_project
     mock_db.add.return_value = None
     mock_db.commit.return_value = None
     mock_db.refresh.return_value = None
-    
-    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get", return_value=mock_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.create_test_run_execution", return_value=mock_test_run):
-        
+
+    with patch(
+        "app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.get",
+        return_value=mock_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.create_test_run_execution",
+        return_value=mock_test_run,
+    ):
         response = client.post(
             f"{settings.API_V1_STR}/test_run_executions/cli",
             json={
@@ -1488,7 +1493,7 @@ def test_create_cli_test_run_execution_with_valid_project_id_in_execution(
                 "pics": {},
             },
         )
-    
+
     assert response.status_code == 200
     data = response.json()
     assert data["title"] == test_run_execution_create.title
@@ -1501,10 +1506,13 @@ def test_create_cli_test_run_execution_with_invalid_project_id_in_execution(
     """Test creating a CLI test run execution with an invalid project_id in test_run_execution_in"""
     # Set invalid project_id in the test_run_execution_create object
     test_run_execution_create.project_id = 999
-    
-    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get", return_value=None):
-        
+
+    with patch(
+        "app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.get",
+        return_value=None,
+    ):
         response = client.post(
             f"{settings.API_V1_STR}/test_run_executions/cli",
             json={
@@ -1514,7 +1522,7 @@ def test_create_cli_test_run_execution_with_invalid_project_id_in_execution(
                 "pics": {},
             },
         )
-    
+
     assert response.status_code == HTTPStatus.NOT_FOUND
     data = response.json()
     assert "Project with id 999 not found" in data["detail"]
@@ -1526,14 +1534,14 @@ def test_create_cli_test_run_execution_without_project_id_in_execution_uses_defa
     """Test creating a CLI test run execution without project_id in test_run_execution_in uses default CLI project"""
     # Ensure project_id is None in test_run_execution_create
     test_run_execution_create.project_id = None
-    
+
     # Mock default CLI project
     mock_cli_project = Project(
         id=1,
         name=DEFAULT_CLI_PROJECT_NAME,
         config={},
     )
-    
+
     mock_test_run = TestRunExecution(
         id=1,
         title=test_run_execution_create.title,
@@ -1547,18 +1555,25 @@ def test_create_cli_test_run_execution_without_project_id_in_execution_uses_defa
         imported_at=None,
         archived_at=None,
     )
-    
+
     # Configure mocks
     mock_db.query.return_value.filter.return_value.first.return_value = mock_cli_project
     mock_db.add.return_value = None
     mock_db.commit.return_value = None
     mock_db.refresh.return_value = None
-    
-    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name", return_value=mock_cli_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.update", return_value=mock_cli_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create", return_value=mock_test_run):
-        
+
+    with patch(
+        "app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name",
+        return_value=mock_cli_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.update",
+        return_value=mock_cli_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create",
+        return_value=mock_test_run,
+    ):
         response = client.post(
             f"{settings.API_V1_STR}/test_run_executions/cli",
             json={
@@ -1568,7 +1583,7 @@ def test_create_cli_test_run_execution_without_project_id_in_execution_uses_defa
                 "pics": {},
             },
         )
-    
+
     assert response.status_code == 200
     data = response.json()
     assert data["title"] == test_run_execution_create.title
@@ -1581,13 +1596,13 @@ def test_create_cli_test_run_execution_creates_default_project_when_missing_new_
     """Test creating a CLI test run execution creates default CLI project if it doesn't exist (new flow)"""
     # Ensure project_id is None in test_run_execution_create
     test_run_execution_create.project_id = None
-    
+
     mock_new_project = Project(
         id=1,
         name=DEFAULT_CLI_PROJECT_NAME,
         config=default_config,
     )
-    
+
     mock_test_run = TestRunExecution(
         id=1,
         title=test_run_execution_create.title,
@@ -1595,18 +1610,29 @@ def test_create_cli_test_run_execution_creates_default_project_when_missing_new_
         project_id=1,
         operator_id=1,
     )
-    
+
     # Configure mocks: first call returns None (project not found), subsequent calls return the created project
-    mock_db.query.return_value.filter.return_value.first.side_effect = [None, mock_new_project, mock_test_run]
+    mock_db.query.return_value.filter.return_value.first.side_effect = [
+        None,
+        mock_new_project,
+        mock_test_run,
+    ]
     mock_db.add.return_value = None
     mock_db.commit.return_value = None
     mock_db.refresh.return_value = None
-    
-    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name", return_value=None), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.create", return_value=mock_new_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.create_test_run_execution", return_value=mock_test_run):
-        
+
+    with patch(
+        "app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name",
+        return_value=None,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.create",
+        return_value=mock_new_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.create_test_run_execution",
+        return_value=mock_test_run,
+    ):
         response = client.post(
             f"{settings.API_V1_STR}/test_run_executions/cli",
             json={
@@ -1616,7 +1642,7 @@ def test_create_cli_test_run_execution_creates_default_project_when_missing_new_
                 "pics": {},
             },
         )
-    
+
     assert response.status_code == 200
     data = response.json()
     assert data["title"] == test_run_execution_create.title
@@ -1629,14 +1655,14 @@ def test_create_cli_test_run_execution_project_id_zero_uses_default(
     """Test creating a CLI test run execution with project_id=0 (falsy) uses default CLI project"""
     # Set project_id to 0 (falsy value) in test_run_execution_create
     test_run_execution_create.project_id = 0
-    
+
     # Mock default CLI project
     mock_cli_project = Project(
         id=1,
         name=DEFAULT_CLI_PROJECT_NAME,
         config={},
     )
-    
+
     mock_test_run = TestRunExecution(
         id=1,
         title=test_run_execution_create.title,
@@ -1650,18 +1676,25 @@ def test_create_cli_test_run_execution_project_id_zero_uses_default(
         imported_at=None,
         archived_at=None,
     )
-    
+
     # Configure mocks
     mock_db.query.return_value.filter.return_value.first.return_value = mock_cli_project
     mock_db.add.return_value = None
     mock_db.commit.return_value = None
     mock_db.refresh.return_value = None
-    
-    with patch("app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name", return_value=mock_cli_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.project.update", return_value=mock_cli_project), \
-         patch("app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create", return_value=mock_test_run):
-        
+
+    with patch(
+        "app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.get_by_name",
+        return_value=mock_cli_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.update",
+        return_value=mock_cli_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create",
+        return_value=mock_test_run,
+    ):
         response = client.post(
             f"{settings.API_V1_STR}/test_run_executions/cli",
             json={
@@ -1671,7 +1704,7 @@ def test_create_cli_test_run_execution_project_id_zero_uses_default(
                 "pics": {},
             },
         )
-    
+
     assert response.status_code == 200
     data = response.json()
     assert data["title"] == test_run_execution_create.title

--- a/app/tests/api/api_v1/test_test_run_executions.py
+++ b/app/tests/api/api_v1/test_test_run_executions.py
@@ -1671,14 +1671,12 @@ def test_create_cli_test_run_execution_creates_default_project_when_missing_new_
     assert data["project_id"] == 1
 
 
-def test_create_cli_test_run_execution_project_id_zero_uses_default(
+def test_create_cli_test_run_execution_with_none_project_id_uses_default(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test creating a CLI test run execution with project_id=0 (falsy) uses default
-    CLI project"""
-    # Set project_id to None (explicitly falsy) in test_run_execution_create
-    # Note: We test None here instead of 0 because they both evaluate to falsy
-    # and should follow the same code path
+    """Test creating a CLI test run execution with project_id=None uses the default
+    CLI project."""
+    # Set project_id to None to test the default project logic
     test_run_execution_create.project_id = None
 
     # Mock default CLI project


### PR DESCRIPTION
### What changed
The goal of this PR is to add support to attach a cli execution into an existing project. 

### Related Issue
https://github.com/project-chip/certification-tool/issues/714

### Testing

- New unit tests were added and all unit test as running successfully.

- Run cli execution passing project-id argument

> ubuntu@ubuntu:~/certification-tool/cli$ ./cli.sh run-tests --tests-list TC-ACE-1.3 -p pics_tst --project-id 5
> Read config from file: {'network': {'fabric_id': '0', 'thread': {'dataset': {'channel': '15', 'panid': '0x1234', 'extpanid': '1111111122222222', 'networkkey': '00112233445566778899aabbccddeeff', 'networkname': 'DEMO'}, 'rcp_serial_path': '/dev/ttyACM0', 'rcp_baudrate': '115200', 'on_mesh_prefix': 'fd11:22::/64', 'network_interface': 'eth0'}, 'wifi': {'ssid': 'testharness', 'password': 'wifi-password'}}, 'network.thread': {}, 'network.wifi': {}, 'dut_config': {'pairing_mode': 'onnetwork', 'setup_code': '20202021', 'discriminator': '3840', 'chip_use_paa_certs': 'false', 'trace_log': 'true'}, 'test_parameters': {}}
> CLI Config for test run execution: {'network': {'thread': {'dataset': {'channel': '15', 'panid': '0x1234', 'extpanid': '1111111122222222', 'networkkey': '00112233445566778899aabbccddeeff', 'networkname': 'DEMO'}, 'rcp_serial_path': '/dev/ttyACM0', 'rcp_baudrate': '115200', 'on_mesh_prefix': 'fd11:22::/64', 'network_interface': 'eth0'}, 'wifi': {'ssid': 'testharness', 'password': 'wifi-password'}}, 'dut_config': {'discriminator': '3840', 'setup_code': '20202021', 'pairing_mode': 'onnetwork', 'trace_log': True, 'chip_timeout': None, 'chip_use_paa_certs': False}, 'test_parameters': {}}
> PICS Used: {
>   "clusters": {
>     "Access Control cluster": {
>       "name": "Access Control cluster",
>       "items": {
>         "ACL.S": {
>           "number": "ACL.S",
>           "enabled": true
>         },
>         "ACL.C": {
>           "number": "ACL.C",
>           "enabled": false
>         },
>         "ACL.S.A0000": {
>           "number": "ACL.S.A0000",
>           "enabled": true
>         },
>         "ACL.S.A0001": {
>           "number": "ACL.S.A0001",
>           "enabled": true
>         },
>         "ACL.S.A0002": {
>           "number": "ACL.S.A0002",
>           "enabled": true
>         },
>         "ACL.S.A0003": {
>           "number": "ACL.S.A0003",
>           "enabled": true
>         },
>         "ACL.S.A0004": {
>           "number": "ACL.S.A0004",
>           "enabled": true
>         },
>         "ACL.S.E00": {
>           "number": "ACL.S.E00",
>           "enabled": false
>         },
>         "ACL.S.E01": {
>           "number": "ACL.S.E01",
>           "enabled": false
>         }
>       }
>     },
>     "Actions Cluster Test Plan": {
>       "name": "Actions Cluster Test Plan",
>       "items": {
>         "ACT.S": {
>           "number": "ACT.S",
>           "enabled": false
>         },
>         "ACT.C": {
>           "number": "ACT.C",
>           "enabled": false
>         },
>         "ACT.S.A0000": {
>           "number": "ACT.S.A0000",
>           "enabled": false
>         },
>         "ACT.S.A0001": {
>           "number": "ACT.S.A0001",
>           "enabled": false
>         },
>         "ACT.S.A0002": {
>           "number": "ACT.S.A0002",
>           "enabled": false
>         }
>       }
>     }
>   }
> }
> Selected tests: {
>   "SDK Python Tests": {
>     "Python Testing Suite": {
>       "TC_ACE_1_3": 1
>     }
>   }
> }
> Creating new test run with title: 2025-08-20-18:10:30
> Starting Test run: Title: 2025-08-20-18:10:30, id: 111
> Test Run [EXECUTING]
>   - Python Testing Suite [EXECUTING]
> =======================================
> Do you want to reuse the previous commissioning information?
> If you select NO, a new commissioning will be performed
>   1: YES
>   2: NO
> Please enter a number for an option above: 
> 1
> =======================================
>       - TC-ACE-1.3 [EXECUTING]
>             - Start Python test [EXECUTING]
>             - Start Python test [PASSED]
>             - Commissioning, already done [EXECUTING]
>             - Commissioning, already done [PASSED]
>             - TH0 writes ACL all view on PIXIT.ACE.TESTENDPOINT [EXECUTING]
>             - TH0 writes ACL all view on PIXIT.ACE.TESTENDPOINT [PASSED]
>             - TH1 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH0 writes ACL TH1 view on EP0 [EXECUTING]
>             - TH0 writes ACL TH1 view on EP0 [PASSED]
>             - TH1 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH0 writes ACL TH2 view on EP0 [EXECUTING]
>             - TH0 writes ACL TH2 view on EP0 [PASSED]
>             - TH1 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH0 writes ACL TH3 view on EP0 [EXECUTING]
>             - TH0 writes ACL TH3 view on EP0 [PASSED]
>             - TH1 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH0 writes ACL TH1 TH2 view on EP0 [EXECUTING]
>             - TH0 writes ACL TH1 TH2 view on EP0 [PASSED]
>             - TH1 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH0 writes ACL TH1 TH3 view on EP0 [EXECUTING]
>             - TH0 writes ACL TH1 TH3 view on EP0 [PASSED]
>             - TH1 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH0 writes ACL TH2 TH3 view on EP0 [EXECUTING]
>             - TH0 writes ACL TH2 TH3 view on EP0 [PASSED]
>             - TH1 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH0 writes ACL TH1 TH2 TH3 view on EP0 [EXECUTING]
>             - TH0 writes ACL TH1 TH2 TH3 view on EP0 [PASSED]
>             - TH1 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH0 writes ACL cat1v1 view on EP0 [EXECUTING]
>             - TH0 writes ACL cat1v1 view on EP0 [PASSED]
>             - TH1 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH0 writes ACL cat1v2 view on EP0 [EXECUTING]
>             - TH0 writes ACL cat1v2 view on EP0 [PASSED]
>             - TH1 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH0 writes ACL cat1v3 view on EP0 [EXECUTING]
>             - TH0 writes ACL cat1v3 view on EP0 [PASSED]
>             - TH1 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH0 writes ACL cat2v1 view on EP0 [EXECUTING]
>             - TH0 writes ACL cat2v1 view on EP0 [PASSED]
>             - TH1 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH0 writes ACL cat2v2 view on EP0 [EXECUTING]
>             - TH0 writes ACL cat2v2 view on EP0 [PASSED]
>             - TH1 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect SUCCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect SUCCESS [PASSED]
>             - TH0 writes ACL cat2v3 view on EP0 [EXECUTING]
>             - TH0 writes ACL cat2v3 view on EP0 [PASSED]
>             - TH1 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH1 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH2 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH2 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH3 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [EXECUTING]
>             - TH3 reads EP0 descriptor - expect UNSUPPORTED_ACCESS [PASSED]
>             - TH0 writes ACL back to default [EXECUTING]
>             - TH0 writes ACL back to default [PASSED]
>             - Show test logs [EXECUTING]
>             - Show test logs [PASSED]
>       - TC-ACE-1.3 [PASSED]
>   - Python Testing Suite [PASSED]
> Test Run [PASSED]
> Log output in: './output_logs/test_run_2025-08-20-18:10:30.log'