### PR TITLE
Fix the Python test script parser to correctly identify base test classes imported from additional Matter SDK modules.

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
@@ -148,15 +148,18 @@ def base_test_classes(module: ast.Module) -> list[ast.ClassDef]:
         if isinstance(node, ast.ImportFrom):
             # Include imports from support_modules, matter_testing,
             # or any module ending with Base/Test
-            if any(
-                s in node.module
-                for s in [
-                    "support_modules",
-                    "matter_testing",
-                    "matter.testing.basic_composition",
-                    "test_testing",
-                    "TestBase",
-                ]
+            if (
+                node.module
+                and any(
+                    s in node.module
+                    for s in [
+                        "support_modules",
+                        "matter_testing",
+                        "matter.testing.basic_composition",
+                        "test_testing",
+                    ]
+                )
+                or node.module.endswith("TestBase")
             ):
                 for alias in node.names:
                     imported_base_classes.add(alias.name)

--- a/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
@@ -148,13 +148,15 @@ def base_test_classes(module: ast.Module) -> list[ast.ClassDef]:
         if isinstance(node, ast.ImportFrom):
             # Include imports from support_modules, matter_testing,
             # or any module ending with Base/Test
-            if node.module and (
-                "support_modules" in node.module
-                or "matter_testing" in node.module
-                or "matter.testing.basic_composition" in node.module
-                or "test_testing" in node.module
-                or node.module.endswith("TestBase")
-                or "TestBase" in node.module
+            if any(
+                s in node.module
+                for s in [
+                    "support_modules",
+                    "matter_testing",
+                    "matter.testing.basic_composition",
+                    "test_testing",
+                    "TestBase",
+                ]
             ):
                 for alias in node.names:
                     imported_base_classes.add(alias.name)

--- a/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
@@ -148,9 +148,8 @@ def base_test_classes(module: ast.Module) -> list[ast.ClassDef]:
         if isinstance(node, ast.ImportFrom):
             # Include imports from support_modules, matter_testing,
             # or any module ending with Base/Test
-            if (
-                node.module
-                and any(
+            if node.module and (
+                any(
                     s in node.module
                     for s in [
                         "support_modules",

--- a/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
@@ -151,6 +151,8 @@ def base_test_classes(module: ast.Module) -> list[ast.ClassDef]:
             if node.module and (
                 "support_modules" in node.module
                 or "matter_testing" in node.module
+                or "matter.testing.basic_composition" in node.module
+                or "test_testing" in node.module
                 or node.module.endswith("TestBase")
                 or "TestBase" in node.module
             ):


### PR DESCRIPTION
### What Changed
Fix the Python test script parser to correctly identify base test classes imported from additional Matter SDK modules.
                                                                                                                        
  Changes                                                                                                               

  - list_python_tests_classes.py: Added two new module path patterns to the base_test_classes function's import
  detection logic:
    - matter.testing.basic_composition — covers base test classes from the Matter SDK's basic composition testing module
    - test_testing — covers base test classes from test utility/helper modules

  Motivation

  The Python test parser was failing to recognize test classes that inherit from base classes imported via
  matter.testing.basic_composition or test_testing modules. As the Matter SDK evolves, new base class locations are
  introduced; without these patterns the parser would skip valid test classes, causing them to be omitted from the test
  collection discovery.

  Impact

  - Bug fix — no breaking changes
  - Test classes inheriting from base classes in the newly recognized modules will now be correctly discovered and
  included in the Matter certification test collection
  - No API, schema, or configuration changes
  
  ### Related Issue
  https://github.com/project-chip/certification-tool/issues/880
  
  ### Testing
  Along with SDK [PR](https://github.com/project-chip/connectedhomeip/pull/43269), all missing tests are now displayed in TH UI