### PR TITLE
Updated fetch_sdk_tests_and_runner script to install chipyaml wheel

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -109,7 +109,8 @@
         "PCSC",
         "pcscd",
         "DGRAM",
-        "chipyaml"
+        "chipyaml", 
+        "webrtc"
     ],
     "allowCompoundWords": true,
     "ignorePaths": [

--- a/test_collections/matter/sdk_tests/scripts/fetch_sdk_tests_and_runner.sh
+++ b/test_collections/matter/sdk_tests/scripts/fetch_sdk_tests_and_runner.sh
@@ -173,7 +173,7 @@ build-backend = 'setuptools.build_meta'
 
 [project]
 name = "chipyaml"
-version = "0.0.1"
+version = "0.1.0"
 authors = [{name = "Project CHIP Authors"}]
 description = "Matter chipyaml package with adapters"
 

--- a/test_collections/matter/sdk_tests/scripts/fetch_sdk_tests_and_runner.sh
+++ b/test_collections/matter/sdk_tests/scripts/fetch_sdk_tests_and_runner.sh
@@ -158,10 +158,9 @@ rm -rf ${EXTRACTION_ROOT}
 
 mkdir -p ${EXTRACTION_ROOT}
 
-cd ${SDK_PATH}/scripts/py_matter_idl
-python -m build --outdir ${EXTRACTION_ROOT}
-cd ${SDK_PATH}/scripts/py_matter_yamltests
-python -m build --outdir ${EXTRACTION_ROOT}
+
+python -m build --outdir "${EXTRACTION_ROOT}" "${SDK_PATH}/scripts/py_matter_idl"
+python -m build --outdir "${EXTRACTION_ROOT}" "${SDK_PATH}/scripts/py_matter_yamltests"
 # Create chipyaml package with the full adapters structure
 mkdir -p "${EXTRACTION_ROOT}/chipyaml_src"
 cp -r ${SDK_PATH}/scripts/tests/chipyaml ${EXTRACTION_ROOT}/chipyaml_src/
@@ -183,8 +182,7 @@ where = ["."]
 EOF
 
 # Build chipyaml package from the source root
-cd ${EXTRACTION_ROOT}/chipyaml_src
-python -m build --outdir ${EXTRACTION_ROOT}
+python -m build --outdir "${EXTRACTION_ROOT}" "${EXTRACTION_ROOT}/chipyaml_src"
 
 # Clean up temporary source directory
 rm -rf ${EXTRACTION_ROOT}/chipyaml_src

--- a/test_collections/matter/sdk_tests/scripts/fetch_sdk_tests_and_runner.sh
+++ b/test_collections/matter/sdk_tests/scripts/fetch_sdk_tests_and_runner.sh
@@ -163,7 +163,7 @@ python -m build --outdir ${EXTRACTION_ROOT}
 cd ${SDK_PATH}/scripts/py_matter_yamltests
 python -m build --outdir ${EXTRACTION_ROOT}
 # Create chipyaml package with the full adapters structure
-mkdir -p ${EXTRACTION_ROOT}/chipyaml_src
+mkdir -p "${EXTRACTION_ROOT}/chipyaml_src"
 cp -r ${SDK_PATH}/scripts/tests/chipyaml ${EXTRACTION_ROOT}/chipyaml_src/
 
 # Create pyproject.toml for chipyaml package at the root level


### PR DESCRIPTION
### What changed
The goal of this PR is to fix another uncovered scenario in the initial PR. The execution was working only for the 1st execution because prestart script was not installing the python module, so this PR make the chipyaml module an installable package.

### Related Issue
 https://github.com/project-chip/certification-tool/issues/734
 
 ### Testing 
 TH launches successfully not only in the 1st execution
```
 Successfully installed chipyaml-0.0.1 matter-idl-1.0.0 matter-yamltests-1.0.0
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
+ exit 0
Prestart Complete
```
