### PR TITLE
Fixes for Python tests being loaded twice during Test Harness startup

### DIFF
--- a/app/test_engine/test_script_manager.py
+++ b/app/test_engine/test_script_manager.py
@@ -73,44 +73,13 @@ class TestScriptManager(object, metaclass=Singleton):
     def __init__(self) -> None:
         """
         Dynamically discover test collections, ignoring internal test collections.
+
+        Note: Python test collections are initialized separately:
+        - In production: via FastAPI startup event (app/main.py)
+        - In tests: via conftest.py initialization
         """
         self._python_tests_initialized = False
-
-        # Initialize Python tests if not already done (important for tests)
-        self._ensure_python_tests_initialized()
-
         self.test_collections = self._discover_test_collections()
-
-    def _ensure_python_tests_initialized(self) -> None:
-        """
-        Ensure Python test collections are initialized for test environments.
-
-        This is called during TestScriptManager construction to handle cases where
-        tests create new instances that bypass the global initialization.
-        """
-        if self._python_tests_initialized:
-            return
-
-        try:
-            from test_collections.matter.sdk_tests.support.python_testing import (
-                initialize_python_tests_sync,
-                sdk_python_collection,
-            )
-
-            if sdk_python_collection is None:
-                # Initialize collections for test environment
-                initialize_python_tests_sync()
-
-            self._python_tests_initialized = True
-
-        except ImportError:
-            # Python testing module not available (e.g., DRY_RUN mode)
-            self._python_tests_initialized = True
-        except Exception as e:
-            # Log warning but don't fail - FastAPI startup will handle initialization
-            logging.warning(
-                f"Failed to ensure Python test collections initialization: {e}"
-            )
 
     async def initialize_python_tests(self) -> None:
         """

--- a/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
@@ -473,5 +473,66 @@ async def generate_python_test_json_file(
     )
 
 
+async def process_test_commands_with_container(
+    sdk_container: SDKContainer,
+    commands: list,
+    json_output_file: Path,
+    grouped_commands: bool = False,
+) -> None:
+    """Process test commands using an existing SDK container session.
+
+    This function processes test commands without starting/stopping the container,
+    allowing multiple test generations to share a single container session.
+
+    Args:
+        sdk_container: Already started SDKContainer instance
+        commands: List of test commands to process
+        json_output_file: Path where JSON output should be written
+        grouped_commands: Whether to process commands in grouped mode
+    """
+    test_function_count: int = 0
+    invalid_test_function_count: int = 0
+    complete_json: list[dict] = []
+    errors_found: list[str] = []
+    warnings_found: list[str] = []
+
+    if grouped_commands:
+        (
+            test_function_count,
+            invalid_test_function_count,
+        ) = await __process_grouped_commands(
+            sdk_container,
+            commands,
+            complete_json,
+            errors_found,
+            warnings_found,
+        )
+    else:
+        (
+            test_function_count,
+            invalid_test_function_count,
+        ) = await __process_individual_commands(
+            sdk_container,
+            commands,
+            complete_json,
+            errors_found,
+            warnings_found,
+        )
+
+    # Create a wrapper object with sdk_sha at root level
+    json_output = {"sdk_sha": matter_settings.SDK_SHA, "tests": complete_json}
+
+    with open(json_output_file, "w") as json_file:
+        json.dump(json_output, json_file, indent=4, sort_keys=True)
+
+    __print_report(
+        json_output_file,
+        test_function_count,
+        invalid_test_function_count,
+        warnings_found,
+        errors_found,
+    )
+
+
 if __name__ == "__main__":
     asyncio.run(generate_python_test_json_file(grouped_commands=True))

--- a/test_collections/matter/sdk_tests/support/python_testing/test_manager.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/test_manager.py
@@ -89,11 +89,11 @@ async def _generate_all_test_files() -> None:
     """Generate standard and custom test JSON files in a single container session."""
     logger.info("Starting test file generation with shared container session")
 
-    # Create and start a single SDK container for both test generations
-    sdk_container = SDKContainer()
-    await sdk_container.start()
-
     try:
+        # Create and start a single SDK container for both test generations
+        sdk_container = SDKContainer()
+        await sdk_container.start()
+
         # Generate standard SDK tests
         logger.info("Generating standard SDK tests...")
         standard_commands = get_command_list(test_folder=PYTHON_SCRIPTS_FOLDER)

--- a/test_collections/matter/sdk_tests/support/python_testing/test_manager.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/test_manager.py
@@ -19,11 +19,15 @@ import logging
 import sys
 
 from app.test_engine.models.test_declarations import TestCollectionDeclaration
+from test_collections.matter.sdk_tests.support.sdk_container import SDKContainer
 
 from .list_python_tests_classes import (
     CUSTOM_PYTHON_SCRIPTS_FOLDER,
     CUSTOM_PYTHON_TESTS_PARSED_FILE,
-    generate_python_test_json_file,
+    PYTHON_SCRIPTS_FOLDER,
+    PYTHON_TESTS_PARSED_FILE,
+    get_command_list,
+    process_test_commands_with_container,
 )
 from .sdk_python_tests import (
     _create_custom_python_test_collection,
@@ -85,15 +89,29 @@ async def _generate_all_test_files() -> None:
     """Generate standard and custom test JSON files in a single container session."""
     logger.info("Starting test file generation with shared container session")
 
+    # Create and start a single SDK container for both test generations
+    sdk_container = SDKContainer()
+    await sdk_container.start()
+
     try:
-        # Generate standard SDK tests first
-        await generate_python_test_json_file(grouped_commands=True)
+        # Generate standard SDK tests
+        logger.info("Generating standard SDK tests...")
+        standard_commands = get_command_list(test_folder=PYTHON_SCRIPTS_FOLDER)
+        await process_test_commands_with_container(
+            sdk_container=sdk_container,
+            commands=standard_commands,
+            json_output_file=PYTHON_TESTS_PARSED_FILE,
+            grouped_commands=True,
+        )
         logger.info("Standard SDK tests generated successfully")
 
-        # Only generate custom tests if custom folder has test files
+        # Generate custom tests if custom folder has test files
         if _has_custom_tests():
-            await generate_python_test_json_file(
-                test_folder=CUSTOM_PYTHON_SCRIPTS_FOLDER,
+            logger.info("Generating custom tests...")
+            custom_commands = get_command_list(test_folder=CUSTOM_PYTHON_SCRIPTS_FOLDER)
+            await process_test_commands_with_container(
+                sdk_container=sdk_container,
+                commands=custom_commands,
                 json_output_file=CUSTOM_PYTHON_TESTS_PARSED_FILE,
                 grouped_commands=True,
             )
@@ -107,6 +125,10 @@ async def _generate_all_test_files() -> None:
     except Exception as e:
         logger.error(f"Failed to generate test files: {e}")
         raise
+    finally:
+        # Destroy the container in finally block to ensure cleanup
+        sdk_container.destroy()
+        logger.info("SDK container destroyed after test file generation")
 
 
 def _create_collections() -> (


### PR DESCRIPTION
### What changed
Problem: Python tests initialized twice (constructor + FastAPI startup), with 4 separate container launches (2 initializations × 2 test types)

Fix: Single initialization during FastAPI startup, with 1 shared container session
  
The goal of this PR is to eliminate duplicated Python test initialization and consolidating SDK container usage into a single session.

Python test collections were being loaded multiple times during TH startup:

  1. Duplicate Initialization: TestScriptManager constructor + FastAPI startup event = 2× initialization
  2. Multiple Container Launches: Each test generation (SDK + custom) = separate container sessions
  3. Total Overhead: 4 container launches per startup (2 init runs × 2 test types)

  Original Architecture Issues

  - Long-running I/O operations in constructor blocked imports
  - Each test generation started/stopped its own Docker container
  - Test environment needed special handling for parallel execution
  - No explicit separation between production and test initialization paths

### Related Issue
https://github.com/project-chip/certification-tool/issues/850

### Testing
The test scripts are now loading only once and unit tests still passing.