### PR TITLE
Updated all references from Thread to Thread_meshcop

### DIFF
--- a/app/constants/shared_constants.py
+++ b/app/constants/shared_constants.py
@@ -64,4 +64,4 @@ class DutPairingModeEnum(str, Enum):
     BLE_THREAD = "ble-thread"
     WIFIPAF_WIFI = "wifipaf-wifi"
     NFC_THREAD = "nfc-thread"
-    THREAD = "thread"
+    THREAD_MESHCOP = "thread-meshcop"

--- a/test_collections/matter/config.py
+++ b/test_collections/matter/config.py
@@ -23,9 +23,9 @@ class MatterSettings(BaseSettings):
 
     # SDK Docker Image
     SDK_DOCKER_IMAGE: str = "connectedhomeip/chip-cert-bins"
-    SDK_DOCKER_TAG: str = "d3ec6d14cdc637280466b5e1c7b56b8534245c48"
+    SDK_DOCKER_TAG: str = "ead81748828787a656ae05c7d980f908f09ea751-patch"
     # SDK SHA: used to fetch tests (YAML and Python) from SDK.
-    SDK_SHA: str = "d3ec6d14cdc637280466b5e1c7b56b8534245c48"
+    SDK_SHA: str = "ead81748828787a656ae05c7d980f908f09ea751-patch"
 
     class Config:
         case_sensitive = True

--- a/test_collections/matter/config.py
+++ b/test_collections/matter/config.py
@@ -25,7 +25,7 @@ class MatterSettings(BaseSettings):
     SDK_DOCKER_IMAGE: str = "connectedhomeip/chip-cert-bins"
     SDK_DOCKER_TAG: str = "ead81748828787a656ae05c7d980f908f09ea751-patch"
     # SDK SHA: used to fetch tests (YAML and Python) from SDK.
-    SDK_SHA: str = "ead81748828787a656ae05c7d980f908f09ea751-patch"
+    SDK_SHA: str = "ead81748828787a656ae05c7d980f908f09ea751"
 
     class Config:
         case_sensitive = True

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -134,9 +134,9 @@ class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
     async def setup(self) -> None:
         await super().setup()
 
-        # If in BLE-Thread, NFC-Thread, or THREAD_MESHCOP mode and a Thread Auto-Config was
-        # provided by the user, start a new OTBR container app with the according Thread
-        #  topology for all tests in the Python Tests Suite.
+        # If in BLE-Thread, NFC-Thread, or THREAD_MESHCOP mode and a Thread Auto-Config
+        # was provided by the user, start a new OTBR container app with the according
+        # Thread topology for all tests in the Python Tests Suite.
         if self.matter_config.dut_config.pairing_mode in (
             DutPairingModeEnum.BLE_THREAD,
             DutPairingModeEnum.NFC_THREAD,

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -108,7 +108,7 @@ class PythonTestSuite(TestSuite):
         if self.matter_config.dut_config.pairing_mode in (
             DutPairingModeEnum.NFC_THREAD,
             DutPairingModeEnum.NFC_WIFI,
-            DutPairingModeEnum.THREAD,
+            DutPairingModeEnum.THREAD_MESHCOP,
         ):
             # When PCSC reader is used in a Docker container, pollkit should
             #  be disabled
@@ -134,13 +134,13 @@ class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
     async def setup(self) -> None:
         await super().setup()
 
-        # If in BLE-Thread, NFC-Thread, or THREAD mode and a Thread Auto-Config was
+        # If in BLE-Thread, NFC-Thread, or THREAD_MESHCOP mode and a Thread Auto-Config was
         # provided by the user, start a new OTBR container app with the according Thread
         #  topology for all tests in the Python Tests Suite.
         if self.matter_config.dut_config.pairing_mode in (
             DutPairingModeEnum.BLE_THREAD,
             DutPairingModeEnum.NFC_THREAD,
-            DutPairingModeEnum.THREAD,
+            DutPairingModeEnum.THREAD_MESHCOP,
         ) and isinstance(self.matter_config.network.thread, ThreadAutoConfig):
             await self.border_router.start_device(self.matter_config.network.thread)
             await self.border_router.form_thread_topology()

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -59,6 +59,7 @@ async def generate_command_arguments(
     dut_config = config.dut_config
     test_parameters = config.test_parameters
 
+    # Map TH pairing modes to SDK commissioning method names
     pairing_mode = (
         "on-network"
         if dut_config.pairing_mode == DutPairingModeEnum.ON_NETWORK
@@ -91,13 +92,13 @@ async def generate_command_arguments(
     elif pairing_mode in (
         DutPairingModeEnum.BLE_THREAD,
         DutPairingModeEnum.NFC_THREAD,
-        DutPairingModeEnum.THREAD,
+        DutPairingModeEnum.THREAD_MESHCOP,
     ):
         dataset_hex = await __thread_dataset_hex(config.network.thread)
         arguments.append(f"--thread-dataset-hex {dataset_hex}")
 
-        # Add Border Agent parameters for THREAD
-        if pairing_mode == DutPairingModeEnum.THREAD:
+        # Add Border Agent parameters for THREAD_MESHCOP
+        if pairing_mode == DutPairingModeEnum.THREAD_MESHCOP:
             thread_config = config.network.thread
             if thread_config.ba_host:
                 arguments.append(f"--thread-ba-host {thread_config.ba_host}")

--- a/test_collections/matter/sdk_tests/support/tests/matter/test_test_environment_config.py
+++ b/test_collections/matter/sdk_tests/support/tests/matter/test_test_environment_config.py
@@ -82,7 +82,7 @@ def test_create_config_matter_with_thread_valid_succeeds() -> None:
     config_matter = TestEnvironmentConfigMatter(**default_config_thread_valid)
 
     assert config_matter is not None
-    assert config_matter.dut_config.pairing_mode == "thread"
+    assert config_matter.dut_config.pairing_mode == "thread-meshcop"
     assert config_matter.network.thread.ba_host == "127.0.0.1"
     assert config_matter.network.thread.ba_port == 5684
 
@@ -108,7 +108,7 @@ def test_create_config_matter_with_thread_no_ba_port_fails() -> None:
 
 
 def test_create_config_matter_with_thread_no_ba_params_fails() -> None:
-    """Test that THREAD mode fails when both ba_host and ba_port are missing."""
+    """Test that THREAD_MESHCOP mode fails when both ba_host and ba_port are missing."""
     config = {
         "network": {
             "fabric_id": "0",
@@ -121,7 +121,7 @@ def test_create_config_matter_with_thread_no_ba_params_fails() -> None:
             "wifi": {"ssid": "testharness", "password": "wifi-password"},
         },
         "dut_config": {
-            "pairing_mode": "thread",
+            "pairing_mode": "thread-meshcop",
             "setup_code": "20202021",
             "discriminator": "3840",
             "chip_use_paa_certs": False,
@@ -140,14 +140,14 @@ def test_create_config_matter_with_thread_no_ba_params_fails() -> None:
 
 
 def test_create_config_matter_with_thread_no_thread_config_fails() -> None:
-    """Test that THREAD mode fails when thread config is missing entirely."""
+    """Test that THREAD_MESHCOP mode fails when thread config is missing entirely."""
     config = {
         "network": {
             "fabric_id": "0",
             "wifi": {"ssid": "testharness", "password": "wifi-password"},
         },
         "dut_config": {
-            "pairing_mode": "thread",
+            "pairing_mode": "thread-meshcop",
             "setup_code": "20202021",
             "discriminator": "3840",
             "chip_use_paa_certs": False,

--- a/test_collections/matter/sdk_tests/support/tests/utils/utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/utils/utils.py
@@ -145,7 +145,7 @@ default_config_thread_valid = {
         "wifi": {"ssid": "testharness", "password": "wifi-password"},
     },
     "dut_config": {
-        "pairing_mode": "thread",
+        "pairing_mode": "thread-meshcop",
         "setup_code": "20202021",
         "discriminator": "3840",
         "chip_use_paa_certs": False,
@@ -167,7 +167,7 @@ default_config_thread_no_ba_host = {
         "wifi": {"ssid": "testharness", "password": "wifi-password"},
     },
     "dut_config": {
-        "pairing_mode": "thread",
+        "pairing_mode": "thread-meshcop",
         "setup_code": "20202021",
         "discriminator": "3840",
         "chip_use_paa_certs": False,
@@ -189,7 +189,7 @@ default_config_thread_no_ba_port = {
         "wifi": {"ssid": "testharness", "password": "wifi-password"},
     },
     "dut_config": {
-        "pairing_mode": "thread",
+        "pairing_mode": "thread-meshcop",
         "setup_code": "20202021",
         "discriminator": "3840",
         "chip_use_paa_certs": False,

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_chip_suite.py
@@ -184,7 +184,7 @@ async def test_pair_with_dut_thread_with_external_config_success() -> None:
             "wifi": {"ssid": "testharness", "password": "wifi-password"},
         },
         "dut_config": {
-            "pairing_mode": "thread",
+            "pairing_mode": "thread-meshcop",
             "setup_code": "20202021",
             "discriminator": "3840",
             "chip_use_paa_certs": False,
@@ -250,7 +250,7 @@ async def test_pair_with_dut_thread_with_auto_config_success() -> None:
             "wifi": {"ssid": "testharness", "password": "wifi-password"},
         },
         "dut_config": {
-            "pairing_mode": "thread",
+            "pairing_mode": "thread-meshcop",
             "setup_code": "20202021",
             "discriminator": "3840",
             "chip_use_paa_certs": False,
@@ -318,7 +318,7 @@ async def test_pair_with_dut_thread_missing_thread_config_fails() -> None:
             "wifi": {"ssid": "testharness", "password": "wifi-password"},
         },
         "dut_config": {
-            "pairing_mode": "thread",
+            "pairing_mode": "thread-meshcop",
             "setup_code": "20202021",
             "discriminator": "3840",
             "chip_use_paa_certs": False,
@@ -358,7 +358,7 @@ async def test_pair_with_dut_thread_invalid_thread_config_type_fails() -> None:
             "wifi": {"ssid": "testharness", "password": "wifi-password"},
         },
         "dut_config": {
-            "pairing_mode": "thread",
+            "pairing_mode": "thread-meshcop",
             "setup_code": "20202021",
             "discriminator": "3840",
             "chip_use_paa_certs": False,
@@ -398,7 +398,7 @@ async def test_pair_with_dut_thread_pairing_fails() -> None:
             "wifi": {"ssid": "testharness", "password": "wifi-password"},
         },
         "dut_config": {
-            "pairing_mode": "thread",
+            "pairing_mode": "thread-meshcop",
             "setup_code": "20202021",
             "discriminator": "3840",
             "chip_use_paa_certs": False,

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -140,7 +140,10 @@ class ChipSuite(TestSuite, UserPromptSupport):
             is DutPairingModeEnum.WIFIPAF_WIFI
         ):
             pair_result = await self.__pair_wifi_dut_wifi_modes("wifipaf")
-        elif self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.THREAD:
+        elif (
+            self.config_matter.dut_config.pairing_mode
+            is DutPairingModeEnum.THREAD_MESHCOP
+        ):
             pair_result = await self.__pair_with_dut_thread()
         else:
             raise DUTCommissioningError("Unsupported DUT pairing mode")

--- a/test_collections/matter/test_environment_config.py
+++ b/test_collections/matter/test_environment_config.py
@@ -109,13 +109,13 @@ class TestEnvironmentConfigMatter(TestEnvironmentConfig):
                         f"The field {field} is required for dut_config configuration"
                     )
 
-            # Validate THREAD mode requires ba_host and ba_port
+            # Validate THREAD_MESHCOP mode requires ba_host and ba_port
             pairing_mode = dut_config.get("pairing_mode")
-            if pairing_mode == DutPairingModeEnum.THREAD:
+            if pairing_mode == DutPairingModeEnum.THREAD_MESHCOP:
                 thread_config = network.get("thread") if network else None
                 if not thread_config:
                     raise TestEnvironmentConfigMatterError(
-                        "Thread configuration is required for THREAD pairing mode"
+                        "Thread configuration is required for THREAD_MESHCOP pairing mode"
                     )
 
                 # Check if thread config is a dict or object
@@ -129,5 +129,5 @@ class TestEnvironmentConfigMatter(TestEnvironmentConfig):
                 if not ba_host or not ba_port:
                     raise TestEnvironmentConfigMatterError(
                         "ba_host and ba_port are mandatories in thread configuration "
-                        "when pairing_mode is THREAD"
+                        "when pairing_mode is THREAD_MESHCOP"
                     )

--- a/test_collections/matter/test_environment_config.py
+++ b/test_collections/matter/test_environment_config.py
@@ -115,7 +115,8 @@ class TestEnvironmentConfigMatter(TestEnvironmentConfig):
                 thread_config = network.get("thread") if network else None
                 if not thread_config:
                     raise TestEnvironmentConfigMatterError(
-                        "Thread configuration is required for THREAD_MESHCOP pairing mode"
+                        "Thread configuration is required for THREAD_MESHCOP pairing"
+                        " mode"
                     )
 
                 # Check if thread config is a dict or object


### PR DESCRIPTION

Fix Thread commissioning failure by renaming the THREAD pairing mode enum to THREAD_MESHCOP to match the Matter SDK's expected commissioning method name. This resolves the argument parsing error that prevented Thread Border Router (MeshCoP) commissioning from working in the TH UI.

### Related Issue
[#879](https://github.com/project-chip/certification-tool/issues/879)

### Testing
Unit tests updated and passed