### PR TITLE
Implemented configuration for enabling/disabling container information logging

### DIFF
--- a/app/container_manager/container_manager.py
+++ b/app/container_manager/container_manager.py
@@ -51,7 +51,7 @@ class ContainerManager(object, metaclass=Singleton):
         container = self.__run_new_container(docker_image_tag, parameters)
         await self.__container_ready(container)
         if settings.ENABLE_CONTAINER_LOGS:
-            logger.info("Container running for " + docker_image_tag)
+            logger.info(f"Container running for {docker_image_tag}")
 
         return container
 
@@ -164,8 +164,6 @@ class ContainerManager(object, metaclass=Singleton):
                     f" Container Name: {str(container.name)}"
                 )
 
-            # Log equivalent shell command
-            if settings.ENABLE_CONTAINER_LOGS:
                 shell_cmd = docker_cp_from_container_command(
                     container.name,
                     container_file_path,
@@ -202,8 +200,6 @@ class ContainerManager(object, metaclass=Singleton):
                     f" Container Name: {str(container.name)}"
                 )
 
-            # Log equivalent shell command
-            if settings.ENABLE_CONTAINER_LOGS:
                 shell_cmd = docker_cp_to_container_command(
                     container.name, host_file_path, destination_container_path
                 )

--- a/app/container_manager/container_manager.py
+++ b/app/container_manager/container_manager.py
@@ -32,6 +32,7 @@ from app.container_manager.docker_shell_commands import (
     docker_rm_command,
     docker_run_command,
 )
+from app.core.config import settings
 from app.singleton import Singleton
 from app.test_engine.logger import test_engine_logger as logger
 
@@ -49,20 +50,23 @@ class ContainerManager(object, metaclass=Singleton):
     ) -> Container:
         container = self.__run_new_container(docker_image_tag, parameters)
         await self.__container_ready(container)
-        logger.info("Container running for " + docker_image_tag)
+        if settings.ENABLE_CONTAINER_LOGS:
+            logger.info("Container running for " + docker_image_tag)
 
         return container
 
     def destroy(self, container: Container) -> None:
         if self.is_running(container):
             # Log equivalent shell command for kill
-            shell_cmd = docker_kill_command(container.name)
-            logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
+            if settings.ENABLE_CONTAINER_LOGS:
+                shell_cmd = docker_kill_command(container.name)
+                logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
             container.kill()
 
         # Log equivalent shell command for remove
-        shell_cmd = docker_rm_command(container.name, force=True)
-        logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
+        if settings.ENABLE_CONTAINER_LOGS:
+            shell_cmd = docker_rm_command(container.name, force=True)
+            logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
         container.remove(force=True)
 
     def get_container(self, id_or_name: str) -> Optional[Container]:
@@ -109,8 +113,9 @@ class ContainerManager(object, metaclass=Singleton):
         # Create containers
         try:
             # Log equivalent shell command
-            shell_cmd = docker_run_command(docker_image_tag, parameters)
-            logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
+            if settings.ENABLE_CONTAINER_LOGS:
+                shell_cmd = docker_run_command(docker_image_tag, parameters)
+                logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
 
             return self.__client.containers.run(docker_image_tag, **parameters)
         except DockerException as error:
@@ -151,20 +156,22 @@ class ContainerManager(object, metaclass=Singleton):
         destination_file_name: str,
     ) -> None:
         try:
-            logger.info(
-                "### File Copy: CONTAINER->HOST"
-                f" From Container Path: {str(container_file_path)}"
-                f" To Host Path: {str(destination_path)}/{destination_file_name}"
-                f" Container Name: {str(container.name)}"
-            )
+            if settings.ENABLE_CONTAINER_LOGS:
+                logger.info(
+                    "### File Copy: CONTAINER->HOST"
+                    f" From Container Path: {str(container_file_path)}"
+                    f" To Host Path: {str(destination_path)}/{destination_file_name}"
+                    f" Container Name: {str(container.name)}"
+                )
 
             # Log equivalent shell command
-            shell_cmd = docker_cp_from_container_command(
-                container.name,
-                container_file_path,
-                destination_path / destination_file_name,
-            )
-            logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
+            if settings.ENABLE_CONTAINER_LOGS:
+                shell_cmd = docker_cp_from_container_command(
+                    container.name,
+                    container_file_path,
+                    destination_path / destination_file_name,
+                )
+                logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
 
             stream, _ = container.get_archive(str(container_file_path))
             with open(
@@ -187,18 +194,20 @@ class ContainerManager(object, metaclass=Singleton):
         destination_container_path: Path,
     ) -> None:
         try:
-            logger.info(
-                "### File Copy: HOST->CONTAINER"
-                f" From Host Path: {str(host_file_path)}"
-                f" To Container Path: {destination_container_path}"
-                f" Container Name: {str(container.name)}"
-            )
+            if settings.ENABLE_CONTAINER_LOGS:
+                logger.info(
+                    "### File Copy: HOST->CONTAINER"
+                    f" From Host Path: {str(host_file_path)}"
+                    f" To Container Path: {destination_container_path}"
+                    f" Container Name: {str(container.name)}"
+                )
 
             # Log equivalent shell command
-            shell_cmd = docker_cp_to_container_command(
-                container.name, host_file_path, destination_container_path
-            )
-            logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
+            if settings.ENABLE_CONTAINER_LOGS:
+                shell_cmd = docker_cp_to_container_command(
+                    container.name, host_file_path, destination_container_path
+                )
+                logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
 
             tar_stream = io.BytesIO()
             with tarfile.open(f"{host_file_path}", mode="r") as tar_in:

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Project CHIP Authors
+# Copyright (c) 2026 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -109,6 +109,9 @@ class Settings(BaseSettings):
 
     # Python Test Logging
     ENABLE_REALTIME_PYTHON_TEST_LOGS: bool = False
+
+    # Container Logging
+    ENABLE_CONTAINER_LOGS: bool = False
 
     class Config:
         case_sensitive = True

--- a/test_collections/matter/sdk_tests/support/sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/sdk_container.py
@@ -26,6 +26,7 @@ from app.container_manager.docker_shell_commands import (
     SHELL_CMD_LOG_PREFIX,
     docker_exec_command,
 )
+from app.core.config import settings
 from app.schemas.pics import PICS, PICSError
 from app.singleton import Singleton
 from app.test_engine.logger import test_engine_logger as logger
@@ -239,13 +240,14 @@ class SDKContainer(metaclass=Singleton):
         self.logger.info("Sending command to SDK container: " + full_cmd_str)
 
         # Log equivalent shell command
-        shell_cmd = docker_exec_command(
-            self.container_name,
-            full_cmd_str,
-            stdin=True,
-            detach=is_detach,
-        )
-        self.logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
+        if settings.ENABLE_CONTAINER_LOGS:
+            shell_cmd = docker_exec_command(
+                self.container_name,
+                full_cmd_str,
+                stdin=True,
+                detach=is_detach,
+            )
+            self.logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
 
         result = exec_run_in_container(
             self.__container,


### PR DESCRIPTION
### What changed
This PR introduces a new configuration variable ENABLE_CONTAINER_LOGS to control container operation logging verbosity.

### Related Issue
https://github.com/project-chip/certification-tool/issues/845

### Testing

- Launching TH and execute a test run with ENABLE_CONTAINER_LOGS  = **True**, the docker `Docker API call equivalent shell command` are displayed
- Launching TH and execute a test run with ENABLE_CONTAINER_LOGS  = **False**, the docker `Docker API call equivalent shell command` are NOT displayed