### PR TITLE
Remove commissioning prompt from no commissioning tests

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -663,13 +663,6 @@ class PythonTestCase(TestCase, UserPromptSupport):
 class NoCommissioningPythonTestCase(PythonTestCase):
     async def setup(self) -> None:
         await super().setup()
-        user_response = await prompt_for_commissioning_mode(
-            self, logger, None, self.cancel
-        )
-        if user_response == PromptOption.FAIL:
-            raise DUTCommissioningError(
-                "User chose prompt option FAILED for DUT is in Commissioning Mode"
-            )
 
 
 class LegacyPythonTestCase(PythonTestCase):

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -664,10 +664,14 @@ class NoCommissioningPythonTestCase(PythonTestCase):
     async def setup(self) -> None:
         await super().setup()
 
+        logger.info("Setup -  No Commissioning Python Test Case")
+
 
 class LegacyPythonTestCase(PythonTestCase):
     async def setup(self) -> None:
         await super().setup()
+
+        logger.info("Setup -  Legacy Python Test Case")
 
         await self.prompt_about_commissioning()
 

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
@@ -30,7 +30,10 @@ from app.test_engine.logger import test_engine_logger
 from ...models.matter_test_models import MatterTestStep, MatterTestType
 from ...python_testing.models import PythonTestCase
 from ...python_testing.models.python_test_models import PythonTest, PythonTestType
-from ...python_testing.models.test_case import LegacyPythonTestCase
+from ...python_testing.models.test_case import (
+    LegacyPythonTestCase,
+    NoCommissioningPythonTestCase,
+)
 from ...python_testing.models.utils import DUTCommissioningError
 from ...utils import PromptOption
 
@@ -507,3 +510,31 @@ async def test_legacy_python_test_case_new_commissioning() -> None:
 
         mock_prompt_commissioning.assert_called_once()
         mock_commission_device.assert_called()
+
+
+@pytest.mark.asyncio
+async def test_no_commissioning_python_test_case_does_not_prompt_commissioning_mode() -> None:
+    """Test that NoCommissioningPythonTestCase.setup() does not prompt the user to put
+    the DUT in commissioning mode.
+
+    Regression test for: TC_DD_1_5 showing spurious commissioning prompt when run via CLI.
+    """
+    test_case_execution = TestCaseExecution()
+    test = python_test_instance(
+        name="TC-DD-1.5",
+        path=Path("path"),
+        python_test_type=PythonTestType.NO_COMMISSIONING,
+    )
+
+    test_case = NoCommissioningPythonTestCase.class_factory(
+        test=test,
+        python_test_version="version",
+        mandatory=False,
+    )(test_case_execution)
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".prompt_for_commissioning_mode"
+    ) as mock_prompt_commissioning:
+        await test_case.setup()
+        mock_prompt_commissioning.assert_not_called()

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
@@ -526,7 +526,7 @@ async def test_no_commissioning_python_test_case_does_not_prompt_commissioning_m
         python_test_type=PythonTestType.NO_COMMISSIONING,
     )
 
-    test_case = NoCommissioningPythonTestCase.class_factory(
+    test_case = NoCommissioningPythonTestCase.class_factory(  # type: ignore
         test=test,
         python_test_version="version",
         mandatory=False,


### PR DESCRIPTION
### What changed
Fix spurious "Make sure the DUT is in Commissioning Mode" prompt appearing when running NO_COMMISSIONING test cases (e.g. TC-DD-1.5)    
  through the TH CLI.                                                                                                                     
  
####   Changes                                                                                                                                 
- test_case.py — NoCommissioningPythonTestCase.setup()                                                                                    
  - Removed the prompt_for_commissioning_mode call (and its associated DUTCommissioningError raise) from NoCommissioningPythonTestCase.setup(). The method now simply delegates to super().setup().                                              
                                                                                            
- test_python_test_case.py — regression test                                                                                              
  - Added import for NoCommissioningPythonTestCase.                                                                                       
  - Added test_no_commissioning_python_test_case_does_not_prompt_commissioning_mode: asserts that prompt_for_commissioning_mode is never  called during setup of a NO_COMMISSIONING test case.                                                                                    

####  Motivation                                                                                                                                                                                          
  Tests classified as NO_COMMISSIONING (those whose steps have no is_commissioning=True flag, such as TC-DD-1.5 which only validates NFC  onboarding data) were incorrectly prompting users to put the DUT in commissioning mode. This happened because NoCommissioningPythonTestCase.setup() unconditionally called prompt_for_commissioning_mode, despite the test type explicitly indicating commissioning is not required.                            

The bug was invisible when running tests directly with Python because the SDK's InternalTestRunnerHooks.show_prompt() is a no-op. The TH CLI/backend, however, actually surfaces prompts to the user, exposing the issue.
                                                                                                                                          
####  Impact                                                                                                                                  
  - No breaking changes. Tests that previously showed the prompt will now skip it and proceed directly.                                   
  - LegacyPythonTestCase and CommissioningPythonTestCase flows are unaffected.
  - Aligns TH CLI behavior with direct Python execution for all NO_COMMISSIONING suite tests.   

### Related Issue
https://github.com/project-chip/certification-tool/issues/959

### Testing
unit test added - all tests are passing

Running TC-DD-1-5 using GUI and CLI and no prompt requesting the put DUT in commissioning mode were displayed 