### PR TITLE
[Fix] Passing Thread And Wi-Fi Data Always

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -82,16 +82,15 @@ async def generate_command_arguments(
     else:
         arguments.append(f"--commissioning-method {pairing_mode}")
 
-        if pairing_mode == DutPairingModeEnum.BLE_WIFI:
-            arguments.append(f"--wifi-ssid {config.network.wifi.ssid}")
-            arguments.append(f"--wifi-passphrase {config.network.wifi.password}")
-
-        if (
-            pairing_mode == DutPairingModeEnum.BLE_THREAD
-            or pairing_mode == DutPairingModeEnum.NFC_THREAD
-        ):
-            dataset_hex = await __thread_dataset_hex(config.network.thread)
-            arguments.append(f"--thread-dataset-hex {dataset_hex}")
+    if pairing_mode == DutPairingModeEnum.BLE_WIFI:
+        arguments.append(f"--wifi-ssid {config.network.wifi.ssid}")
+        arguments.append(f"--wifi-passphrase {config.network.wifi.password}")
+    elif (
+        pairing_mode == DutPairingModeEnum.BLE_THREAD
+        or pairing_mode == DutPairingModeEnum.NFC_THREAD
+    ):
+        dataset_hex = await __thread_dataset_hex(config.network.thread)
+        arguments.append(f"--thread-dataset-hex {dataset_hex}")
 
     # Retrieve arguments from test_parameters
     if test_parameters:


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/664
Fix: https://github.com/project-chip/certification-tool/issues/742
Fix: https://github.com/project-chip/certification-tool/issues/746
Depends on: https://github.com/project-chip/connectedhomeip/pull/41283
---


## Description
Updating the utility script method that generate the SDK container command arguments by always passing thread and wifi info even when omitting the commissioning operation (since some CNET test cases are requiring those information during the execution).

## Testing
Updating both this backend utility and the SDK's runner script, we had success testing for instance the CNET4.12 test case as shown below:
<img width="1713" height="906" alt="Screenshot 2025-10-06 at 12 16 44" src="https://github.com/user-attachments/assets/476d40c9-2b18-4dcb-a581-97ef960ff949" />
