### PR TITLE
[FIX] Custom Suite And Custom TC Naming

### DIFF
--- a/custom_python
+++ b/custom_python
@@ -1,0 +1,1 @@
+/home/ubuntu/certification-tool/backend/test_collections/matter/sdk_tests/sdk_checkout/python_testing/scripts/custom

--- a/custom_yaml
+++ b/custom_yaml
@@ -1,0 +1,1 @@
+/home/ubuntu/certification-tool/backend/test_collections/matter/sdk_tests/sdk_checkout/yaml_tests/yaml/custom

--- a/test_collections/matter/sdk_tests/support/performance_tests/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/performance_tests/models/test_suite.py
@@ -63,11 +63,7 @@ class PerformanceTestSuite(TestSuite):
                 "name": name,
                 "performance_test_version": performance_test_version,
                 "metadata": {
-                    "public_id": (
-                        name
-                        if performance_test_version != "custom"
-                        else name + "-custom"
-                    ),
+                    "public_id": name,
                     "version": "0.0.1",
                     "title": name,
                     "description": name,

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -380,9 +380,9 @@ class PythonTestCase(TestCase, UserPromptSupport):
         title = cls.__title(test.name)
         class_name = cls.__class_name(test.name)
         custom_suffix = (
-            ""
-            if python_test_version != CUSTOM_TEST_IDENTIFIER
-            else "-" + CUSTOM_TEST_IDENTIFIER
+            f"-{CUSTOM_TEST_IDENTIFIER}"
+            if python_test_version == CUSTOM_TEST_IDENTIFIER
+            else ""
         )
 
         return type(

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -379,6 +379,11 @@ class PythonTestCase(TestCase, UserPromptSupport):
         """class factory method for PythonTestCase."""
         title = cls.__title(test.name)
         class_name = cls.__class_name(test.name)
+        custom_suffix = (
+            ""
+            if python_test_version != CUSTOM_TEST_IDENTIFIER
+            else "-" + CUSTOM_TEST_IDENTIFIER
+        )
 
         return type(
             class_name,
@@ -387,13 +392,9 @@ class PythonTestCase(TestCase, UserPromptSupport):
                 "python_test": test,
                 "python_test_version": python_test_version,
                 "metadata": {
-                    "public_id": (
-                        test.name
-                        if python_test_version != CUSTOM_TEST_IDENTIFIER
-                        else test.name + "-" + CUSTOM_TEST_IDENTIFIER
-                    ),
+                    "public_id": test.name + custom_suffix,
                     "version": "0.0.1",
-                    "title": title,
+                    "title": title + custom_suffix,
                     "description": test.description,
                     "mandatory": mandatory,
                 },

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -87,9 +87,7 @@ class PythonTestSuite(TestSuite):
                 "name": name,
                 "python_test_version": python_test_version,
                 "metadata": {
-                    "public_id": (
-                        name if python_test_version != "custom" else name + "-custom"
-                    ),
+                    "public_id": name,
                     "version": "0.0.1",
                     "title": name,
                     "description": name,

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
@@ -96,6 +96,11 @@ class YamlTestCase(TestCase):
         identifier = cls.__test_identifier(test.name)
         class_name = cls.__class_name(identifier)
         title = cls.__title(identifier=identifier, test_yaml=test)
+        custom_suffix = (
+            ""
+            if yaml_version != CUSTOM_TEST_IDENTIFIER
+            else "-" + CUSTOM_TEST_IDENTIFIER
+        )
 
         return type(
             class_name,
@@ -105,13 +110,9 @@ class YamlTestCase(TestCase):
                 "yaml_version": yaml_version,
                 "chip_test_identifier": class_name,
                 "metadata": {
-                    "public_id": (
-                        identifier
-                        if yaml_version != CUSTOM_TEST_IDENTIFIER
-                        else identifier + "-" + CUSTOM_TEST_IDENTIFIER
-                    ),
+                    "public_id": identifier + custom_suffix,
                     "version": "0.0.1",
-                    "title": title,
+                    "title": title + custom_suffix,
                     "description": test.name,
                 },
             },

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/test_case.py
@@ -97,9 +97,9 @@ class YamlTestCase(TestCase):
         class_name = cls.__class_name(identifier)
         title = cls.__title(identifier=identifier, test_yaml=test)
         custom_suffix = (
-            ""
-            if yaml_version != CUSTOM_TEST_IDENTIFIER
-            else "-" + CUSTOM_TEST_IDENTIFIER
+            f"-{CUSTOM_TEST_IDENTIFIER}"
+            if yaml_version == CUSTOM_TEST_IDENTIFIER
+            else ""
         )
 
         return type(


### PR DESCRIPTION
fixes: https://github.com/project-chip/certification-tool/issues/799
---

# Description
Fixing Python Testing **Custom** Suite Naming and Both Python and YAML **Custom** Test Case Naming for presentation.

# Problem
The Python Testing Custom name was being presented in the TH application with the custom suffix (`-custom`) duplicated as we may seen in the image below:
<img width="567" height="118" alt="custom_duplicated" src="https://github.com/user-attachments/assets/7bc26a8f-b094-42d6-b407-fade70525f38" />

Furthermore, we may also verify that the Test Case doesn't show the appropriate tag above to signalize as custom as well.

# Solution

This change removes the duplication tag by removing from the `test_suite.py` file since the SDK Python init method already adds the tag at the `sdk_python_tests.py` file.

For the Test Cases, the logic present in both YAML and Python `test_case.py` files was updated to use a variable for the custom tag and add not only to the **public_id** but also for the **title** of the **class_factory()** method.

# Testing

The Unit Tests passed successfully and the results of the tests may be verified in the images below for both UI and CLI:

**Custom YAML UI:**
<img width="560" height="208" alt="custom_name_yaml" src="https://github.com/user-attachments/assets/17ab1224-6fe2-4fcd-97fd-185c798f88ef" />

**Custom YAML CLI:**
<img width="378" height="192" alt="custom_yaml_cli" src="https://github.com/user-attachments/assets/403a31b4-c774-46d4-bf13-658aa44e9a26" />

**Custom Python UI:**
<img width="558" height="249" alt="custom_name_python" src="https://github.com/user-attachments/assets/b2d77119-598f-4a12-826d-6cd9eaa3a744" />

**Custom Python CLI:**
<img width="435" height="312" alt="custom_python_cli" src="https://github.com/user-attachments/assets/12ebb453-2fd7-4422-ab2c-402e065dca74" />

---
Also, this change adds two symbolic links for easy access to the custom folders with the below:
- custom_python
- custom_yaml