### PR TITLE
Fixed imports in test_harness_client.py file

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
@@ -24,8 +24,8 @@ from contextlib import redirect_stdout
 from multiprocessing.managers import BaseManager
 
 from matter.testing.commissioning import CommissionDeviceTest
-from matter.testing.matter_testing import (
-    MatterTestConfig,
+from matter.testing.matter_testing import MatterTestConfig
+from matter.testing.runner import (
     TestStep,
     get_test_info,
     parse_matter_test_args,


### PR DESCRIPTION
The goal of this PR is to fix the SDK imports used by test_harness_client.py 

Fixes: [877](https://github.com/project-chip/certification-tool/issues/877)
