### PR TITLE
Fix TC_DD_3_24 hang on user prompt timeout in _show_prompt_request

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -280,9 +280,16 @@ class PythonTestCase(TestCase, UserPromptSupport):
     async def _show_prompt_request(self, request: PromptRequest) -> None:
         user_response = await self.send_prompt_request(request)
 
-        if self.test_socket and user_response.response_str:
-            response = f"{user_response.response_str}\n".encode()
-            self.test_socket._sock.sendall(response)  # type: ignore[attr-defined]
+        if self.test_socket:
+            # Always send something to unblock the SDK's input() call.
+            # On timeout/cancel response_str is None, so fall back to default_value
+            # or an empty line — otherwise the SDK process hangs waiting on stdin.
+            reply = user_response.response_str or getattr(request, "default_value", None) or ""
+            self.test_socket._sock.sendall(  # type: ignore[attr-defined]
+                f"{reply}\n".encode()
+            )
+
+        self.__evaluate_user_response_for_errors(user_response)
 
     async def show_prompt(
         self,

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -284,7 +284,7 @@ class PythonTestCase(TestCase, UserPromptSupport):
             # Always send something to unblock the SDK's input() call.
             # On timeout/cancel response_str is None, so fall back to default_value
             # or an empty line — otherwise the SDK process hangs waiting on stdin.
-            reply = user_response.response_str or getattr(request, "default_value", None) or ""
+            reply = (user_response.response_str if user_response else None) or getattr(request, "default_value", None) or ""
             self.test_socket._sock.sendall(  # type: ignore[attr-defined]
                 f"{reply}\n".encode()
             )

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -284,7 +284,11 @@ class PythonTestCase(TestCase, UserPromptSupport):
             # Always send something to unblock the SDK's input() call.
             # On timeout/cancel response_str is None, so fall back to default_value
             # or an empty line — otherwise the SDK process hangs waiting on stdin.
-            reply = (user_response.response_str if user_response else None) or getattr(request, "default_value", None) or ""
+            reply = (
+                user_response.response_str
+                or getattr(request, "default_value", None)
+                or ""
+            )
             self.test_socket._sock.sendall(  # type: ignore[attr-defined]
                 f"{reply}\n".encode()
             )
@@ -325,13 +329,7 @@ class PythonTestCase(TestCase, UserPromptSupport):
             timeout=USER_PROMPT_TIMEOUT,
             image_hex_str=img_hex_str,
         )
-
-        user_response = await self.send_prompt_request(prompt_request)
-        self.__evaluate_user_response_for_errors(user_response)
-
-        if self.test_socket and user_response.response_str:
-            response = f"{user_response.response_str}\n".encode()
-            self.test_socket._sock.sendall(response)  # type: ignore[attr-defined]
+        await self._show_prompt_request(prompt_request)
 
     async def show_push_av_stream_prompt(self, msg: str) -> None:
         options = {


### PR DESCRIPTION
### What Changed 
Fixes a TH hang when a user prompt times out during SDK-based Python tests. Reported in #971 — TC_DD_3_24 ("Power ON the device" prompt) would hang indefinitely on timeout, requiring a CTRL-C to recover.   

#### Changes                                                                                                                                      
  - test_collections/matter/sdk_tests/support/python_testing/models/test_case.py — _show_prompt_request:                                  
    - Always writes a line to the test socket regardless of whether response_str is set, falling back to default_value or "" on timeout/cancel
    - Calls __evaluate_user_response_for_errors after the socket write so a timeout raises TestError("Prompt timed out.") and the test fails cleanly                                                                                                                           
                                                            
####  Motivation                                                                                                                              
  On prompt timeout, PromptExchange.response() correctly sets status_code = TIMEOUT and response_str = None. But _show_prompt_request only wrote to the socket if user_response.response_str — so on timeout nothing was sent. The SDK process's wait_for_user_input() blocks on input() waiting for a newline that never arrives, hanging the TH. Additionally, __evaluate_user_response_for_errors was never called for text prompts, so the timeout was silently swallowed even if the socket were fixed.

####  Impact
  - TH now reports "Prompt timed out." and exits cleanly instead of hanging                                                               
  - No behavioural change on successful user response
  - Affects all tests using wait_for_user_input via _show_prompt_request     

### Related Issue
https://github.com/project-chip/certification-tool/issues/971

### Testing

- Unit tests passing
- The originator tested with the provided branch and confirmed it fixed the issue: https://github.com/project-chip/certification-tool/issues/971#issuecomment-4326622077