### PR TITLE
Adding nfc-wifi to the backend rebased to V2.15-develop

### DIFF
--- a/app/constants/shared_constants.py
+++ b/app/constants/shared_constants.py
@@ -60,6 +60,7 @@ class MessageKeysEnum(str, Enum):
 class DutPairingModeEnum(str, Enum):
     ON_NETWORK = "onnetwork"
     BLE_WIFI = "ble-wifi"
+    NFC_WIFI = "nfc-wifi"
     BLE_THREAD = "ble-thread"
     WIFIPAF_WIFI = "wifipaf-wifi"
     NFC_THREAD = "nfc-thread"

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -139,10 +139,7 @@ class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
         if self.matter_config.dut_config.pairing_mode in (
             DutPairingModeEnum.BLE_THREAD,
             DutPairingModeEnum.NFC_THREAD,
-        ) and isinstance(
-            self.matter_config.network.thread, 
-            ThreadAutoConfig
-        ):
+        ) and isinstance(self.matter_config.network.thread, ThreadAutoConfig):
             await self.border_router.start_device(self.matter_config.network.thread)
             await self.border_router.form_thread_topology()
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -105,9 +105,9 @@ class PythonTestSuite(TestSuite):
         await self.sdk_container.start()
 
         self.matter_config = TestEnvironmentConfigMatter(**self.config)
-        if (
-            self.matter_config.dut_config.pairing_mode is DutPairingModeEnum.NFC_THREAD
-            or self.matter_config.dut_config.pairing_mode is DutPairingModeEnum.NFC_WIFI
+        if self.matter_config.dut_config.pairing_mode in (
+            DutPairingModeEnum.NFC_THREAD,
+            DutPairingModeEnum.NFC_WIFI,
         ):
             # When PCSC reader is used in a Docker container, pollkit should
             #  be disabled

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -136,11 +136,13 @@ class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
         # If in BLE-Thread or NFC-Thread mode and a Thread Auto-Config was provided by
         # the user, start a new OTBR container app with the according Thread topology
         # for all tests in the Python Tests Suite.
-        if (
-            self.matter_config.dut_config.pairing_mode == DutPairingModeEnum.BLE_THREAD
-            or self.matter_config.dut_config.pairing_mode
-            == DutPairingModeEnum.NFC_THREAD
-        ) and isinstance(self.matter_config.network.thread, ThreadAutoConfig):
+        if self.matter_config.dut_config.pairing_mode in (
+            DutPairingModeEnum.BLE_THREAD,
+            DutPairingModeEnum.NFC_THREAD,
+        ) and isinstance(
+            self.matter_config.network.thread, 
+            ThreadAutoConfig
+        ):
             await self.border_router.start_device(self.matter_config.network.thread)
             await self.border_router.form_thread_topology()
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -105,7 +105,10 @@ class PythonTestSuite(TestSuite):
         await self.sdk_container.start()
 
         self.matter_config = TestEnvironmentConfigMatter(**self.config)
-        if self.matter_config.dut_config.pairing_mode is DutPairingModeEnum.NFC_THREAD:
+        if (
+            self.matter_config.dut_config.pairing_mode is DutPairingModeEnum.NFC_THREAD
+            or self.matter_config.dut_config.pairing_mode is DutPairingModeEnum.NFC_WIFI
+        ):
             # When PCSC reader is used in a Docker container, pollkit should
             #  be disabled
             self.sdk_container.send_command("--disable-polkit", prefix="pcscd")

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -85,7 +85,10 @@ async def generate_command_arguments(
     else:
         arguments.append(f"--commissioning-method {pairing_mode}")
 
-    if pairing_mode == DutPairingModeEnum.BLE_WIFI:
+    if (
+        pairing_mode == DutPairingModeEnum.BLE_WIFI
+        or pairing_mode == DutPairingModeEnum.NFC_WIFI
+    ):
         arguments.append(f"--wifi-ssid {config.network.wifi.ssid}")
         arguments.append(f"--wifi-passphrase {config.network.wifi.password}")
     elif (

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -85,10 +85,7 @@ async def generate_command_arguments(
     else:
         arguments.append(f"--commissioning-method {pairing_mode}")
 
-    if (
-        pairing_mode == DutPairingModeEnum.BLE_WIFI
-        or pairing_mode == DutPairingModeEnum.NFC_WIFI
-    ):
+    if pairing_mode in (DutPairingModeEnum.BLE_WIFI, DutPairingModeEnum.NFC_WIFI):
         arguments.append(f"--wifi-ssid {config.network.wifi.ssid}")
         arguments.append(f"--wifi-passphrase {config.network.wifi.password}")
     elif (

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -89,10 +89,10 @@ async def generate_command_arguments(
         arguments.append(f"--wifi-ssid {config.network.wifi.ssid}")
         arguments.append(f"--wifi-passphrase {config.network.wifi.password}")
     elif pairing_mode in (
-        DutPairingModeEnum.BLE_THREAD, 
+        DutPairingModeEnum.BLE_THREAD,
         DutPairingModeEnum.NFC_THREAD,
         DutPairingModeEnum.THREAD,
-        ):
+    ):
         dataset_hex = await __thread_dataset_hex(config.network.thread)
         arguments.append(f"--thread-dataset-hex {dataset_hex}")
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -88,10 +88,7 @@ async def generate_command_arguments(
     if pairing_mode in (DutPairingModeEnum.BLE_WIFI, DutPairingModeEnum.NFC_WIFI):
         arguments.append(f"--wifi-ssid {config.network.wifi.ssid}")
         arguments.append(f"--wifi-passphrase {config.network.wifi.password}")
-    elif (
-        pairing_mode == DutPairingModeEnum.BLE_THREAD
-        or pairing_mode == DutPairingModeEnum.NFC_THREAD
-    ):
+    elif pairing_mode in (DutPairingModeEnum.BLE_THREAD, DutPairingModeEnum.NFC_THREAD):
         dataset_hex = await __thread_dataset_hex(config.network.thread)
         arguments.append(f"--thread-dataset-hex {dataset_hex}")
 

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -98,8 +98,6 @@ async def test_generate_command_arguments_on_network() -> None:
     ] == arguments
 
 
-
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "pairing_mode, commissioning_method",
     [
@@ -107,7 +105,11 @@ async def test_generate_command_arguments_on_network() -> None:
         (DutPairingModeEnum.NFC_WIFI, "nfc-wifi"),
     ],
 )
-async def test_generate_command_arguments_wifi_pairing_mode() -> None:
+@pytest.mark.asyncio
+async def test_generate_command_arguments_wifi_pairing_mode(
+    pairing_mode: DutPairingModeEnum,
+    commissioning_method: str,
+) -> None:
     # Mock config
     mock_config = default_environment_config.copy(deep=True)  # type: ignore
 

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -131,6 +131,7 @@ async def test_generate_command_arguments_ble_wifi() -> None:
         "--storage_path /root/admin_storage.json",
     ] == arguments
 
+
 @pytest.mark.asyncio
 async def test_generate_command_arguments_nfc_wifi() -> None:
     # Mock config
@@ -163,6 +164,7 @@ async def test_generate_command_arguments_nfc_wifi() -> None:
         "--paa-trust-store-path /paa-root-certs",
         "--storage_path /root/admin_storage.json",
     ] == arguments
+
 
 @pytest.mark.asyncio
 async def test_generate_command_arguments_ble_thread() -> None:

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -131,6 +131,38 @@ async def test_generate_command_arguments_ble_wifi() -> None:
         "--storage_path /root/admin_storage.json",
     ] == arguments
 
+@pytest.mark.asyncio
+async def test_generate_command_arguments_nfc_wifi() -> None:
+    # Mock config
+    mock_config = default_environment_config.copy(deep=True)  # type: ignore
+
+    mock_config.test_parameters = {
+        "paa-trust-store-path": "/paa-root-certs",
+        "storage_path": "/root/admin_storage.json",
+    }
+
+    mock_dut_config = DutConfig(
+        discriminator="147",
+        setup_code="357",
+        pairing_mode=DutPairingModeEnum.NFC_WIFI,
+    )
+
+    mock_config.dut_config = mock_dut_config
+
+    arguments = await generate_command_arguments(
+        config=mock_config, omit_commissioning_method=False
+    )
+
+    assert [
+        "--trace-to json:log",
+        "--commissioning-method nfc-wifi",
+        "--wifi-ssid testharness",
+        "--wifi-passphrase wifi-password",
+        "--discriminator 147",
+        "--passcode 357",
+        "--paa-trust-store-path /paa-root-certs",
+        "--storage_path /root/admin_storage.json",
+    ] == arguments
 
 @pytest.mark.asyncio
 async def test_generate_command_arguments_ble_thread() -> None:

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -98,8 +98,16 @@ async def test_generate_command_arguments_on_network() -> None:
     ] == arguments
 
 
+
 @pytest.mark.asyncio
-async def test_generate_command_arguments_ble_wifi() -> None:
+@pytest.mark.parametrize(
+    "pairing_mode, commissioning_method",
+    [
+        (DutPairingModeEnum.BLE_WIFI, "ble-wifi"),
+        (DutPairingModeEnum.NFC_WIFI, "nfc-wifi"),
+    ],
+)
+async def test_generate_command_arguments_wifi_pairing_mode() -> None:
     # Mock config
     mock_config = default_environment_config.copy(deep=True)  # type: ignore
 
@@ -111,7 +119,7 @@ async def test_generate_command_arguments_ble_wifi() -> None:
     mock_dut_config = DutConfig(
         discriminator="147",
         setup_code="357",
-        pairing_mode=DutPairingModeEnum.BLE_WIFI,
+        pairing_mode=pairing_mode,
     )
 
     mock_config.dut_config = mock_dut_config
@@ -122,41 +130,7 @@ async def test_generate_command_arguments_ble_wifi() -> None:
 
     assert [
         "--trace-to json:log",
-        "--commissioning-method ble-wifi",
-        "--wifi-ssid testharness",
-        "--wifi-passphrase wifi-password",
-        "--discriminator 147",
-        "--passcode 357",
-        "--paa-trust-store-path /paa-root-certs",
-        "--storage_path /root/admin_storage.json",
-    ] == arguments
-
-
-@pytest.mark.asyncio
-async def test_generate_command_arguments_nfc_wifi() -> None:
-    # Mock config
-    mock_config = default_environment_config.copy(deep=True)  # type: ignore
-
-    mock_config.test_parameters = {
-        "paa-trust-store-path": "/paa-root-certs",
-        "storage_path": "/root/admin_storage.json",
-    }
-
-    mock_dut_config = DutConfig(
-        discriminator="147",
-        setup_code="357",
-        pairing_mode=DutPairingModeEnum.NFC_WIFI,
-    )
-
-    mock_config.dut_config = mock_dut_config
-
-    arguments = await generate_command_arguments(
-        config=mock_config, omit_commissioning_method=False
-    )
-
-    assert [
-        "--trace-to json:log",
-        "--commissioning-method nfc-wifi",
+        f"--commissioning-method {commissioning_method}",
         "--wifi-ssid testharness",
         "--wifi-passphrase wifi-password",
         "--discriminator 147",

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
@@ -378,7 +378,14 @@ async def test_pairing_on_network_command_params() -> None:
 
 
 @pytest.mark.asyncio
-async def test_pairing_ble_wifi_command_params() -> None:
+@pytest.mark.parametrize(
+    "pairing_fn_name, pairing_cmd",
+    [
+        ("pairing_ble_wifi", "ble-wifi"),
+        ("pairing_nfc_wifi", "nfc-wifi"),
+    ],
+)
+async def test_pairing_wifi_command_params(pairing_fn_name: str, pairing_cmd: str) -> None:
     original_trace_setting_value = matter_settings.CHIP_TOOL_TRACE
     if original_trace_setting_value is True:
         matter_settings.CHIP_TOOL_TRACE = False
@@ -396,7 +403,8 @@ async def test_pairing_ble_wifi_command_params() -> None:
         attribute="send_websocket_command",
         return_value='{"results": []}',
     ) as mock_send_websocket_command:
-        result = await runner.pairing_ble_wifi(
+        pairing_fn = getattr(runner, pairing_fn_name)
+        result = await pairing_fn(
             ssid=ssid,
             password=password,
             setup_code=setup_code,
@@ -406,46 +414,7 @@ async def test_pairing_ble_wifi_command_params() -> None:
     expected_params = (
         f"{hex(chip_server.node_id)} {ssid} {password} {setup_code} {discriminator}"
     )
-    expected_command = f"pairing ble-wifi {expected_params}"
-
-    assert result is True
-    mock_send_websocket_command.assert_awaited_once_with(expected_command)
-
-    # clean up:
-    matter_settings.CHIP_TOOL_TRACE = original_trace_setting_value
-    chip_server._ChipServer__node_id = None
-
-
-@pytest.mark.asyncio
-async def test_pairing_nfc_wifi_command_params() -> None:
-    original_trace_setting_value = matter_settings.CHIP_TOOL_TRACE
-    if original_trace_setting_value is True:
-        matter_settings.CHIP_TOOL_TRACE = False
-
-    # Attributes
-    runner: MatterYAMLRunner = MatterYAMLRunner()
-    chip_server: ChipServer = ChipServer()
-    discriminator = "1234"
-    setup_code = "0123456"
-    ssid = "WifiIsGood"
-    password = "WifiIsGoodAndSecret"
-
-    with mock.patch.object(
-        target=runner,
-        attribute="send_websocket_command",
-        return_value='{"results": []}',
-    ) as mock_send_websocket_command:
-        result = await runner.pairing_nfc_wifi(
-            ssid=ssid,
-            password=password,
-            setup_code=setup_code,
-            discriminator=discriminator,
-        )
-
-    expected_params = (
-        f"{hex(chip_server.node_id)} {ssid} {password} {setup_code} {discriminator}"
-    )
-    expected_command = f"pairing nfc-wifi {expected_params}"
+    expected_command = f"pairing {pairing_cmd} {expected_params}"
 
     assert result is True
     mock_send_websocket_command.assert_awaited_once_with(expected_command)

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
@@ -415,6 +415,43 @@ async def test_pairing_ble_wifi_command_params() -> None:
     matter_settings.CHIP_TOOL_TRACE = original_trace_setting_value
     chip_server._ChipServer__node_id = None
 
+@pytest.mark.asyncio
+async def test_pairing_nfc_wifi_command_params() -> None:
+    original_trace_setting_value = matter_settings.CHIP_TOOL_TRACE
+    if original_trace_setting_value is True:
+        matter_settings.CHIP_TOOL_TRACE = False
+
+    # Attributes
+    runner: MatterYAMLRunner = MatterYAMLRunner()
+    chip_server: ChipServer = ChipServer()
+    discriminator = "1234"
+    setup_code = "0123456"
+    ssid = "WifiIsGood"
+    password = "WifiIsGoodAndSecret"
+
+    with mock.patch.object(
+        target=runner,
+        attribute="send_websocket_command",
+        return_value='{"results": []}',
+    ) as mock_send_websocket_command:
+        result = await runner.pairing_nfc_wifi(
+            ssid=ssid,
+            password=password,
+            setup_code=setup_code,
+            discriminator=discriminator,
+        )
+
+    expected_params = (
+        f"{hex(chip_server.node_id)} {ssid} {password} {setup_code} {discriminator}"
+    )
+    expected_command = f"pairing nfc-wifi {expected_params}"
+
+    assert result is True
+    mock_send_websocket_command.assert_awaited_once_with(expected_command)
+
+    # clean up:
+    matter_settings.CHIP_TOOL_TRACE = original_trace_setting_value
+    chip_server._ChipServer__node_id = None
 
 @pytest.mark.asyncio
 async def test_pairing_ble_thread_command_params() -> None:

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
@@ -415,6 +415,7 @@ async def test_pairing_ble_wifi_command_params() -> None:
     matter_settings.CHIP_TOOL_TRACE = original_trace_setting_value
     chip_server._ChipServer__node_id = None
 
+
 @pytest.mark.asyncio
 async def test_pairing_nfc_wifi_command_params() -> None:
     original_trace_setting_value = matter_settings.CHIP_TOOL_TRACE
@@ -452,6 +453,7 @@ async def test_pairing_nfc_wifi_command_params() -> None:
     # clean up:
     matter_settings.CHIP_TOOL_TRACE = original_trace_setting_value
     chip_server._ChipServer__node_id = None
+
 
 @pytest.mark.asyncio
 async def test_pairing_ble_thread_command_params() -> None:

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
@@ -385,7 +385,9 @@ async def test_pairing_on_network_command_params() -> None:
         ("pairing_nfc_wifi", "nfc-wifi"),
     ],
 )
-async def test_pairing_wifi_command_params(pairing_fn_name: str, pairing_cmd: str) -> None:
+async def test_pairing_wifi_command_params(
+    pairing_fn_name: str, pairing_cmd: str
+) -> None:
     original_trace_setting_value = matter_settings.CHIP_TOOL_TRACE
     if original_trace_setting_value is True:
         matter_settings.CHIP_TOOL_TRACE = False

--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -57,6 +57,7 @@ TEST_RUNNER_OPTIONS = TestRunnerOptions(
 PAIRING_CMD = "pairing"
 PAIRING_MODE_ONNETWORK = "onnetwork-long"
 PAIRING_MODE_BLE_WIFI = "ble-wifi"
+PAIRING_MODE_NFC_WIFI = "nfc-wifi"
 PAIRING_MODE_BLE_THREAD = "ble-thread"
 PAIRING_MODE_WIFIPAF_WIFI = "wifipaf-wifi"
 PAIRING_MODE_NFC_THREAD = "nfc-thread"
@@ -282,6 +283,22 @@ class MatterYAMLRunner(metaclass=Singleton):
     ) -> bool:
         return await self.pairing(
             PAIRING_MODE_BLE_WIFI,
+            hex(self.chip_server.node_id),
+            ssid,
+            password,
+            setup_code,
+            discriminator,
+        )
+
+    async def pairing_nfc_wifi(
+        self,
+        ssid: str,
+        password: str,
+        setup_code: str,
+        discriminator: str,
+    ) -> bool:
+        return await self.pairing(
+            PAIRING_MODE_NFC_WIFI,
             hex(self.chip_server.node_id),
             ssid,
             password,

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -71,9 +71,9 @@ class ChipSuite(TestSuite, UserPromptSupport):
         logger.info("Setting up SDK container")
         await self.sdk_container.start()
 
-        if (
-            self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.NFC_THREAD
-            or self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.NFC_WIFI
+        if self.config_matter.dut_config.pairing_mode in (
+            DutPairingModeEnum.NFC_THREAD,
+            DutPairingModeEnum.NFC_WIFI,
         ):
             # When PCSC reader is used in a Docker container, pollkit should
             #  be disabled

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -125,9 +125,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
             pair_result = await self.__pair_with_dut_onnetwork()
         elif self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.BLE_WIFI:
             pair_result = await self.__pair_with_dut_ble_wifi()
-        elif (
-            self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.NFC_WIFI
-        ):
+        elif self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.NFC_WIFI:
             pair_result = await self.__pair_with_dut_nfc_wifi()
         elif (
             self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.BLE_THREAD

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -124,9 +124,9 @@ class ChipSuite(TestSuite, UserPromptSupport):
         if self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.ON_NETWORK:
             pair_result = await self.__pair_with_dut_onnetwork()
         elif self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.BLE_WIFI:
-            pair_result = await self.__pair_with_dut_ble_wifi()
+            pair_result = await self.__pair_wifi_dut_wifi_modes("ble")
         elif self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.NFC_WIFI:
-            pair_result = await self.__pair_with_dut_nfc_wifi()
+            pair_result = await self.__pair_wifi_dut_wifi_modes("nfc")
         elif (
             self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.BLE_THREAD
         ):
@@ -139,7 +139,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
             self.config_matter.dut_config.pairing_mode
             is DutPairingModeEnum.WIFIPAF_WIFI
         ):
-            pair_result = await self.__pair_with_dut_wifipaf_wifi()
+            pair_result = await self.__pair_wifi_dut_wifi_modes("wifipaf")
         else:
             raise DUTCommissioningError("Unsupported DUT pairing mode")
 
@@ -152,33 +152,12 @@ class ChipSuite(TestSuite, UserPromptSupport):
             discriminator=self.config_matter.dut_config.discriminator,
         )
 
-    async def __pair_with_dut_ble_wifi(self) -> bool:
+    async def __pair_wifi_dut_wifi_modes(self, mode: str) -> bool:
         if self.config_matter.network.wifi is None:
             raise DUTCommissioningError("Tool config is missing wifi config.")
-
-        return await self.runner.pairing_ble_wifi(
-            ssid=self.config_matter.network.wifi.ssid,
-            password=self.config_matter.network.wifi.password,
-            setup_code=self.config_matter.dut_config.setup_code,
-            discriminator=self.config_matter.dut_config.discriminator,
-        )
-
-    async def __pair_with_dut_nfc_wifi(self) -> bool:
-        if self.config_matter.network.wifi is None:
-            raise DUTCommissioningError("Tool config is missing wifi config.")
-
-        return await self.runner.pairing_nfc_wifi(
-            ssid=self.config_matter.network.wifi.ssid,
-            password=self.config_matter.network.wifi.password,
-            setup_code=self.config_matter.dut_config.setup_code,
-            discriminator=self.config_matter.dut_config.discriminator,
-        )
-
-    async def __pair_with_dut_wifipaf_wifi(self) -> bool:
-        if self.config_matter.network.wifi is None:
-            raise DUTCommissioningError("Tool config is missing wifi config.")
-
-        return await self.runner.pairing_wifipaf_wifi(
+        
+        pairing_function = getattr(self.runner, f"pairing_{mode}_wifi")
+        return await pairing_function(
             ssid=self.config_matter.network.wifi.ssid,
             password=self.config_matter.network.wifi.password,
             setup_code=self.config_matter.dut_config.setup_code,

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -155,7 +155,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
     async def __pair_wifi_dut_wifi_modes(self, mode: str) -> bool:
         if self.config_matter.network.wifi is None:
             raise DUTCommissioningError("Tool config is missing wifi config.")
-        
+
         pairing_function = getattr(self.runner, f"pairing_{mode}_wifi")
         return await pairing_function(
             ssid=self.config_matter.network.wifi.ssid,

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -71,7 +71,10 @@ class ChipSuite(TestSuite, UserPromptSupport):
         logger.info("Setting up SDK container")
         await self.sdk_container.start()
 
-        if self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.NFC_THREAD:
+        if (
+            self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.NFC_THREAD
+            or self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.NFC_WIFI
+        ):
             # When PCSC reader is used in a Docker container, pollkit should
             #  be disabled
             self.sdk_container.send_command("--disable-polkit", prefix="pcscd")
@@ -123,6 +126,10 @@ class ChipSuite(TestSuite, UserPromptSupport):
         elif self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.BLE_WIFI:
             pair_result = await self.__pair_with_dut_ble_wifi()
         elif (
+            self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.NFC_WIFI
+        ):
+            pair_result = await self.__pair_with_dut_nfc_wifi()
+        elif (
             self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.BLE_THREAD
         ):
             pair_result = await self.__pair_with_dut_ble_thread()
@@ -152,6 +159,17 @@ class ChipSuite(TestSuite, UserPromptSupport):
             raise DUTCommissioningError("Tool config is missing wifi config.")
 
         return await self.runner.pairing_ble_wifi(
+            ssid=self.config_matter.network.wifi.ssid,
+            password=self.config_matter.network.wifi.password,
+            setup_code=self.config_matter.dut_config.setup_code,
+            discriminator=self.config_matter.dut_config.discriminator,
+        )
+
+    async def __pair_with_dut_nfc_wifi(self) -> bool:
+        if self.config_matter.network.wifi is None:
+            raise DUTCommissioningError("Tool config is missing wifi config.")
+
+        return await self.runner.pairing_nfc_wifi(
             ssid=self.config_matter.network.wifi.ssid,
             password=self.config_matter.network.wifi.password,
             setup_code=self.config_matter.dut_config.setup_code,


### PR DESCRIPTION
#### Summary
Adding support for nfc-wifi rebased to V2.15-develop using the reference pull requests from @OlivierGre 

- https://github.com/project-chip/certification-tool-backend/pull/185

- https://github.com/project-chip/certification-tool-backend/pull/201

- https://github.com/project-chip/certification-tool-backend/pull/269