### PR TITLE
[Fix] Returning Correct Prompt Response Type

### DIFF
--- a/app/user_prompt_support/prompt_response.py
+++ b/app/user_prompt_support/prompt_response.py
@@ -35,4 +35,6 @@ class PromptResponse(BaseModel):
         super().__init__(**kwargs)
         # Preserve the original response
         if "response" in kwargs:
-            self.response_str = kwargs["response"]
+            self.response_str = (
+                str(kwargs["response"]) if kwargs["response"] is not None else None
+            )


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/907
---

## Description
There's a problem when executing the CLI that pydantic type coercion is interpreting the response type as integer, since the response type is an Python's Union of **int or str** (line 24 of file `prompt_response.py`).

## Solution
As the `response_str` variable should always return string, forcing the return to cast to str seems straight forward and error prune.

## Version
This is affecting the TH `v2.14.1-beta2+winter2026` (Matter 1.5.1 MVE)

## Testing
The Test case and scenario pointed by the issue#907 is now passing for the TH version used:

<img width="621" height="677" alt="Screenshot 2026-03-10 at 09 56 46" src="https://github.com/user-attachments/assets/d1a7341e-69ed-467d-979f-b5a9f2f3f4e7" />