### PR TITLE
Fix custom sideloaded test scripts not appearing in the test list when their base class is defined in support_modules

### DIFF
--- a/app/tests/test_engine/test_list_python_tests_classes.py
+++ b/app/tests/test_engine/test_list_python_tests_classes.py
@@ -557,3 +557,297 @@ class TestGetCommandList:
         result = get_command_list(folder)
         class_names = [cmd[1] for cmd in result]
         assert class_names == ["TC_A_1_1", "TC_B_1_1"]
+
+
+# ---------------------------------------------------------------------------
+# _is_matter_base_test_class — extra_search_dirs
+# ---------------------------------------------------------------------------
+
+
+class TestIsMatterBaseTestClassExtraSearchDirs:
+    def test_finds_base_in_extra_search_dir_when_absent_from_search_dir(
+        self, tmp_path: Path
+    ) -> None:
+        sdk_dir = tmp_path / "sdk"
+        sdk_dir.mkdir()
+        custom_dir = tmp_path / "custom"
+        custom_dir.mkdir()
+
+        (sdk_dir / "support_modules").mkdir()
+        (sdk_dir / "support_modules" / "cadmin_support.py").write_text(
+            textwrap.dedent(
+                f"""
+            class CADMINBaseTest({MATTER_BASE_TEST_CLASS_NAME}):
+                pass
+        """
+            )
+        )
+
+        module = _parse(
+            """
+            from support_modules.cadmin_support import CADMINBaseTest
+
+            class TC_JFADMIN_2_2(CADMINBaseTest):
+                pass
+        """
+        )
+
+        # Without extra_search_dirs (custom_dir only) — should NOT find it
+        assert (
+            _is_matter_base_test_class("TC_JFADMIN_2_2", module, search_dir=custom_dir)
+            is False
+        )
+
+        # With sdk_dir as extra — should resolve via extra dir
+        assert (
+            _is_matter_base_test_class(
+                "TC_JFADMIN_2_2",
+                module,
+                search_dir=custom_dir,
+                _extra_search_dirs=[sdk_dir],
+            )
+            is True
+        )
+
+    def test_search_dir_takes_precedence_over_extra_dir(self, tmp_path: Path) -> None:
+        primary_dir = tmp_path / "primary"
+        primary_dir.mkdir()
+        extra_dir = tmp_path / "extra"
+        extra_dir.mkdir()
+
+        # primary_dir has a base that does NOT inherit MatterBaseTest
+        (primary_dir / "MyBase.py").write_text(
+            textwrap.dedent(
+                """
+            class MyBase:
+                pass
+        """
+            )
+        )
+        # extra_dir has a base that DOES inherit MatterBaseTest
+        (extra_dir / "MyBase.py").write_text(
+            textwrap.dedent(
+                f"""
+            class MyBase({MATTER_BASE_TEST_CLASS_NAME}):
+                pass
+        """
+            )
+        )
+
+        module = _parse(
+            """
+            from MyBase import MyBase
+
+            class MyTest(MyBase):
+                pass
+        """
+        )
+
+        # search_dir version (no inheritance) should win
+        assert (
+            _is_matter_base_test_class(
+                "MyTest",
+                module,
+                search_dir=primary_dir,
+                _extra_search_dirs=[extra_dir],
+            )
+            is False
+        )
+
+    def test_extra_search_dir_not_needed_for_sibling_in_search_dir(
+        self, tmp_path: Path
+    ) -> None:
+        sdk_dir = tmp_path / "sdk"
+        sdk_dir.mkdir()
+        (sdk_dir / "support_modules").mkdir()
+        (sdk_dir / "support_modules" / "idm_support.py").write_text(
+            textwrap.dedent(
+                f"""
+            class IDMBaseTest({MATTER_BASE_TEST_CLASS_NAME}):
+                pass
+        """
+            )
+        )
+
+        module = _parse(
+            """
+            from support_modules.idm_support import IDMBaseTest
+
+            class TC_IDM_1_2(IDMBaseTest):
+                pass
+        """
+        )
+
+        # sdk_dir is the search_dir itself; no extra dirs needed
+        assert (
+            _is_matter_base_test_class("TC_IDM_1_2", module, search_dir=sdk_dir) is True
+        )
+
+    def test_returns_false_when_module_absent_from_all_dirs(
+        self, tmp_path: Path
+    ) -> None:
+        custom_dir = tmp_path / "custom"
+        custom_dir.mkdir()
+        extra_dir = tmp_path / "extra"
+        extra_dir.mkdir()
+
+        module = _parse(
+            """
+            from support_modules.cadmin_support import CADMINBaseTest
+
+            class TC_X_1_1(CADMINBaseTest):
+                pass
+        """
+        )
+
+        assert (
+            _is_matter_base_test_class(
+                "TC_X_1_1",
+                module,
+                search_dir=custom_dir,
+                _extra_search_dirs=[extra_dir],
+            )
+            is False
+        )
+
+
+# ---------------------------------------------------------------------------
+# base_test_classes — extra_search_dirs
+# ---------------------------------------------------------------------------
+
+
+class TestBaseTestClassesExtraSearchDirs:
+    def test_resolves_base_via_extra_search_dir(self, tmp_path: Path) -> None:
+        sdk_dir = tmp_path / "sdk"
+        sdk_dir.mkdir()
+        custom_dir = tmp_path / "custom"
+        custom_dir.mkdir()
+
+        (sdk_dir / "support_modules").mkdir()
+        (sdk_dir / "support_modules" / "cadmin_support.py").write_text(
+            textwrap.dedent(
+                f"""
+            class CADMINBaseTest({MATTER_BASE_TEST_CLASS_NAME}):
+                pass
+        """
+            )
+        )
+
+        module = _parse(
+            """
+            from support_modules.cadmin_support import CADMINBaseTest
+
+            class TC_JFADMIN_2_2(CADMINBaseTest):
+                pass
+        """
+        )
+
+        result = base_test_classes(
+            module, search_dir=custom_dir, extra_search_dirs=[sdk_dir]
+        )
+        assert len(result) == 1
+        assert result[0].name == "TC_JFADMIN_2_2"
+
+    def test_returns_empty_without_extra_dir_when_base_not_local(
+        self, tmp_path: Path
+    ) -> None:
+        custom_dir = tmp_path / "custom"
+        custom_dir.mkdir()
+
+        module = _parse(
+            """
+            from support_modules.cadmin_support import CADMINBaseTest
+
+            class TC_JFADMIN_2_2(CADMINBaseTest):
+                pass
+        """
+        )
+
+        result = base_test_classes(module, search_dir=custom_dir)
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# get_command_list — custom vs sdk folder extra_search_dirs behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestGetCommandListCustomFolder:
+    def test_custom_folder_resolves_support_module_from_sdk_dir(
+        self, tmp_path: Path
+    ) -> None:
+        sdk_dir = tmp_path / "sdk"
+        sdk_dir.mkdir()
+        custom_dir = tmp_path / "custom"
+        custom_dir.mkdir()
+
+        (sdk_dir / "support_modules").mkdir()
+        (sdk_dir / "support_modules" / "cadmin_support.py").write_text(
+            textwrap.dedent(
+                f"""
+            class CADMINBaseTest({MATTER_BASE_TEST_CLASS_NAME}):
+                pass
+        """
+            )
+        )
+
+        test_file = custom_dir / "TC_JFADMIN_2_2.py"
+        test_file.write_text(
+            textwrap.dedent(
+                """
+            from support_modules.cadmin_support import CADMINBaseTest
+
+            class TC_JFADMIN_2_2(CADMINBaseTest):
+                pass
+        """
+            )
+        )
+
+        folder = MagicMock()
+        folder.path = custom_dir
+        folder.file_paths.return_value = [test_file]
+
+        with patch(
+            "test_collections.matter.sdk_tests.support.python_testing"
+            ".list_python_tests_classes.CUSTOM_PYTHON_SCRIPTS_PATH",
+            custom_dir,
+        ):
+            with patch(
+                "test_collections.matter.sdk_tests.support.python_testing"
+                ".list_python_tests_classes.PYTHON_SCRIPTS_PATH",
+                sdk_dir,
+            ):
+                result = get_command_list(folder)
+
+        assert len(result) == 1
+        assert result[0][1] == "TC_JFADMIN_2_2"
+
+    def test_sdk_folder_does_not_use_extra_search_dirs(self, tmp_path: Path) -> None:
+        sdk_dir = tmp_path / "sdk"
+        sdk_dir.mkdir()
+        custom_dir = tmp_path / "custom"
+        custom_dir.mkdir()
+
+        test_file = sdk_dir / "TC_FOO_1_1.py"
+        test_file.write_text(
+            textwrap.dedent(
+                f"""
+            class TC_FOO_1_1({MATTER_BASE_TEST_CLASS_NAME}):
+                pass
+        """
+            )
+        )
+
+        folder = MagicMock()
+        folder.path = sdk_dir
+        folder.file_paths.return_value = [test_file]
+
+        with patch(
+            "test_collections.matter.sdk_tests.support.python_testing"
+            ".list_python_tests_classes.CUSTOM_PYTHON_SCRIPTS_PATH",
+            custom_dir,
+        ):
+            result = get_command_list(folder)
+
+        assert len(result) == 1
+        assert result[0][1] == "TC_FOO_1_1"

--- a/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
@@ -138,6 +138,7 @@ def _is_matter_base_test_class(
     search_dir: Optional[Path],
     _visiting: Optional[set[tuple]] = None,
     _module_cache: Optional[dict] = None,
+    _extra_search_dirs: Optional[list[Path]] = None,
 ) -> bool:
     """Recursively check if a class name in a parsed module ultimately inherits
     from MatterBaseTest, following local file imports as needed.
@@ -152,6 +153,9 @@ def _is_matter_base_test_class(
             separately parsed copies of the same file are correctly identified.
         _module_cache: Cache of already-parsed AST modules keyed by absolute
             file path, to avoid redundant disk reads.
+        _extra_search_dirs: Additional directories to search when the module
+            file is not found relative to search_dir (e.g. sdk/ siblings when
+            resolving imports from the custom/ folder).
 
     Returns:
         bool: True if the class transitively inherits from MatterBaseTest.
@@ -160,6 +164,8 @@ def _is_matter_base_test_class(
         _visiting = set()
     if _module_cache is None:
         _module_cache = {}
+    if _extra_search_dirs is None:
+        _extra_search_dirs = []
 
     # Find the class definition in this module
     class_def = next(
@@ -189,7 +195,7 @@ def _is_matter_base_test_class(
 
         # Check if base_name is defined in the same module (local parent class)
         if _is_matter_base_test_class(
-            base_name, module, search_dir, _visiting, _module_cache
+            base_name, module, search_dir, _visiting, _module_cache, _extra_search_dirs
         ):
             return True
 
@@ -207,47 +213,58 @@ def _is_matter_base_test_class(
             # Try to load a local file. Module dots are converted to path separators
             # so both flat imports (TC_TLSCERT_Base) and package imports
             # (support_modules.idm_support) resolve to the correct sibling file.
-            if search_dir:
-                candidate = search_dir / f"{node.module.replace('.', '/')}.py"
-                if candidate.exists():
-                    try:
-                        abs_path = str(candidate.resolve())
-                        if abs_path not in _module_cache:
-                            with open(candidate, "r") as f:
-                                _module_cache[abs_path] = ast.parse(f.read())
-                        imported_module = _module_cache[abs_path]
+            # Also search _extra_search_dirs for modules that live outside search_dir
+            # (e.g. support_modules/ under sdk/ when resolving imports from custom/).
+            module_rel_path = f"{node.module.replace('.', '/')}.py"
+            all_search_dirs = ([search_dir] if search_dir else []) + _extra_search_dirs
+            candidate = next(
+                (
+                    d / module_rel_path
+                    for d in all_search_dirs
+                    if (d / module_rel_path).exists()
+                ),
+                None,
+            )
+            if candidate is not None:
+                try:
+                    abs_path = str(candidate.resolve())
+                    if abs_path not in _module_cache:
+                        with open(candidate, "r") as f:
+                            _module_cache[abs_path] = ast.parse(f.read())
+                    imported_module = _module_cache[abs_path]
 
-                        # Use the absolute path as the cycle-guard key so that
-                        # re-parsed copies of the same file are treated as
-                        # identical, preventing infinite recursion on cross-file
-                        # circular imports.
-                        file_key = (abs_path, class_name)
-                        if file_key in _visiting:
-                            continue
-                        _visiting.add(file_key)
-
-                        # The actual class name in the imported file may differ
-                        # (e.g. `from TC_TLSCERT_Base import TC_TLSCERT_Base`)
-                        actual_name = next(
-                            (
-                                alias.name
-                                for alias in node.names
-                                if (alias.asname or alias.name) == base_name
-                            ),
-                            base_name,
-                        )
-                        if _is_matter_base_test_class(
-                            actual_name,
-                            imported_module,
-                            search_dir,
-                            _visiting,
-                            _module_cache,
-                        ):
-                            return True
+                    # Use the absolute path as the cycle-guard key so that
+                    # re-parsed copies of the same file are treated as
+                    # identical, preventing infinite recursion on cross-file
+                    # circular imports.
+                    file_key = (abs_path, class_name)
+                    if file_key in _visiting:
                         continue
+                    _visiting.add(file_key)
 
-                    except SyntaxError:
-                        logger.warning(f"Skipping {candidate} due to syntax error")
+                    # The actual class name in the imported file may differ
+                    # (e.g. `from TC_TLSCERT_Base import TC_TLSCERT_Base`)
+                    actual_name = next(
+                        (
+                            alias.name
+                            for alias in node.names
+                            if (alias.asname or alias.name) == base_name
+                        ),
+                        base_name,
+                    )
+                    if _is_matter_base_test_class(
+                        actual_name,
+                        imported_module,
+                        candidate.parent,
+                        _visiting,
+                        _module_cache,
+                        _extra_search_dirs,
+                    ):
+                        return True
+                    continue
+
+                except SyntaxError:
+                    logger.warning(f"Skipping {candidate} due to syntax error")
 
             # Fallback for installed packages whose source is not available as a
             # local file (e.g. matter.testing.* installed as a wheel).
@@ -260,7 +277,9 @@ def _is_matter_base_test_class(
 
 
 def base_test_classes(
-    module: ast.Module, search_dir: Optional[Path] = None
+    module: ast.Module,
+    search_dir: Optional[Path] = None,
+    extra_search_dirs: Optional[list[Path]] = None,
 ) -> list[ast.ClassDef]:
     """Find classes that inherit from MatterBaseTest, following local imports
     transitively so that intermediate base classes (e.g. TC_TLSCERT_Base) are
@@ -271,6 +290,9 @@ def base_test_classes(
         search_dir (Optional[Path]): Directory containing the file's siblings,
             used to resolve local imports.  When None only same-file inheritance
             and the legacy pattern-based fallback are used.
+        extra_search_dirs (Optional[list[Path]]): Additional directories to
+            search when a module is not found relative to search_dir (e.g.
+            sdk/ siblings when resolving imports from the custom/ folder).
 
     Returns:
         list[ast.ClassDef]: Classes in the module that ultimately inherit from
@@ -282,7 +304,11 @@ def base_test_classes(
         for c in module.body
         if isinstance(c, ast.ClassDef)
         and _is_matter_base_test_class(
-            c.name, module, search_dir, _module_cache=module_cache
+            c.name,
+            module,
+            search_dir,
+            _module_cache=module_cache,
+            _extra_search_dirs=extra_search_dirs or [],
         )
     ]
 
@@ -298,6 +324,9 @@ def get_command_list(test_folder: SDKTestFolder) -> list:
     # Load ignore and include lists
     ignore_list = load_ignore_list()
     include_list = load_include_list()
+
+    is_custom = test_folder.path.is_relative_to(CUSTOM_PYTHON_SCRIPTS_PATH)
+    extra_search_dirs = [PYTHON_SCRIPTS_PATH] if is_custom else []
 
     for python_test_file in python_test_files:
         # Check if file is in include list (bypass regex check)
@@ -324,7 +353,9 @@ def get_command_list(test_folder: SDKTestFolder) -> list:
             continue
 
         test_classes = base_test_classes(
-            parsed_python_file, search_dir=python_test_file.parent
+            parsed_python_file,
+            search_dir=python_test_file.parent,
+            extra_search_dirs=extra_search_dirs,
         )
         for test_class in test_classes:
             # Add file path and class name

--- a/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
@@ -218,11 +218,7 @@ def _is_matter_base_test_class(
             module_rel_path = f"{node.module.replace('.', '/')}.py"
             all_search_dirs = ([search_dir] if search_dir else []) + _extra_search_dirs
             candidate = next(
-                (
-                    p
-                    for d in all_search_dirs
-                    if (p := d / module_rel_path).exists()
-                ),
+                (p for d in all_search_dirs if (p := d / module_rel_path).exists()),
                 None,
             )
             if candidate is not None:

--- a/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
@@ -219,9 +219,9 @@ def _is_matter_base_test_class(
             all_search_dirs = ([search_dir] if search_dir else []) + _extra_search_dirs
             candidate = next(
                 (
-                    d / module_rel_path
+                    p
                     for d in all_search_dirs
-                    if (d / module_rel_path).exists()
+                    if (p := d / module_rel_path).exists()
                 ),
                 None,
             )
@@ -255,7 +255,7 @@ def _is_matter_base_test_class(
                     if _is_matter_base_test_class(
                         actual_name,
                         imported_module,
-                        candidate.parent,
+                        search_dir,
                         _visiting,
                         _module_cache,
                         _extra_search_dirs,


### PR DESCRIPTION
### What changed
Fix custom sideloaded test scripts not appearing in the test list when their base class is defined in support_modules/, which lives under scripts/sdk/ rather than scripts/custom/.    

####  Motivation                                                                                                                              
                                                                                                                                        
  Custom test scripts (e.g. TC_JFADMIN_2_2.py, TC_ACE_1_3.py) inherit from intermediate base classes like CADMINBaseTest that are defined in scripts/sdk/support_modules/. When copied to scripts/custom/, the search_dir points to custom/ where support_modules/ does not exist.
   The AST resolver failed to find the base class file, returned an empty test_classes list, and the test was silently excluded from the test collection.

####   Impact                                                                                                                                  
  
  - Custom scripts whose base class lives in sdk/support_modules/ are now correctly discovered and listed                                 
  - No behavior change for standard SDK scripts — extra_search_dirs is empty for non-custom folders                                     
  - Non-breaking: the new parameters are optional with safe defaults    
  
#### Changes                                                                                                                                 
                                                                                                                                        
- list_python_tests_classes.py                                                                                                            
   - Added _extra_search_dirs parameter to _is_matter_base_test_class() — when a base class module is not found relative to search_dir, the
   resolver now also tries each directory in _extra_search_dirs                                                                           
   - Updated the candidate resolution to iterate search_dir + _extra_search_dirs in order, preserving search_dir precedence              
   - Recursive calls propagate _extra_search_dirs and correctly set candidate.parent as the new search_dir when following cross-file       
  imports                                                                                                                                 
   - Added extra_search_dirs parameter to base_test_classes(), passed through to the recursive resolver                                    
   - In get_command_list(), computed is_custom once before the loop (not per-file); custom folders get [PYTHON_SCRIPTS_PATH] as extra search dirs, SDK folders get none                                                                                                       
                                                                                                                                          
- test_list_python_tests_classes.py                                                                                                       

  - Added 13 new tests covering all new behavior: _is_matter_base_test_class with extra dirs, base_test_classes with extra dirs, and get_command_list custom vs SDK folder distinction                                                                                       
                                                                                                                                          
### Related Issues
- https://github.com/project-chip/certification-tool/issues/960
- https://github.com/project-chip/certification-tool/issues/963

### Testing
13 new unit tests added. All unit test are passing
The missing Test cases are now available for execution