### PR TITLE
[Fix] Argument Generation When Using NFC Commissioning

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -52,6 +52,11 @@ TEST_OUTPUT_FILE_PATH = "sdk_checkout/python_testing/test_output.txt"
 
 TEST_PARAMETER_STORAGE_PATH_KEY = "storage-path"
 
+NFC_PAIRING_MODES = [
+    DutPairingModeEnum.NFC_WIFI.value,
+    DutPairingModeEnum.NFC_THREAD.value,
+]
+
 
 async def generate_command_arguments(
     config: TestEnvironmentConfigMatter, omit_commissioning_method: bool = False
@@ -112,6 +117,7 @@ async def generate_command_arguments(
         if (
             "manual-code" not in test_parameters.keys()
             and "qr-code" not in test_parameters.keys()
+            and pairing_mode not in NFC_PAIRING_MODES
         ):
             # Retrieve arguments from dut_config
             arguments.append(f"--discriminator {dut_config.discriminator}")
@@ -122,8 +128,9 @@ async def generate_command_arguments(
             arguments.append(f"--{name} {arg_value}")
     else:
         # Retrieve arguments from dut_config
-        arguments.append(f"--discriminator {dut_config.discriminator}")
-        arguments.append(f"--passcode {dut_config.setup_code}")
+        if pairing_mode not in NFC_PAIRING_MODES:
+            arguments.append(f"--discriminator {dut_config.discriminator}")
+            arguments.append(f"--passcode {dut_config.setup_code}")
 
     return arguments
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -52,10 +52,10 @@ TEST_OUTPUT_FILE_PATH = "sdk_checkout/python_testing/test_output.txt"
 
 TEST_PARAMETER_STORAGE_PATH_KEY = "storage-path"
 
-NFC_PAIRING_MODES = [
+NFC_PAIRING_MODES = {
     DutPairingModeEnum.NFC_WIFI.value,
     DutPairingModeEnum.NFC_THREAD.value,
-]
+}
 
 
 async def generate_command_arguments(
@@ -110,27 +110,24 @@ async def generate_command_arguments(
             if thread_config.ba_port:
                 arguments.append(f"--thread-ba-port {thread_config.ba_port}")
 
+    # NFC pairing modes don't need discriminator and passcode in the arguments,
+    # since it is provided directly by the NFC tag.
+    # Also, if manual-code or qr-code and also discriminator and passcode are provided,
+    # the test will think that we're trying to commission 2 DUTs and it will fail
+    if (
+        pairing_mode not in NFC_PAIRING_MODES
+        and ("manual-code" not in test_parameters.keys() if test_parameters else True)
+        and ("qr-code" not in test_parameters.keys() if test_parameters else True)
+    ):
+        # Retrieve arguments from dut_config
+        arguments.append(f"--discriminator {dut_config.discriminator}")
+        arguments.append(f"--passcode {dut_config.setup_code}")
+
     # Retrieve arguments from test_parameters
     if test_parameters:
-        # If manual-code or qr-code and also discriminator and passcode are provided,
-        # the test will think that we're trying to commission 2 DUTs and it will fail
-        if (
-            "manual-code" not in test_parameters.keys()
-            and "qr-code" not in test_parameters.keys()
-            and pairing_mode not in NFC_PAIRING_MODES
-        ):
-            # Retrieve arguments from dut_config
-            arguments.append(f"--discriminator {dut_config.discriminator}")
-            arguments.append(f"--passcode {dut_config.setup_code}")
-
         for name, value in test_parameters.items():
             arg_value = str(value) if value is not None else ""
             arguments.append(f"--{name} {arg_value}")
-    else:
-        # Retrieve arguments from dut_config
-        if pairing_mode not in NFC_PAIRING_MODES:
-            arguments.append(f"--discriminator {dut_config.discriminator}")
-            arguments.append(f"--passcode {dut_config.setup_code}")
 
     return arguments
 

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -47,6 +47,7 @@ async def test_generate_command_arguments_with_null_value_attribute() -> None:
         discriminator="123",
         setup_code="1234",
         pairing_mode=DutPairingModeEnum.ON_NETWORK,
+        chip_timeout=None,
     )
 
     mock_config.dut_config = mock_dut_config
@@ -80,6 +81,7 @@ async def test_generate_command_arguments_on_network() -> None:
         discriminator="123",
         setup_code="1234",
         pairing_mode=DutPairingModeEnum.ON_NETWORK,
+        chip_timeout=None,
     )
 
     mock_config.dut_config = mock_dut_config
@@ -98,18 +100,8 @@ async def test_generate_command_arguments_on_network() -> None:
     ] == arguments
 
 
-@pytest.mark.parametrize(
-    "pairing_mode, commissioning_method",
-    [
-        (DutPairingModeEnum.BLE_WIFI, "ble-wifi"),
-        (DutPairingModeEnum.NFC_WIFI, "nfc-wifi"),
-    ],
-)
 @pytest.mark.asyncio
-async def test_generate_command_arguments_wifi_pairing_mode(
-    pairing_mode: DutPairingModeEnum,
-    commissioning_method: str,
-) -> None:
+async def test_generate_command_arguments_ble_wifi_pairing_mode() -> None:
     # Mock config
     mock_config = default_environment_config.copy(deep=True)  # type: ignore
 
@@ -121,7 +113,8 @@ async def test_generate_command_arguments_wifi_pairing_mode(
     mock_dut_config = DutConfig(
         discriminator="147",
         setup_code="357",
-        pairing_mode=pairing_mode,
+        pairing_mode=DutPairingModeEnum.BLE_WIFI,
+        chip_timeout=None,
     )
 
     mock_config.dut_config = mock_dut_config
@@ -132,11 +125,44 @@ async def test_generate_command_arguments_wifi_pairing_mode(
 
     assert [
         "--trace-to json:log",
-        f"--commissioning-method {commissioning_method}",
+        f"--commissioning-method {DutPairingModeEnum.BLE_WIFI.value}",
         "--wifi-ssid testharness",
         "--wifi-passphrase wifi-password",
         "--discriminator 147",
         "--passcode 357",
+        "--paa-trust-store-path /paa-root-certs",
+        "--storage_path /root/admin_storage.json",
+    ] == arguments
+
+
+@pytest.mark.asyncio
+async def test_generate_command_arguments_nfc_wifi_pairing_mode() -> None:
+    # Mock config
+    mock_config = default_environment_config.copy(deep=True)  # type: ignore
+
+    mock_config.test_parameters = {
+        "paa-trust-store-path": "/paa-root-certs",
+        "storage_path": "/root/admin_storage.json",
+    }
+
+    mock_dut_config = DutConfig(
+        discriminator="147",
+        setup_code="357",
+        pairing_mode=DutPairingModeEnum.NFC_WIFI,
+        chip_timeout=None,
+    )
+
+    mock_config.dut_config = mock_dut_config
+
+    arguments = await generate_command_arguments(
+        config=mock_config, omit_commissioning_method=False
+    )
+
+    assert [
+        "--trace-to json:log",
+        f"--commissioning-method {DutPairingModeEnum.NFC_WIFI.value}",
+        "--wifi-ssid testharness",
+        "--wifi-passphrase wifi-password",
         "--paa-trust-store-path /paa-root-certs",
         "--storage_path /root/admin_storage.json",
     ] == arguments
@@ -156,6 +182,7 @@ async def test_generate_command_arguments_ble_thread() -> None:
         discriminator="456",
         setup_code="8765",
         pairing_mode=DutPairingModeEnum.BLE_THREAD,
+        chip_timeout=None,
     )
 
     mock_config.dut_config = mock_dut_config
@@ -205,6 +232,7 @@ async def test_generate_command_arguments_ble_thread_for_external_network() -> N
         discriminator="456",
         setup_code="8765",
         pairing_mode=DutPairingModeEnum.BLE_THREAD,
+        chip_timeout=None,
     )
 
     mock_config.dut_config = mock_dut_config
@@ -250,6 +278,7 @@ async def test_generate_command_arguments_nfc_thread() -> None:
         setup_code="8765",
         pairing_mode=DutPairingModeEnum.NFC_THREAD,
         discriminator="456",
+        chip_timeout=None,
     )
 
     mock_config.dut_config = mock_dut_config
@@ -278,11 +307,11 @@ async def test_generate_command_arguments_nfc_thread() -> None:
                 "23402081111111122222222051000112233445566778899aabbccddeeff030444454d4"
                 "f"
             ),
-            "--discriminator 456",
-            "--passcode 8765",
             "--paa-trust-store-path /paa-root-certs",
             "--storage_path /root/admin_storage.json",
         ] == arguments
+        assert mock_dut_config.discriminator not in arguments
+        assert mock_dut_config.setup_code not in arguments
 
 
 @pytest.mark.asyncio
@@ -299,6 +328,7 @@ async def test_generate_command_arguments_nfc_thread_for_external_network() -> N
         setup_code="8765",
         pairing_mode=DutPairingModeEnum.NFC_THREAD,
         discriminator="783",
+        chip_timeout=None,
     )
 
     mock_config.dut_config = mock_dut_config
@@ -323,11 +353,11 @@ async def test_generate_command_arguments_nfc_thread_for_external_network() -> N
             "4f20410d477d767e424a5f2ef25c16fc9b621e90c0402a0f7f8000300000f0102123402081"
             "111111122222222051000112233445566778899aabbccddeeff030444454d4f"
         ),
-        "--discriminator 783",
-        "--passcode 8765",
         "--paa-trust-store-path /paa-root-certs",
         "--storage_path /root/admin_storage.json",
     ] == arguments
+    assert mock_dut_config.discriminator not in arguments
+    assert mock_dut_config.setup_code not in arguments
 
 
 @pytest.mark.asyncio
@@ -341,6 +371,7 @@ async def test_generate_command_arguments_no_test_parameter_informed() -> None:
         discriminator="456",
         setup_code="8765",
         pairing_mode=DutPairingModeEnum.BLE_THREAD,
+        chip_timeout=None,
     )
 
     mock_config.dut_config = mock_dut_config
@@ -386,6 +417,7 @@ async def test_generate_command_arguments_trace_log_false_informed() -> None:
         setup_code="8765",
         pairing_mode=DutPairingModeEnum.BLE_THREAD,
         trace_log=False,
+        chip_timeout=None,
     )
 
     mock_config.dut_config = mock_dut_config
@@ -427,6 +459,7 @@ async def test_generate_command_arguments_omit_comissioning_method() -> None:
         discriminator="456",
         setup_code="8765",
         pairing_mode=DutPairingModeEnum.ON_NETWORK,
+        chip_timeout=None,
     )
 
     mock_config.dut_config = mock_dut_config


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/874
---

The DUT config should not provide discriminator, passcode, manual code or QR-code when using **NFC** pairing mode.

Running the Test Case using **NFC** with those present results in an error from the SDK side during test execution:
`Error: Do not provide discriminator, passcode, manual code or qr-code for NFC commissioning. The payload is read directly from the NFC tag.`

With this change, those arguments are not provided when using any NFC commissioning (NFC-Thread and NFC-WiFi for now).