### PR TITLE
[Camera] Restore msg argument in SDKPythonTestResultShowTwoWayTalkPrompt

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/python_testing_hooks_proxy.py
@@ -133,6 +133,7 @@ class SDKPythonTestResultShowImagePrompt(SDKPythonTestResultBase):
 
 class SDKPythonTestResultShowTwoWayTalkPrompt(SDKPythonTestResultBase):
     type = SDKPythonTestResultEnum.SHOW_TWO_WAY_TALK_PROMPT
+    msg: str
 
 
 class SDKPythonTestResultShowPushAVStreamPrompt(SDKPythonTestResultBase):


### PR DESCRIPTION
The msg argument was removed when merging PR #257 : https://github.com/project-chip/certification-tool-backend/pull/257/commits/cfad37666ad14a865ea6439f8737f962f91922f5

This PR restores the same in order to view the pop up.