### PR TITLE
Add nfc-onnetwork pairing mode

### DIFF
--- a/app/constants/shared_constants.py
+++ b/app/constants/shared_constants.py
@@ -59,6 +59,7 @@ class MessageKeysEnum(str, Enum):
 # Enum for DUT Pairing Modes
 class DutPairingModeEnum(str, Enum):
     ON_NETWORK = "onnetwork"
+    NFC_ON_NETWORK = "nfc-onnetwork"
     BLE_WIFI = "ble-wifi"
     NFC_WIFI = "nfc-wifi"
     BLE_THREAD = "ble-thread"

--- a/test_collections/matter/sdk_tests/support/performance_tests/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/performance_tests/models/utils.py
@@ -38,11 +38,14 @@ async def generate_command_arguments(
     dut_config = config.dut_config  # type: ignore[attr-defined]
     test_parameters = config.test_parameters
 
-    pairing_mode = (
-        "on-network"
-        if dut_config.pairing_mode == DutPairingModeEnum.ON_NETWORK
-        else dut_config.pairing_mode
-    )
+    // TH env uses "onnetwork" whereas SDK uses "on-network"
+    // Same thing for "nfc-onnetwork" and "nfc-on-network"
+    if dut_config.pairing_mode == DutPairingModeEnum.ON_NETWORK:
+        pairing_mode = "on-network"
+    elif dut_config.pairing_mode == DutPairingModeEnum.NFC_ON_NETWORK:
+        pairing_mode = "nfc-on-network"
+    else:
+        pairing_mode = dut_config.pairing_mode
 
     arguments = []
     # Increase log level by adding trace log

--- a/test_collections/matter/sdk_tests/support/performance_tests/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/performance_tests/models/utils.py
@@ -38,8 +38,7 @@ async def generate_command_arguments(
     dut_config = config.dut_config  # type: ignore[attr-defined]
     test_parameters = config.test_parameters
 
-    // TH env uses "onnetwork" whereas SDK uses "on-network"
-    // Same thing for "nfc-onnetwork" and "nfc-on-network"
+    # Map TH pairing modes to SDK commissioning method names
     if dut_config.pairing_mode == DutPairingModeEnum.ON_NETWORK:
         pairing_mode = "on-network"
     elif dut_config.pairing_mode == DutPairingModeEnum.NFC_ON_NETWORK:

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -108,6 +108,7 @@ class PythonTestSuite(TestSuite):
         if self.matter_config.dut_config.pairing_mode in (
             DutPairingModeEnum.NFC_THREAD,
             DutPairingModeEnum.NFC_WIFI,
+            DutPairingModeEnum.NFC_ON_NETWORK,
             DutPairingModeEnum.THREAD_MESHCOP,
         ):
             # When PCSC reader is used in a Docker container, pollkit should

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -55,6 +55,7 @@ TEST_PARAMETER_STORAGE_PATH_KEY = "storage-path"
 NFC_PAIRING_MODES = {
     DutPairingModeEnum.NFC_WIFI.value,
     DutPairingModeEnum.NFC_THREAD.value,
+    DutPairingModeEnum.NFC_ON_NETWORK.value,
 }
 
 
@@ -65,11 +66,12 @@ async def generate_command_arguments(
     test_parameters = config.test_parameters
 
     # Map TH pairing modes to SDK commissioning method names
-    pairing_mode = (
-        "on-network"
-        if dut_config.pairing_mode == DutPairingModeEnum.ON_NETWORK
-        else dut_config.pairing_mode
-    )
+    if dut_config.pairing_mode == DutPairingModeEnum.ON_NETWORK:
+        pairing_mode = "on-network"
+    elif dut_config.pairing_mode == DutPairingModeEnum.NFC_ON_NETWORK:
+        pairing_mode = "nfc-on-network"
+    else:
+        pairing_mode = dut_config.pairing_mode
 
     arguments = []
     # Increase log level by adding trace log

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -101,6 +101,41 @@ async def test_generate_command_arguments_on_network() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generate_command_arguments_nfc_on_network() -> None:
+    # Mock config
+    mock_config = default_environment_config.copy(deep=True)  # type: ignore
+
+    # Using attributes with both - and _ word separators in test_parameters
+    # Both must be considered as python test arguments the way it was configured
+    mock_config.test_parameters = {
+        "paa-trust-store-path": "/paa-root-certs",
+        "storage_path": "/root/admin_storage.json",
+    }
+
+    mock_dut_config = DutConfig(
+        discriminator="123",
+        setup_code="1234",
+        pairing_mode=DutPairingModeEnum.NFC_ON_NETWORK,
+        chip_timeout=None,
+    )
+
+    mock_config.dut_config = mock_dut_config
+
+    arguments = await generate_command_arguments(
+        config=mock_config, omit_commissioning_method=False
+    )
+
+    assert [
+        "--trace-to json:log",
+        "--commissioning-method nfc-on-network",
+        "--discriminator 123",
+        "--passcode 1234",
+        "--paa-trust-store-path /paa-root-certs",
+        "--storage_path /root/admin_storage.json",
+    ] == arguments
+
+
+@pytest.mark.asyncio
 async def test_generate_command_arguments_ble_wifi_pairing_mode() -> None:
     # Mock config
     mock_config = default_environment_config.copy(deep=True)  # type: ignore

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
@@ -378,6 +378,39 @@ async def test_pairing_on_network_command_params() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pairing_nfc_on_network_command_params() -> None:
+    original_trace_setting_value = matter_settings.CHIP_TOOL_TRACE
+    if original_trace_setting_value is True:
+        matter_settings.CHIP_TOOL_TRACE = False
+
+    # Attributes
+    runner: MatterYAMLRunner = MatterYAMLRunner()
+    chip_server: ChipServer = ChipServer()
+    discriminator = "1234"
+    setup_code = "0123456"
+
+    with mock.patch.object(
+        target=runner,
+        attribute="send_websocket_command",
+        return_value='{"results": []}',
+    ) as mock_send_websocket_command:
+        result = await runner.pairing_nfc_on_network(
+            setup_code=setup_code,
+            discriminator=discriminator,
+        )
+
+    expected_params = f"{hex(chip_server.node_id)} {setup_code} {discriminator}"
+    expected_command = f"pairing nfc-onnetwork-long {expected_params}"
+
+    assert result is True
+    mock_send_websocket_command.assert_awaited_once_with(expected_command)
+
+    # clean up:
+    matter_settings.CHIP_TOOL_TRACE = original_trace_setting_value
+    chip_server._ChipServer__node_id = None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "pairing_fn_name, pairing_cmd",
     [

--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -56,6 +56,7 @@ TEST_RUNNER_OPTIONS = TestRunnerOptions(
 
 PAIRING_CMD = "pairing"
 PAIRING_MODE_ONNETWORK = "onnetwork-long"
+PAIRING_MODE_NFC_ONNETWORK = "nfc-onnetwork-long"
 PAIRING_MODE_BLE_WIFI = "ble-wifi"
 PAIRING_MODE_NFC_WIFI = "nfc-wifi"
 PAIRING_MODE_BLE_THREAD = "ble-thread"
@@ -267,6 +268,18 @@ class MatterYAMLRunner(metaclass=Singleton):
     ) -> bool:
         return await self.pairing(
             PAIRING_MODE_ONNETWORK,
+            hex(self.chip_server.node_id),
+            setup_code,
+            discriminator,
+        )
+
+    async def pairing_nfc_on_network(
+        self,
+        setup_code: str,
+        discriminator: str,
+    ) -> bool:
+        return await self.pairing(
+            PAIRING_MODE_NFC_ONNETWORK,
             hex(self.chip_server.node_id),
             setup_code,
             discriminator,

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -74,6 +74,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
         if self.config_matter.dut_config.pairing_mode in (
             DutPairingModeEnum.NFC_THREAD,
             DutPairingModeEnum.NFC_WIFI,
+            DutPairingModeEnum.NFC_ON_NETWORK,
         ):
             # When PCSC reader is used in a Docker container, pollkit should
             #  be disabled
@@ -123,6 +124,11 @@ class ChipSuite(TestSuite, UserPromptSupport):
     async def __pair_with_dut(self) -> None:
         if self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.ON_NETWORK:
             pair_result = await self.__pair_with_dut_onnetwork()
+        if (
+            self.config_matter.dut_config.pairing_mode
+            is DutPairingModeEnum.NFC_ON_NETWORK
+        ):
+            pair_result = await self.__pair_with_dut_nfc_onnetwork()
         elif self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.BLE_WIFI:
             pair_result = await self.__pair_wifi_dut_wifi_modes("ble")
         elif self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.NFC_WIFI:
@@ -153,6 +159,12 @@ class ChipSuite(TestSuite, UserPromptSupport):
 
     async def __pair_with_dut_onnetwork(self) -> bool:
         return await self.runner.pairing_on_network(
+            setup_code=self.config_matter.dut_config.setup_code,
+            discriminator=self.config_matter.dut_config.discriminator,
+        )
+
+    async def __pair_with_dut_nfc_onnetwork(self) -> bool:
+        return await self.runner.pairing_nfc_on_network(
             setup_code=self.config_matter.dut_config.setup_code,
             discriminator=self.config_matter.dut_config.discriminator,
         )


### PR DESCRIPTION
Add nfc-onnetwork pairing mode. It will allow to test Ethernet devices supporting NFC commissioning