### PR TITLE
[FIX] Updating Test Run Executions To Handle temporary PICS

### DIFF
--- a/alembic/versions/a16c8c20cd36_add_execution_pics_to_test_run_execution.py
+++ b/alembic/versions/a16c8c20cd36_add_execution_pics_to_test_run_execution.py
@@ -1,0 +1,32 @@
+"""add execution_pics to test_run_execution
+
+Revision ID: a16c8c20cd36
+Revises: e6153267b741
+Create Date: 2026-04-08 17:41:21.198510
+
+"""
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "a16c8c20cd36"
+down_revision = "e6153267b741"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Add execution_pics column to testrunexecution table (optional JSON)
+    op.add_column(
+        "testrunexecution",
+        sa.Column(
+            "execution_pics", postgresql.JSON(astext_type=sa.Text()), nullable=True
+        ),
+    )
+
+
+def downgrade():
+    # Remove execution_pics column
+    op.drop_column("testrunexecution", "execution_pics")

--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -110,30 +110,9 @@ def create_test_run_execution(
     return test_run_execution
 
 
-def __convert_pics_dict_to_object(pics: dict) -> schemas.PICS | None:
-    """Convert a dictionary to a PICS object.
-
-    Args:
-        pics (dict): Dictionary containing PICS data
-
-    Returns:
-        schemas.PICS: PICS object if conversion successful.
-    """
-    if not pics:
-        return schemas.PICS(clusters={})
-
-    try:
-        return schemas.PICS(**pics)
-    except Exception as e:
-        logger.error(f"Invalid PICS data: {e}")
-        return None
-
-
 def _cli_project(
     db: Session,
     project_id: int | None,
-    config: dict | None,
-    pics_obj: schemas.PICS,
 ) -> Project:
     """Retrieve or create the default CLI project."""
 
@@ -145,11 +124,10 @@ def _cli_project(
                 db=db, name=DEFAULT_CLI_PROJECT_NAME
             )
         ):
-            new_config = (
-                default_environment_config.__dict__ if config is None else config
-            )
             project_create = schemas.ProjectCreate(
-                name=DEFAULT_CLI_PROJECT_NAME, config=new_config, pics=pics_obj
+                name=DEFAULT_CLI_PROJECT_NAME,
+                config=default_environment_config.__dict__,
+                pics=schemas.PICS(clusters={}),
             )
             return crud.project.create(db=db, obj_in=project_create)
     else:
@@ -160,15 +138,6 @@ def _cli_project(
                 detail=f"Project with ID {project_id} not found.",
             )
 
-    if config is not None:
-        logger.info(f"CLI Config Arguments: {config}")
-        project_update = schemas.ProjectUpdate(
-            name=cli_project.name, config=config, pics=pics_obj
-        )
-        cli_project = crud.project.update(
-            db=db, db_obj=cli_project, obj_in=project_update
-        )
-
     return cli_project
 
 
@@ -178,41 +147,37 @@ def create_cli_test_run_execution(
     db: Session = Depends(get_db),
     test_run_execution_in: schemas.TestRunExecutionCreate,
     selected_tests: schemas.TestSelection,
-    config: dict | None = None,
     execution_config: dict | None = None,
-    pics: dict = {},
+    execution_pics: dict | None = None,
 ) -> TestRunExecution:
     """Creates a new test run execution on CLI request.
        Attention: if both config and execution_config are provided,
        only config will be persisted, while execution_config will be for
-       this execution only.
+       this execution only. Similarly, if both pics and execution_pics are provided,
+       only pics will be persisted, while execution_pics will be for execution only.
 
     Args:
         test_run_execution_in: Test run execution data
         selected_tests: Selected tests to run
         config: Configuration parameters that update project (optional, persists)
         execution_config: Execution-specific config override (optional, temporary)
-        pics: PICS configuration (optional)
+        pics: PICS configuration that updates project (optional, persists)
+        execution_pics: Execution-specific PICS override (optional, temporary)
     """
 
-    # Convert pics dict to PICS object if provided
-    logger.info(f"CLI PICS Arguments: {pics}")
-    pics_obj = __convert_pics_dict_to_object(pics)
-    if pics_obj is None:
-        raise HTTPException(
-            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-            detail="Invalid PICS data provided. Please check the format.",
-        )
-
     # Retrieve or create the CLI project
-    # Only update project if config is provided (not execution_config)
-    cli_project = _cli_project(db, test_run_execution_in.project_id, config, pics_obj)
+    cli_project = _cli_project(db, test_run_execution_in.project_id)
     test_run_execution_in.project_id = cli_project.id
 
     # Store execution_config if provided (temporary, per-execution)
     if execution_config is not None:
         logger.info(f"CLI Execution Config (Temporary): {execution_config}")
         test_run_execution_in.execution_config = execution_config
+
+    # Store execution_pics if provided (temporary, per-execution)
+    if execution_pics is not None:
+        logger.info(f"CLI Execution PICS (Temporary): {execution_pics}")
+        test_run_execution_in.execution_pics = execution_pics
 
     test_run_execution_in.certification_mode = False
 

--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -151,18 +151,14 @@ def create_cli_test_run_execution(
     execution_pics: dict | None = None,
 ) -> TestRunExecution:
     """Creates a new test run execution on CLI request.
-       Attention: if both config and execution_config are provided,
-       only config will be persisted, while execution_config will be for
-       this execution only. Similarly, if both pics and execution_pics are provided,
-       only pics will be persisted, while execution_pics will be for execution only.
 
     Args:
         test_run_execution_in: Test run execution data
         selected_tests: Selected tests to run
-        config: Configuration parameters that update project (optional, persists)
         execution_config: Execution-specific config override (optional, temporary)
-        pics: PICS configuration that updates project (optional, persists)
         execution_pics: Execution-specific PICS override (optional, temporary)
+    Returns:
+        The created TestRunExecution.
     """
 
     # Retrieve or create the CLI project

--- a/app/models/test_run_execution.py
+++ b/app/models/test_run_execution.py
@@ -59,6 +59,11 @@ class TestRunExecution(Base):
         JSON, nullable=True, default=None
     )
 
+    # Execution-specific PICS (temporary, not persisted to project)
+    execution_pics: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, nullable=True, default=None
+    )
+
     test_run_config_id: Mapped[int | None] = mapped_column(
         ForeignKey("testrunconfig.id"), nullable=True
     )

--- a/app/schemas/test_run_execution.py
+++ b/app/schemas/test_run_execution.py
@@ -39,6 +39,7 @@ class TestRunExecutionBase(BaseModel):
     title: str
     description: str | None
     execution_config: dict | None = None
+    execution_pics: dict | None = None
     certification_mode: bool = False
 
 

--- a/app/test_engine/models/test_run.py
+++ b/app/test_engine/models/test_run.py
@@ -16,6 +16,7 @@
 from asyncio import CancelledError, Task, create_task
 
 from app.models import Project, TestRunExecution, TestStateEnum
+from app.schemas.pics import PICS
 from app.schemas.test_run_log_entry import TestRunLogEntry
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.test_observable import TestObservable
@@ -61,6 +62,17 @@ class TestRun(TestObservable, UserPromptSupport):
         if self.test_run_execution.execution_config is not None:
             return self.test_run_execution.execution_config
         return self.project.config
+
+    @property
+    def pics(self) -> PICS:
+        """Get PICS for test suite.
+
+        Returns execution_pics if available (temporary, per-execution PICS),
+        otherwise returns project.pics (persistent PICS).
+        """
+        if self.test_run_execution.execution_pics is not None:
+            return PICS.parse_obj(self.test_run_execution.execution_pics)
+        return PICS.parse_obj(self.project.pics)
 
     @property
     def state(self) -> TestStateEnum:

--- a/app/test_engine/models/test_run.py
+++ b/app/test_engine/models/test_run.py
@@ -72,7 +72,7 @@ class TestRun(TestObservable, UserPromptSupport):
         """
         if self.test_run_execution.execution_pics is not None:
             return PICS.parse_obj(self.test_run_execution.execution_pics)
-        return PICS.parse_obj(self.project.pics)
+        return self.project.pics
 
     @property
     def state(self) -> TestStateEnum:

--- a/app/test_engine/models/test_suite.py
+++ b/app/test_engine/models/test_suite.py
@@ -70,6 +70,14 @@ class TestSuite(TestObservable):
 
     @property
     def pics(self) -> PICS:
+        """Get PICS for test suite.
+
+        Returns execution_pics if available (temporary override from CLI),
+        otherwise returns project.pics (persistent PICS).
+        """
+        test_run_execution = self.test_suite_execution.test_run_execution
+        if test_run_execution.execution_pics is not None:
+            return PICS.parse_obj(test_run_execution.execution_pics)
         return PICS.parse_obj(self.project.pics)
 
     @property

--- a/app/test_engine/test_runner.py
+++ b/app/test_engine/test_runner.py
@@ -161,8 +161,8 @@ class TestRunner(object, metaclass=Singleton):
             test_engine_logger.info(f"TH Version: {version_information.version}")
             test_engine_logger.info(f"TH SHA: {version_information.sha}")
             test_engine_logger.info(f"TH SDK SHA: {version_information.sdk_sha}")
-            test_engine_logger.info(f"Project config:\n{self.test_run.project.config}")
-            test_engine_logger.info(f"Project PICS:\n{self.test_run.project.pics}")
+            test_engine_logger.info(f"Project config:\n{self.test_run.config}")
+            test_engine_logger.info(f"Project PICS:\n{self.test_run.pics}")
 
             # Execute each test suite asynchronously
             self.__state = TestRunnerState.RUNNING

--- a/app/tests/api/api_v1/test_test_run_executions.py
+++ b/app/tests/api/api_v1/test_test_run_executions.py
@@ -19,7 +19,7 @@
 import asyncio
 from asyncio import sleep
 from http import HTTPStatus
-from unittest.mock import ANY, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from faker import Faker

--- a/app/tests/api/api_v1/test_test_run_executions.py
+++ b/app/tests/api/api_v1/test_test_run_executions.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2025 Project CHIP Authors
+# Copyright (c) 2025-2026 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -1743,11 +1743,11 @@ def test_create_cli_test_run_execution_with_none_project_id_uses_default(
     assert data["project_id"] == 1  # Default CLI project ID
 
 
-def test_create_cli_test_run_execution_updates_existing_project_with_config(
+def test_create_cli_test_run_execution_does_not_update_existing_project_config(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test that when project_id is provided, the existing project is updated with the
-    config."""
+    """Test that when project_id is provided, the execution stores execution_config
+    without updating the project."""
     # Set project_id in the test_run_execution_create object
     test_run_execution_create.project_id = 123
 
@@ -1758,14 +1758,7 @@ def test_create_cli_test_run_execution_updates_existing_project_with_config(
         config={"old_key": "old_value"},
     )
 
-    # Updated project after config update
-    mock_updated_project = Project(
-        id=123,
-        name="Existing Test Project",
-        config=default_config,
-    )
-
-    # Mock test run execution
+    # Mock test run execution with execution_config
     mock_test_run = TestRunExecution(
         id=1,
         title=test_run_execution_create.title,
@@ -1779,26 +1772,24 @@ def test_create_cli_test_run_execution_updates_existing_project_with_config(
         imported_at=None,
         archived_at=None,
     )
+    mock_test_run.execution_config = default_config
 
     with patch(
         "app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db
     ), patch(
         "app.api.api_v1.endpoints.test_run_executions.crud.project.get",
         return_value=mock_project,
-    ) as mock_get, patch(
-        "app.api.api_v1.endpoints.test_run_executions.crud.project.update",
-        return_value=mock_updated_project,
-    ) as mock_update, patch(
+    ), patch(
         "app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create",
         return_value=mock_test_run,
-    ):
+    ) as mock_create:
         response = client.post(
             f"{settings.API_V1_STR}/test_run_executions/cli",
             json={
                 "test_run_execution_in": test_run_execution_create.dict(),
                 "selected_tests": test_selection,
-                "config": default_config,
-                "pics": {},
+                "execution_config": default_config,
+                "execution_pics": {},
             },
         )
 
@@ -1807,24 +1798,18 @@ def test_create_cli_test_run_execution_updates_existing_project_with_config(
     assert data["title"] == test_run_execution_create.title
     assert data["project_id"] == 123
 
-    # Verify that project.get was called with the correct ID
-    mock_get.assert_called_once_with(db=ANY, id=123)
-
-    # Verify that project.update was called to update the config
-    mock_update.assert_called_once()
-    args, kwargs = mock_update.call_args
-    assert kwargs["db"] is not None
-    assert kwargs["db_obj"] == mock_project
-    # Verify the ProjectUpdate object has the config
-    project_update = kwargs["obj_in"]
-    assert project_update.config == default_config
+    # Verify that the execution was created with execution_config
+    mock_create.assert_called_once()
+    _, kwargs = mock_create.call_args
+    execution_in = kwargs["obj_in"]
+    assert execution_in.execution_config == default_config
 
 
-def test_create_cli_test_run_execution_updates_existing_project_with_config_and_pics(
+def test_create_cli_test_run_execution_does_not_update_existing_project_config_and_pics(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test that when project_id is provided, the existing project is updated with both
-    config and PICS."""
+    """Test that when project_id is provided, the execution stores both execution_config
+    and execution_pics without updating the project."""
     # Set project_id in the test_run_execution_create object
     test_run_execution_create.project_id = 456
 
@@ -1849,15 +1834,7 @@ def test_create_cli_test_run_execution_updates_existing_project_with_config_and_
         pics=None,
     )
 
-    # Updated project after config and PICS update
-    mock_updated_project = Project(
-        id=456,
-        name="Existing Test Project",
-        config=default_config,
-        pics=pics_data,
-    )
-
-    # Mock test run execution
+    # Mock test run execution with execution_config and execution_pics
     mock_test_run = TestRunExecution(
         id=1,
         title=test_run_execution_create.title,
@@ -1871,26 +1848,25 @@ def test_create_cli_test_run_execution_updates_existing_project_with_config_and_
         imported_at=None,
         archived_at=None,
     )
+    mock_test_run.execution_config = default_config
+    mock_test_run.execution_pics = pics_data
 
     with patch(
         "app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db
     ), patch(
         "app.api.api_v1.endpoints.test_run_executions.crud.project.get",
         return_value=mock_project,
-    ) as mock_get, patch(
-        "app.api.api_v1.endpoints.test_run_executions.crud.project.update",
-        return_value=mock_updated_project,
-    ) as mock_update, patch(
+    ), patch(
         "app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create",
         return_value=mock_test_run,
-    ):
+    ) as mock_create:
         response = client.post(
             f"{settings.API_V1_STR}/test_run_executions/cli",
             json={
                 "test_run_execution_in": test_run_execution_create.dict(),
                 "selected_tests": test_selection,
-                "config": default_config,
-                "pics": pics_data,
+                "execution_config": default_config,
+                "execution_pics": pics_data,
             },
         )
 
@@ -1899,25 +1875,19 @@ def test_create_cli_test_run_execution_updates_existing_project_with_config_and_
     assert data["title"] == test_run_execution_create.title
     assert data["project_id"] == 456
 
-    # Verify that project.get was called with the correct ID
-    mock_get.assert_called_once_with(db=ANY, id=456)
-
-    # Verify that project.update was called to update both config and PICS
-    mock_update.assert_called_once()
-    args, kwargs = mock_update.call_args
-    assert kwargs["db"] is not None
-    assert kwargs["db_obj"] == mock_project
-    # Verify the ProjectUpdate object has both config and PICS
-    project_update = kwargs["obj_in"]
-    assert project_update.config == default_config
-    assert project_update.pics is not None
-    assert project_update.pics.clusters["OnOff"].name == "OnOff"
+    # Verify that the execution was created with both execution config and pics
+    mock_create.assert_called_once()
+    _, kwargs = mock_create.call_args
+    execution_in = kwargs["obj_in"]
+    assert execution_in.execution_config == default_config
+    assert execution_in.execution_pics == pics_data
 
 
-def test_create_cli_test_run_execution_updates_existing_project_config_only_no_pics(
+def test_create_cli_test_run_execution_does_not_update_existing_project_no_pics(
     mock_db, test_run_execution_create, test_selection, default_config
 ):
-    """Test that when project_id is provided without PICS, only config is updated."""
+    """Test that when project_id is provided without PICS, only execution_config
+    is stored on the execution."""
     # Set project_id in the test_run_execution_create object
     test_run_execution_create.project_id = 789
 
@@ -1929,15 +1899,7 @@ def test_create_cli_test_run_execution_updates_existing_project_config_only_no_p
         pics={"clusters": {"existing": "data"}},
     )
 
-    # Updated project after config update only
-    mock_updated_project = Project(
-        id=789,
-        name="Existing Test Project",
-        config=default_config,
-        pics={"clusters": {"existing": "data"}},  # PICS should remain unchanged
-    )
-
-    # Mock test run execution
+    # Mock test run execution with execution_config only
     mock_test_run = TestRunExecution(
         id=1,
         title=test_run_execution_create.title,
@@ -1951,26 +1913,25 @@ def test_create_cli_test_run_execution_updates_existing_project_config_only_no_p
         imported_at=None,
         archived_at=None,
     )
+    mock_test_run.execution_config = default_config
+    mock_test_run.execution_pics = {}
 
     with patch(
         "app.api.api_v1.endpoints.test_run_executions.get_db", return_value=mock_db
     ), patch(
         "app.api.api_v1.endpoints.test_run_executions.crud.project.get",
         return_value=mock_project,
-    ) as mock_get, patch(
-        "app.api.api_v1.endpoints.test_run_executions.crud.project.update",
-        return_value=mock_updated_project,
-    ) as mock_update, patch(
+    ), patch(
         "app.api.api_v1.endpoints.test_run_executions.crud.test_run_execution.create",
         return_value=mock_test_run,
-    ):
+    ) as mock_create:
         response = client.post(
             f"{settings.API_V1_STR}/test_run_executions/cli",
             json={
                 "test_run_execution_in": test_run_execution_create.dict(),
                 "selected_tests": test_selection,
-                "config": default_config,
-                "pics": {},  # Empty PICS
+                "execution_config": default_config,
+                "execution_pics": {},  # Empty PICS
             },
         )
 
@@ -1979,17 +1940,9 @@ def test_create_cli_test_run_execution_updates_existing_project_config_only_no_p
     assert data["title"] == test_run_execution_create.title
     assert data["project_id"] == 789
 
-    # Verify that project.get was called with the correct ID
-    mock_get.assert_called_once_with(db=ANY, id=789)
-
-    # Verify that project.update was called to update only config
-    mock_update.assert_called_once()
-    args, kwargs = mock_update.call_args
-    assert kwargs["db"] is not None
-    assert kwargs["db_obj"] == mock_project
-    # Verify the ProjectUpdate object has config but no PICS
-    project_update = kwargs["obj_in"]
-    assert project_update.config == default_config
-    # PICS should be set to empty PICS object when empty dict is provided
-    assert project_update.pics is not None
-    assert project_update.pics.clusters == {}
+    # Verify that the execution was created with execution_config but no execution_pics
+    mock_create.assert_called_once()
+    _, kwargs = mock_create.call_args
+    execution_in = kwargs["obj_in"]
+    assert execution_in.execution_config == default_config
+    assert execution_in.execution_pics == {}


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/941
Required for: https://github.com/project-chip/certification-tool-cli/pull/80
---

## Description
When users passed a PICS folder through the CLI `run_tests` command using `--pics-config-folder`, the PICS data was being persisted to the project in the database, overwriting the project's configured PICS.

## Solution
Implemented `execution_pics` field following the same pattern as `execution_config`. This allows temporary, execution-specific PICS data to be used for a single test run without persisting it to the project.

## Changes

### Database Model
**File:** `backend/app/models/test_run_execution.py`
- Added `execution_pics` field (JSON, nullable) to store temporary PICS data
- Field is stored at the test run execution level, not persisted to project

### Schemas
**File:** `backend/app/schemas/test_run_execution.py`
- Added `execution_pics: dict | None = None` to `TestRunExecutionBase` schema
- Ensures the field is properly serialized/deserialized in API responses

### API Endpoint
**File:** `backend/app/api/api_v1/endpoints/test_run_executions.py`
- Updated `create_cli_test_run_execution()` endpoint:
  - `execution_pics` (optional): Stored in test run execution only (temporary)
- Added logic to handle `execution_pics` parameter and store it in the test run execution

### Test Engine
**File:** `backend/app/test_engine/models/test_suite.py`
- Modified `pics` property to implement priority logic:
  1. First, check for `execution_pics` (temporary override from CLI)
  2. Fallback to `project.pics` (persistent configuration)
- Mirrors the same behavior as the existing `config` property

### Database Migration
**File:** `backend/alembic/versions/f9a1b2c3d4e5_add_execution_pics_to_test_run_execution.py`
- Created Alembic migration to add `execution_pics` column to `testrunexecution` table
- Column type: JSON (nullable)
- Includes both upgrade and downgrade functions

## Behavior

### Before
```
CLI run_tests --pics-config-folder ./pics
  ↓
Project PICS updated in DB (unwanted side effect)
  ↓
All future test runs use the new PICS
```

### After
```
CLI run_tests --pics-config-folder ./pics
  ↓
execution_pics stored in test_run_execution (temporary)
  ↓
Only this test run uses the PICS, project unchanged
```

This ensures consistency with the existing `execution_config` vs `project.config`.

## Migration Required
After merging, run: `alembic upgrade head`