### PR TITLE
[Feature] Adding chip-server information API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,5 +15,6 @@ test_db_creation.lock
 .sha_information
 test_collections/matter/sdk_tests/sdk_checkout
 performance-logs
+output_logs/
 test_collections/matter/sdk_tests/custom_python_tests_info.json
 test_collections/matter/sdk_tests/python_tests_info.json

--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -266,19 +266,16 @@ def get_test_runner_status() -> dict[str, Any]:
 
 
 @router.get("/chip-server/info", response_model=schemas.ChipServerInfo)
-def get_chip_server_info() -> dict[str, Any]:
+def get_chip_server_info() -> schemas.ChipServerInfo:
     """
     Retrieve ChipServer node ID information.
 
     Returns:
         ChipServerInfo: Contains node_id (int) and node_id_hex (str) values.
     """
-    chip_server: ChipServer = ChipServer()
+    chip_server = ChipServer()
     node_id = chip_server.node_id
-    return {
-        "node_id": node_id,
-        "node_id_hex": hex(node_id),
-    }
+    return schemas.ChipServerInfo(node_id=node_id, node_id_hex=hex(node_id))
 
 
 @router.get("/{id}", response_model=schemas.TestRunExecutionWithChildren)

--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -44,6 +44,7 @@ from app.utils import (
     selected_tests_from_execution,
 )
 from app.version import version_information
+from test_collections.matter.sdk_tests.support.chip.chip_server import ChipServer
 from test_collections.matter.sdk_tests.support.performance_tests.utils import (
     create_summary_report,
 )
@@ -262,6 +263,22 @@ def get_test_runner_status() -> dict[str, Any]:
         status["test_run_execution_id"] = test_runner.test_run.test_run_execution.id
 
     return status
+
+
+@router.get("/chip-server/info", response_model=schemas.ChipServerInfo)
+def get_chip_server_info() -> dict[str, Any]:
+    """
+    Retrieve ChipServer node ID information.
+
+    Returns:
+        ChipServerInfo: Contains node_id (int) and node_id_hex (str) values.
+    """
+    chip_server: ChipServer = ChipServer()
+    node_id = chip_server.node_id
+    return {
+        "node_id": node_id,
+        "node_id_hex": hex(node_id),
+    }
 
 
 @router.get("/{id}", response_model=schemas.TestRunExecutionWithChildren)

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Project CHIP Authors
+# Copyright (c) 2025 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from .chip_server_info import ChipServerInfo
 from .grouped_test_run_execution_logs import GroupedTestRunExecutionLogs
 from .mock import Mock
 from .msg import Msg

--- a/app/schemas/chip_server_info.py
+++ b/app/schemas/chip_server_info.py
@@ -1,0 +1,31 @@
+#
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from pydantic import BaseModel
+
+
+class ChipServerInfo(BaseModel):
+    """Schema for ChipServer information."""
+
+    node_id: int
+    node_id_hex: str
+
+    class Config:
+        schema_extra = {
+            "example": {
+                "node_id": 1234567890,
+                "node_id_hex": "0x499602d2",
+            }
+        }


### PR DESCRIPTION
Related to: https://github.com/project-chip/certification-tool/issues/802
Related to: https://github.com/project-chip/certification-tool-cli/pull/48
---

Adding a new API to retrieve the Node ID information from the CHIP-server.
This information is particularly useful for the CLI output to be used in the test run executions.