### PR TITLE
[Feature] Updating CHIP Server Info Endpoint to Include Manual Pairing Code

### DIFF
--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -309,7 +309,7 @@ def get_chip_server_info(
     return schemas.ChipServerInfo(
         node_id=node_id,
         node_id_hex=hex(node_id),
-        manual_pairing_code=manual_pairing_code if manual_pairing_code else None,
+        manual_pairing_code=manual_pairing_code or None,
     )
 
 

--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -17,7 +17,7 @@ import json
 import os
 from datetime import datetime
 from http import HTTPStatus
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import requests
 from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, UploadFile
@@ -55,12 +55,12 @@ router = APIRouter()
 DEFAULT_CLI_PROJECT_NAME = "CLI Project Execution"
 
 
-@router.get("/", response_model=List[schemas.TestRunExecutionWithStats])
+@router.get("/", response_model=list[schemas.TestRunExecutionWithStats])
 def read_test_run_executions(
     db: Session = Depends(get_db),
-    project_id: Optional[int] = None,
+    project_id: int | None = None,
     archived: bool = False,
-    search_query: Optional[str] = None,
+    search_query: str | None = None,
     skip: int = 0,
     limit: int = 100,
     sort_order: str = "asc",
@@ -110,7 +110,7 @@ def create_test_run_execution(
     return test_run_execution
 
 
-def __convert_pics_dict_to_object(pics: dict) -> Optional[schemas.PICS]:
+def __convert_pics_dict_to_object(pics: dict) -> schemas.PICS | None:
     """Convert a dictionary to a PICS object.
 
     Args:
@@ -131,8 +131,8 @@ def __convert_pics_dict_to_object(pics: dict) -> Optional[schemas.PICS]:
 
 def __cli_project(
     db: Session,
-    project_id: Optional[int],
-    config: Optional[dict],
+    project_id: int | None,
+    config: dict | None,
     pics_obj: schemas.PICS,
 ) -> Project:
     """Retrieve or create the default CLI project."""
@@ -178,7 +178,7 @@ def create_cli_test_run_execution(
     db: Session = Depends(get_db),
     test_run_execution_in: schemas.TestRunExecutionCreate,
     selected_tests: schemas.TestSelection,
-    config: Optional[dict] = None,
+    config: dict | None = None,
     pics: dict = {},
 ) -> TestRunExecution:
     """Creates a new test run execution on CLI request.
@@ -233,7 +233,7 @@ def rename_test_run_execution(
     )
 
 
-@router.post("/abort-testing", response_model=Dict[str, str])
+@router.post("/abort-testing", response_model=dict[str, str])
 def abort_testing(
     *,
     db: Session = Depends(get_db),
@@ -270,16 +270,47 @@ def get_test_runner_status() -> dict[str, Any]:
 
 
 @router.get("/chip-server/info", response_model=schemas.ChipServerInfo)
-def get_chip_server_info() -> schemas.ChipServerInfo:
+def get_chip_server_info(
+    discriminator: str | None = None,
+    setup_pin_code: str | None = None,
+    version: int = 0,
+    vendor_id: int = 0,
+    product_id: int = 0,
+) -> schemas.ChipServerInfo:
     """
-    Retrieve ChipServer node ID information.
+    Retrieve ChipServer node ID information and generate manual pairing code.
+
+    Note: Manual pairing code generation requires the SDK container to be running.
+    If called before the SDK container starts, manual_pairing_code will be None.
+
+    Args:
+        discriminator: Device discriminator (optional)
+        setup_pin_code: Setup PIN code (optional)
+        version: Version number (default: 0)
+        vendor_id: Vendor ID (default: 0)
+        product_id: Product ID (default: 0)
 
     Returns:
-        ChipServerInfo: Contains node_id (int) and node_id_hex (str) values.
+        ChipServerInfo: Contains node_id, node_id_hex, and optional manual_pairing_code.
     """
     chip_server = ChipServer()
     node_id = chip_server.node_id
-    return schemas.ChipServerInfo(node_id=node_id, node_id_hex=hex(node_id))
+
+    manual_pairing_code = None
+    if discriminator and setup_pin_code:
+        manual_pairing_code = chip_server.generate_manual_pairing_code_with_chip_tool(
+            discriminator=discriminator,
+            setup_pin_code=setup_pin_code,
+            version=version,
+            vendor_id=vendor_id,
+            product_id=product_id,
+        )
+
+    return schemas.ChipServerInfo(
+        node_id=node_id,
+        node_id_hex=hex(node_id),
+        manual_pairing_code=manual_pairing_code if manual_pairing_code else None,
+    )
 
 
 @router.get("/{id}", response_model=schemas.TestRunExecutionWithChildren)
@@ -384,7 +415,7 @@ def unarchive(
 
 @router.post("/{id}/repeat", response_model=schemas.TestRunExecutionWithChildren)
 def repeat_test_run_execution(
-    *, db: Session = Depends(get_db), id: int, title: Optional[str] = None
+    *, db: Session = Depends(get_db), id: int, title: str | None = None
 ) -> TestRunExecution:
     """Repeat a test run execution by id.
 

--- a/app/schemas/chip_server_info.py
+++ b/app/schemas/chip_server_info.py
@@ -21,11 +21,13 @@ class ChipServerInfo(BaseModel):
 
     node_id: int
     node_id_hex: str
+    manual_pairing_code: str | None = None
 
     class Config:
         schema_extra = {
             "example": {
                 "node_id": 1234567890,
                 "node_id_hex": "0x499602d2",
+                "manual_pairing_code": "34970112332",
             }
         }

--- a/test_collections/matter/sdk_tests/support/chip/chip_server.py
+++ b/test_collections/matter/sdk_tests/support/chip/chip_server.py
@@ -176,6 +176,7 @@ class ChipServer(metaclass=Singleton):
                 # Extract the Manual Code:"
                 code = line.split("Manual Code:")[-1].strip()
                 self.logger.info(f"Generated manual pairing code: {code}")
+                break
         return code
 
     def __reset_node_id(self) -> int:

--- a/test_collections/matter/sdk_tests/support/chip/chip_server.py
+++ b/test_collections/matter/sdk_tests/support/chip/chip_server.py
@@ -15,6 +15,7 @@
 #
 from __future__ import annotations
 
+import re
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -90,6 +91,92 @@ class ChipServer(metaclass=Singleton):
             return self.__reset_node_id()
 
         return self.__node_id
+
+    def generate_manual_pairing_code_with_chip_tool(
+        self,
+        discriminator: str,
+        setup_pin_code: str,
+        version: int = 0,
+        vendor_id: int = 0,
+        product_id: int = 0,
+    ) -> str:
+        """Generate manual pairing code using chip-tool payload command.
+
+        Note: This method requires the SDK container to be running.
+
+        Args:
+            discriminator: 12-bit discriminator value
+            setup_pin_code: Setup PIN code
+            version: Version number (default: 0)
+            vendor_id: Vendor ID (default: 0)
+            product_id: Product ID (default: 0)
+
+        Returns:
+            str: Manual pairing code or empty string if generation fails
+        """
+        # Check if SDK container is up
+        if not self.sdk_container.is_running():
+            self.logger.warning(
+                "SDK container is not running. Cannot generate manual pairing code."
+            )
+            return ""
+
+        try:
+            command = [
+                "payload",
+                "generate-manualcode",
+                "--discriminator",
+                discriminator,
+                "--setup-pin-code",
+                setup_pin_code,
+                "--version",
+                str(version),
+                "--vendor-id",
+                str(vendor_id),
+                "--product-id",
+                str(product_id),
+            ]
+
+            result = self.sdk_container.send_command(
+                command,
+                prefix=CHIP_TOOL_EXE,
+            )
+
+            # Parse the output result to extract the manual pairing code
+            if result.exit_code == 0 and result.output:
+                return self.__extract_manual_code(result.output)
+
+            self.logger.warning(
+                "Failed to generate manual pairing code from chip-tool output"
+            )
+            return ""
+        except Exception as e:
+            self.logger.error(f"Error generating manual pairing code: {e}")
+            return ""
+
+    def __extract_manual_code(self, log_chunk: Generator | bytes | tuple) -> str:
+        # Extracts the manual pairing code from the chip-tool output logs.
+        # Log format: "[timestamp] [pid:tid] [TOO] Manual Code: XXXXXXXXXX"
+        code = ""
+        output_str: str
+
+        # Convert output to string
+        if isinstance(log_chunk, bytes):
+            output_str = log_chunk.decode()
+        else:
+            # Handle Generator or tuple - convert to string
+            output_str = str(log_chunk)
+
+        # Remove ANSI escape sequences
+        output_str = re.sub(r"\x1b\[[0-9;]*m", "", output_str)
+
+        for line in output_str.splitlines():
+            # Look for the line containing "[TOO] Manual Code:"
+            if "[TOO] Manual Code:" in line:
+                # Extract the Manual Code:"
+                code = line.split("Manual Code:")[-1].strip()
+                self.logger.info(f"Generated manual pairing code: {code}")
+        return code
 
     def __reset_node_id(self) -> int:
         """Resets node_id to a random uint64."""


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/831
Related to: https://github.com/project-chip/certification-tool/issues/821
---

# Description
Updating the `CHIP Server Info` **endpoint** to also generate and return the **Manual Pairing Code** data to be used on Simulated Test Cases.

# Testing
Used the `openapi` docs to verify the new endpoint and running the CLI's TC that use the Manual Code data.

**PS**:
- Unit Tests are ok
- Sanity test with TCs