### PR TITLE
Make pcscd --disable-polkit started unconditionally

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -105,14 +105,8 @@ class PythonTestSuite(TestSuite):
         await self.sdk_container.start()
 
         self.matter_config = TestEnvironmentConfigMatter(**self.config)
-        if self.matter_config.dut_config.pairing_mode in (
-            DutPairingModeEnum.NFC_THREAD,
-            DutPairingModeEnum.NFC_WIFI,
-            DutPairingModeEnum.THREAD_MESHCOP,
-        ):
-            # When PCSC reader is used in a Docker container, pollkit should
-            #  be disabled
-            self.sdk_container.send_command("--disable-polkit", prefix="pcscd")
+        # pcscd is required for NFC reader access regardless of pairing mode
+        self.sdk_container.send_command("--disable-polkit", prefix="pcscd")
 
         if len(self.pics.clusters) > 0:
             logger.info("Create PICS file for DUT")

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -71,13 +71,8 @@ class ChipSuite(TestSuite, UserPromptSupport):
         logger.info("Setting up SDK container")
         await self.sdk_container.start()
 
-        if self.config_matter.dut_config.pairing_mode in (
-            DutPairingModeEnum.NFC_THREAD,
-            DutPairingModeEnum.NFC_WIFI,
-        ):
-            # When PCSC reader is used in a Docker container, pollkit should
-            #  be disabled
-            self.sdk_container.send_command("--disable-polkit", prefix="pcscd")
+        # pcscd is required for NFC reader access regardless of pairing mode
+        self.sdk_container.send_command("--disable-polkit", prefix="pcscd")
 
         logger.info("Setting up test runner")
         await self.runner.setup(


### PR DESCRIPTION
### Description 
Start pcscd --disable-polkit unconditionally on SDK container setup to fix NFC reader access for all pairing modes.                     
                                                                                                                                          
####   Changes                                                                                                                                 
                                                                                                                                          
  - test_suite.py: Removed the pairing mode condition (NFC_THREAD, NFC_WIFI, THREAD_MESHCOP) that gated the pcscd --disable-polkit        
  command. It now runs unconditionally on every test suite setup.
  - chip_suite.py: Same change — removed the NFC_THREAD / NFC_WIFI condition, pcscd --disable-polkit now always runs on SDK container     
  setup.                                                                                                                                  
                                                                                                                                          
####  Motivation                                                                                                                              
                                                                                                                                        
  TC_DD_1_5 (and other NFC-related tests) use the NFC reader to verify the onboarding payload independently of the commissioning method.  
  The previous implementation only started the PC/SC daemon (pcscd) for NFC-based pairing modes, causing tests to fail with             
  EstablishContextException: Service not available (0x8010001D) when run with any other pairing mode (e.g. ble-wifi).                     

#### Impact                                                                                                                                
                                                                                                                                          
  - pcscd --disable-polkit will now always be started inside the th-sdk container at setup time.                                          
  - No side effects when no NFC reader is present — the daemon starts and sits idle.
  - All pairing modes are now supported for NFC verification tests.
  
### Related issue                                                                                                                                        
- https://github.com/project-chip/certification-tool/issues/975
- https://github.com/project-chip/connectedhomeip/issues/71656
- https://github.com/project-chip/connectedhomeip/issues/71673

                                                                                                                                          
### Testing
All unit test are passing
Using any pairing mode the log prints: 

> Sending command to SDK container: pcscd --disable-polkit
