### PR TITLE
Fixing Backend's API for the CLI Test Run Execution

### DIFF
--- a/app/singleton.py
+++ b/app/singleton.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+# type: ignore
+# Ignore mypy type check for this file
+
 from typing import Any, Dict, Type, TypeVar, cast
 
 T = TypeVar("T")
@@ -31,5 +34,5 @@ class Singleton(type):
 
     def __call__(cls: Type[T], *args: Any, **kwargs: Any) -> T:
         if cls not in Singleton._instances:
-            Singleton._instances[cls] = super().__call__(*args, **kwargs)  # type: ignore[misc]
+            Singleton._instances[cls] = super().__call__(*args, **kwargs)
         return cast(T, Singleton._instances[cls])

--- a/app/singleton.py
+++ b/app/singleton.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Project CHIP Authors
+# Copyright (c) 2025 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,11 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from typing import Any, Dict, Type
+from typing import Any, Dict, Type, TypeVar, cast
+
+T = TypeVar("T")
 
 
 class Singleton(type):
-    """This is a metaclass for declaring classes a singletons
+    """This is a metaclass for declaring classes as singletons
 
     usage:
     ```
@@ -27,7 +29,7 @@ class Singleton(type):
 
     _instances: Dict[Type, object] = {}
 
-    def __call__(cls, *args: Any, **kwargs: Any) -> object:
-        if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args, **kwargs)
-        return cls._instances[cls]
+    def __call__(cls: Type[T], *args: Any, **kwargs: Any) -> T:
+        if cls not in Singleton._instances:
+            Singleton._instances[cls] = super().__call__(*args, **kwargs)  # type: ignore[misc]
+        return cast(T, Singleton._instances[cls])

--- a/app/singleton.py
+++ b/app/singleton.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# type: ignore
-# Ignore mypy type check for this file
-
 from typing import Any, Dict, Type, TypeVar, cast
 
 T = TypeVar("T")
@@ -34,5 +31,7 @@ class Singleton(type):
 
     def __call__(cls: Type[T], *args: Any, **kwargs: Any) -> T:
         if cls not in Singleton._instances:
-            Singleton._instances[cls] = super().__call__(*args, **kwargs)
+            Singleton._instances[cls] = super().__call__(  # type: ignore[misc]
+                *args, **kwargs
+            )
         return cast(T, Singleton._instances[cls])

--- a/app/tests/api/api_v1/test_test_run_executions.py
+++ b/app/tests/api/api_v1/test_test_run_executions.py
@@ -1528,7 +1528,7 @@ def test_create_cli_test_run_execution_with_invalid_project_id_in_execution(
 
     assert response.status_code == HTTPStatus.NOT_FOUND
     data = response.json()
-    assert "Project with id 999 not found" in data["detail"]
+    assert "Project with ID 999 not found" in data["detail"]
 
 
 def test_create_cli_test_run_execution_without_project_id_in_execution_uses_default(
@@ -1612,6 +1612,8 @@ def test_create_cli_test_run_execution_creates_default_project_when_missing(
         description=test_run_execution_create.description,
         project_id=1,
         operator_id=1,
+        certification_mode=False,
+        state=TestStateEnum.PENDING,
     )
 
     with patch(
@@ -1623,7 +1625,10 @@ def test_create_cli_test_run_execution_creates_default_project_when_missing(
         "app.api.api_v1.endpoints.test_run_executions.crud.project.create",
         return_value=mock_new_project,
     ), patch(
-        "app.api.api_v1.endpoints.test_run_executions.create_test_run_execution",
+        "app.api.api_v1.endpoints.test_run_executions.crud.project.update",
+        return_value=mock_new_project,
+    ), patch(
+        "app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create",
         return_value=mock_test_run,
     ):
         response = client.post(


### PR DESCRIPTION
Related to: https://github.com/project-chip/certification-tool/issues/816
---

# Description

Fixing the `create_cli_test_run_execution()` to overwrite if the config parameter is provided, **or** use project config if the parameter is None.

Also, updating the Singleton file as developer quality of life, since it now recognizes the type of the Singleton.

Finally, CLI Unit Test updated accordingly.

