### PR TITLE
Make discriminator and setup_code optional for nfc_* pairing mode and ignore qr-code for Python Testing Suite - Auto commissioning suite

### DIFF
--- a/app/constants/shared_constants.py
+++ b/app/constants/shared_constants.py
@@ -65,3 +65,9 @@ class DutPairingModeEnum(str, Enum):
     WIFIPAF_WIFI = "wifipaf-wifi"
     NFC_THREAD = "nfc-thread"
     THREAD_MESHCOP = "thread-meshcop"
+
+
+NFC_PAIRING_MODES = {
+    DutPairingModeEnum.NFC_WIFI.value,
+    DutPairingModeEnum.NFC_THREAD.value,
+}

--- a/test_collections/matter/sdk_tests/support/performance_tests/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/performance_tests/models/utils.py
@@ -20,7 +20,7 @@ from typing import Generator, cast
 
 import loguru
 
-from app.constants.shared_constants import DutPairingModeEnum
+from app.constants.shared_constants import NFC_PAIRING_MODES, DutPairingModeEnum
 from app.schemas.test_environment_config import TestEnvironmentConfig
 from app.test_engine.logger import test_engine_logger as logger
 
@@ -50,7 +50,7 @@ async def generate_command_arguments(
     if dut_config.trace_log:
         arguments.append("--trace-to json:log")
     # NFC modes don't use discriminator/passcode — onboarding data comes from the tag
-    if pairing_mode in (DutPairingModeEnum.NFC_WIFI, DutPairingModeEnum.NFC_THREAD):
+    if pairing_mode in NFC_PAIRING_MODES:
         logger.warning(
             f"pairing_mode is {pairing_mode}: discriminator and setup_code from"
             " project config are ignored. Onboarding data is read from the NFC tag."

--- a/test_collections/matter/sdk_tests/support/performance_tests/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/performance_tests/models/utils.py
@@ -22,6 +22,7 @@ import loguru
 
 from app.constants.shared_constants import DutPairingModeEnum
 from app.schemas.test_environment_config import TestEnvironmentConfig
+from app.test_engine.logger import test_engine_logger as logger
 
 from ...python_testing.models.utils import (
     EXECUTABLE,
@@ -48,9 +49,15 @@ async def generate_command_arguments(
     # Increase log level by adding trace log
     if dut_config.trace_log:
         arguments.append("--trace-to json:log")
-    # Retrieve arguments from dut_config
-    arguments.append(f"--discriminator {dut_config.discriminator}")
-    arguments.append(f"--passcode {dut_config.setup_code}")
+    # NFC modes don't use discriminator/passcode — onboarding data comes from the tag
+    if pairing_mode in (DutPairingModeEnum.NFC_WIFI, DutPairingModeEnum.NFC_THREAD):
+        logger.warning(
+            f"pairing_mode is {pairing_mode}: discriminator and setup_code from"
+            " project config are ignored. Onboarding data is read from the NFC tag."
+        )
+    else:
+        arguments.append(f"--discriminator {dut_config.discriminator}")
+        arguments.append(f"--passcode {dut_config.setup_code}")
     if not omit_commissioning_method:
         arguments.append(f"--commissioning-method {pairing_mode}")
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from socket import SocketIO
 from typing import Any, Optional, Type, TypeVar
 
+from app.constants.shared_constants import NFC_PAIRING_MODES
 from app.core.config import settings
 from app.models import TestCaseExecution
 from app.test_engine.logger import PYTHON_TEST_LEVEL
@@ -567,8 +568,36 @@ class PythonTestCase(TestCase, UserPromptSupport):
             # Generate the command argument by getting the test_parameters from
             # project configuration
             # comissioning method is omitted because it's handled by the test suite
+            config = TestEnvironmentConfigMatter(**self.config)
+
+            # For COMMISSIONING tests running under CommissioningPythonTestSuite with
+            # an NFC pairing mode, qr-code in test_parameters must be dropped —
+            # the onboarding data comes from the NFC tag. For NO_COMMISSIONING tests
+            # like TC_DD_1_5, qr-code is a legitimate input and must be preserved.
+            pairing_mode = config.dut_config.pairing_mode
+            if (
+                self.python_test.python_test_type == PythonTestType.COMMISSIONING
+                and pairing_mode in NFC_PAIRING_MODES
+                and config.test_parameters
+                and "qr-code" in config.test_parameters
+            ):
+                logger.warning(
+                    f"pairing_mode is {pairing_mode}: qr-code in test_parameters is"
+                    " ignored for Python Testing Suite - Auto commissioning."
+                    "Onboarding data is read from the NFC tag."
+                )
+                config = config.copy(
+                    update={
+                        "test_parameters": {
+                            k: v
+                            for k, v in config.test_parameters.items()
+                            if k != "qr-code"
+                        }
+                    }
+                )
+
             command_arguments = await generate_command_arguments(
-                config=TestEnvironmentConfigMatter(**self.config),
+                config=config,
                 omit_commissioning_method=True,
             )
             command.extend(command_arguments)

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -22,9 +22,10 @@ from typing import Generator, cast
 
 import loguru
 
-from app.constants.shared_constants import DutPairingModeEnum
+from app.constants.shared_constants import NFC_PAIRING_MODES, DutPairingModeEnum
 from app.schemas.test_environment_config import ThreadAutoConfig
 from app.test_engine.logger import PYTHON_TEST_LEVEL
+from app.test_engine.logger import test_engine_logger as logger
 from app.user_prompt_support import UserPromptSupport
 from test_collections.matter.sdk_tests.support.otbr_manager.otbr_manager import (
     ThreadBorderRouter,
@@ -52,11 +53,6 @@ EXECUTABLE = "python3"
 TEST_OUTPUT_FILE_PATH = "sdk_checkout/python_testing/test_output.txt"
 
 TEST_PARAMETER_STORAGE_PATH_KEY = "storage-path"
-
-NFC_PAIRING_MODES = {
-    DutPairingModeEnum.NFC_WIFI.value,
-    DutPairingModeEnum.NFC_THREAD.value,
-}
 
 # Typed SDK argument flags that accept NAME:VALUE pairs and require special
 # handling to survive the container shell without mangling.
@@ -122,11 +118,14 @@ async def generate_command_arguments(
     # since it is provided directly by the NFC tag.
     # Also, if manual-code or qr-code and also discriminator and passcode are provided,
     # the test will think that we're trying to commission 2 DUTs and it will fail
-    if (
-        pairing_mode not in NFC_PAIRING_MODES
-        and ("manual-code" not in test_parameters.keys() if test_parameters else True)
-        and ("qr-code" not in test_parameters.keys() if test_parameters else True)
-    ):
+    if pairing_mode in NFC_PAIRING_MODES:
+        logger.warning(
+            f"pairing_mode is {pairing_mode}: discriminator and setup_code from"
+            " project config are ignored. Onboarding data is read from the NFC tag."
+        )
+    elif (
+        "manual-code" not in test_parameters.keys() if test_parameters else True
+    ) and ("qr-code" not in test_parameters.keys() if test_parameters else True):
         # Retrieve arguments from dut_config
         arguments.append(f"--discriminator {dut_config.discriminator}")
         arguments.append(f"--passcode {dut_config.setup_code}")

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -119,10 +119,11 @@ async def generate_command_arguments(
     # Also, if manual-code or qr-code and also discriminator and passcode are provided,
     # the test will think that we're trying to commission 2 DUTs and it will fail
     if pairing_mode in NFC_PAIRING_MODES:
-        logger.warning(
-            f"pairing_mode is {pairing_mode}: discriminator and setup_code from"
-            " project config are ignored. Onboarding data is read from the NFC tag."
-        )
+        if dut_config.discriminator is not None or dut_config.setup_code is not None:
+            logger.warning(
+                f"pairing_mode is {pairing_mode}: discriminator and setup_code from"
+                " project config are ignored. Onboarding data is read from the NFC tag."
+            )
     elif (
         "manual-code" not in test_parameters.keys() if test_parameters else True
     ) and ("qr-code" not in test_parameters.keys() if test_parameters else True):

--- a/test_collections/matter/sdk_tests/support/tests/matter/test_test_environment_config.py
+++ b/test_collections/matter/sdk_tests/support/tests/matter/test_test_environment_config.py
@@ -290,7 +290,6 @@ def test_create_config_matter_with_only_manual_code_succeeds() -> None:
         "ble-wifi",
         "ble-thread",
         "wifipaf-wifi",
-        "nfc-thread",
     ],
 )
 def test_create_config_matter_with_non_thread_modes_no_ba_params_succeeds(
@@ -329,6 +328,123 @@ def test_create_config_matter_with_non_thread_modes_no_ba_params_succeeds(
 
     assert config_matter is not None
     assert config_matter.dut_config.pairing_mode == pairing_mode
+
+
+@pytest.mark.parametrize("pairing_mode", ["nfc-thread", "nfc-wifi"])
+def test_create_config_matter_nfc_without_discriminator_and_setup_code_succeeds(
+    pairing_mode: str,
+) -> None:
+    """Test that NFC pairing modes succeed without discriminator and setup_code."""
+    config = {
+        "network": {
+            "fabric_id": "0",
+            "thread": {
+                "dataset": {
+                    "channel": "15",
+                    "panid": "0x1234",
+                    "extpanid": "1111111122222222",
+                    "networkkey": "00112233445566778899aabbccddeeff",
+                    "networkname": "DEMO",
+                },
+                "rcp_serial_path": "/dev/ttyACM0",
+                "rcp_baudrate": 115200,
+                "on_mesh_prefix": "fd11:22::/64",
+                "network_interface": "eth0",
+            },
+            "wifi": {"ssid": "testharness", "password": "wifi-password"},
+        },
+        "dut_config": {
+            "pairing_mode": pairing_mode,
+            "chip_use_paa_certs": False,
+            "trace_log": True,
+        },
+        "test_parameters": None,
+    }
+
+    config_matter = TestEnvironmentConfigMatter(**config)
+
+    assert config_matter is not None
+    assert config_matter.dut_config.pairing_mode == pairing_mode
+    assert config_matter.dut_config.discriminator is None
+    assert config_matter.dut_config.setup_code is None
+
+
+@pytest.mark.parametrize("pairing_mode", ["nfc-thread", "nfc-wifi"])
+def test_create_config_matter_nfc_with_discriminator_fails(
+    pairing_mode: str,
+) -> None:
+    """Test that NFC pairing modes fail when discriminator is provided."""
+    config = {
+        "network": {
+            "fabric_id": "0",
+            "thread": {
+                "dataset": {
+                    "channel": "15",
+                    "panid": "0x1234",
+                    "extpanid": "1111111122222222",
+                    "networkkey": "00112233445566778899aabbccddeeff",
+                    "networkname": "DEMO",
+                },
+                "rcp_serial_path": "/dev/ttyACM0",
+                "rcp_baudrate": 115200,
+                "on_mesh_prefix": "fd11:22::/64",
+                "network_interface": "eth0",
+            },
+            "wifi": {"ssid": "testharness", "password": "wifi-password"},
+        },
+        "dut_config": {
+            "pairing_mode": pairing_mode,
+            "discriminator": "3840",
+            "chip_use_paa_certs": False,
+            "trace_log": True,
+        },
+        "test_parameters": None,
+    }
+
+    with pytest.raises(TestEnvironmentConfigError) as e:
+        TestEnvironmentConfigMatter(**config)
+
+    assert "discriminator" in str(e.value)
+    assert "must not be set" in str(e.value)
+
+
+@pytest.mark.parametrize("pairing_mode", ["nfc-thread", "nfc-wifi"])
+def test_create_config_matter_nfc_with_setup_code_fails(
+    pairing_mode: str,
+) -> None:
+    """Test that NFC pairing modes fail when setup_code is provided."""
+    config = {
+        "network": {
+            "fabric_id": "0",
+            "thread": {
+                "dataset": {
+                    "channel": "15",
+                    "panid": "0x1234",
+                    "extpanid": "1111111122222222",
+                    "networkkey": "00112233445566778899aabbccddeeff",
+                    "networkname": "DEMO",
+                },
+                "rcp_serial_path": "/dev/ttyACM0",
+                "rcp_baudrate": 115200,
+                "on_mesh_prefix": "fd11:22::/64",
+                "network_interface": "eth0",
+            },
+            "wifi": {"ssid": "testharness", "password": "wifi-password"},
+        },
+        "dut_config": {
+            "pairing_mode": pairing_mode,
+            "setup_code": "20202021",
+            "chip_use_paa_certs": False,
+            "trace_log": True,
+        },
+        "test_parameters": None,
+    }
+
+    with pytest.raises(TestEnvironmentConfigError) as e:
+        TestEnvironmentConfigMatter(**config)
+
+    assert "setup_code" in str(e.value)
+    assert "must not be set" in str(e.value)
 
 
 def test_create_config_matter_without_discriminator_fails() -> None:

--- a/test_collections/matter/sdk_tests/support/tests/matter/test_test_environment_config.py
+++ b/test_collections/matter/sdk_tests/support/tests/matter/test_test_environment_config.py
@@ -370,10 +370,10 @@ def test_create_config_matter_nfc_without_discriminator_and_setup_code_succeeds(
 
 
 @pytest.mark.parametrize("pairing_mode", ["nfc-thread", "nfc-wifi"])
-def test_create_config_matter_nfc_with_discriminator_fails(
+def test_create_config_matter_nfc_with_discriminator_succeeds(
     pairing_mode: str,
 ) -> None:
-    """Test that NFC pairing modes fail when discriminator is provided."""
+    """Test that NFC pairing modes accept discriminator (it is ignored at runtime)."""
     config = {
         "network": {
             "fabric_id": "0",
@@ -401,18 +401,15 @@ def test_create_config_matter_nfc_with_discriminator_fails(
         "test_parameters": None,
     }
 
-    with pytest.raises(TestEnvironmentConfigError) as e:
-        TestEnvironmentConfigMatter(**config)
-
-    assert "discriminator" in str(e.value)
-    assert "must not be set" in str(e.value)
+    config_matter = TestEnvironmentConfigMatter(**config)
+    assert config_matter.dut_config.discriminator == "3840"
 
 
 @pytest.mark.parametrize("pairing_mode", ["nfc-thread", "nfc-wifi"])
-def test_create_config_matter_nfc_with_setup_code_fails(
+def test_create_config_matter_nfc_with_setup_code_succeeds(
     pairing_mode: str,
 ) -> None:
-    """Test that NFC pairing modes fail when setup_code is provided."""
+    """Test that NFC pairing modes accept setup_code (it is ignored at runtime)."""
     config = {
         "network": {
             "fabric_id": "0",
@@ -440,11 +437,8 @@ def test_create_config_matter_nfc_with_setup_code_fails(
         "test_parameters": None,
     }
 
-    with pytest.raises(TestEnvironmentConfigError) as e:
-        TestEnvironmentConfigMatter(**config)
-
-    assert "setup_code" in str(e.value)
-    assert "must not be set" in str(e.value)
+    config_matter = TestEnvironmentConfigMatter(**config)
+    assert config_matter.dut_config.setup_code == "20202021"
 
 
 def test_create_config_matter_without_discriminator_fails() -> None:

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
@@ -21,6 +21,7 @@ from unittest import mock
 
 import pytest
 
+from app.constants.shared_constants import DutPairingModeEnum
 from app.models.project import Project
 from app.models.test_case_execution import TestCaseExecution
 from app.models.test_run_execution import TestRunExecution
@@ -538,3 +539,222 @@ async def test_no_commissioning_python_test_case_does_not_prompt_commissioning_m
     ) as mock_prompt_commissioning:
         await test_case.setup()
         mock_prompt_commissioning.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Helpers for qr-code / NFC execute() tests
+# ---------------------------------------------------------------------------
+
+NFC_PROJECT_CONFIG = {
+    "network": {
+        "wifi": {"ssid": "test_ssid", "password": "test_password"},
+        "thread": {
+            "operational_dataset_hex": "0e080000000000010000000300001235",
+        },
+    },
+    "dut_config": {
+        "pairing_mode": DutPairingModeEnum.NFC_WIFI.value,
+        "chip_use_paa_certs": False,
+        "trace_log": True,
+    },
+    "test_parameters": {
+        "qr-code": "MT:Y.K90SO527JA0648G00",
+        "paa-trust-store-path": "/paa-root-certs",
+    },
+}
+
+ON_NETWORK_PROJECT_CONFIG = {
+    "network": {
+        "wifi": {"ssid": "test_ssid", "password": "test_password"},
+        "thread": {
+            "operational_dataset_hex": "0e080000000000010000000300001235",
+        },
+    },
+    "dut_config": {
+        "discriminator": "3840",
+        "setup_code": "20202021",
+        "pairing_mode": DutPairingModeEnum.ON_NETWORK.value,
+        "chip_use_paa_certs": False,
+        "trace_log": True,
+    },
+    "test_parameters": {
+        "qr-code": "MT:Y.K90SO527JA0648G00",
+        "paa-trust-store-path": "/paa-root-certs",
+    },
+}
+
+
+def _make_test_case_with_config(
+    project_config: dict,
+    python_test_type: PythonTestType,
+) -> PythonTestCase:
+    project = Project(name="test_project")
+    project.config = project_config
+
+    test_run_execution = TestRunExecution()
+    test_run_execution.project = project
+
+    test_suite_execution = TestSuiteExecution()
+    test_suite_execution.test_run_execution = test_run_execution
+
+    test_case_execution = TestCaseExecution()
+    test_case_execution.test_suite_execution = test_suite_execution
+
+    test = python_test_instance(
+        name="TC-Test-1.1",
+        path=Path("sdk/TC_Test_1_1.py"),
+        class_name="TC_Test_1_1",
+        python_test_type=python_test_type,
+    )
+
+    case_class = (
+        NoCommissioningPythonTestCase
+        if python_test_type == PythonTestType.NO_COMMISSIONING
+        else PythonTestCase
+    )
+
+    return case_class.class_factory(  # type: ignore
+        test=test,
+        python_test_version="version",
+        mandatory=False,
+    )(test_case_execution)
+
+
+@pytest.mark.asyncio
+async def test_execute_commissioning_nfc_drops_qr_code() -> None:
+    """COMMISSIONING test with NFC pairing: qr-code must be stripped from
+    test_parameters before being forwarded to generate_command_arguments."""
+    test_case = _make_test_case_with_config(
+        NFC_PROJECT_CONFIG, PythonTestType.COMMISSIONING
+    )
+
+    captured_configs: list = []
+
+    async def _capture_config(config, omit_commissioning_method=False):
+        captured_configs.append(config)
+        return []
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".generate_command_arguments",
+        side_effect=_capture_config,
+    ), mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".SDKContainer"
+    ) as mock_sdk_container_cls, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".BaseManager"
+    ):
+        mock_sdk_container = mock.MagicMock()
+        mock_sdk_container_cls.return_value = mock_sdk_container
+        mock_exec_result = mock.MagicMock()
+        mock_exec_result.socket = mock.MagicMock()
+        mock_sdk_container.send_command.return_value = mock_exec_result
+        mock_sdk_container.pics_file_created = False
+
+        mock_hooks = mock.MagicMock()
+        mock_hooks.update_test.return_value = None
+        mock_hooks.is_finished.return_value = True
+
+        with mock.patch(
+            "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+            ".SDKPythonTestRunnerHooks",
+        ):
+            try:
+                await test_case.execute()
+            except Exception:
+                pass
+
+    assert len(captured_configs) == 1
+    assert "qr-code" not in (captured_configs[0].test_parameters or {})
+    assert "paa-trust-store-path" in (captured_configs[0].test_parameters or {})
+
+
+@pytest.mark.asyncio
+async def test_execute_no_commissioning_nfc_preserves_qr_code() -> None:
+    """NO_COMMISSIONING test (e.g. TC_DD_1_5) with NFC pairing: qr-code must be
+    preserved in test_parameters because the test uses it as a direct input."""
+    test_case = _make_test_case_with_config(
+        NFC_PROJECT_CONFIG, PythonTestType.NO_COMMISSIONING
+    )
+
+    captured_configs: list = []
+
+    async def _capture_config(config, omit_commissioning_method=False):
+        captured_configs.append(config)
+        return []
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".generate_command_arguments",
+        side_effect=_capture_config,
+    ), mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".SDKContainer"
+    ) as mock_sdk_container_cls, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".BaseManager"
+    ):
+        mock_sdk_container = mock.MagicMock()
+        mock_sdk_container_cls.return_value = mock_sdk_container
+        mock_exec_result = mock.MagicMock()
+        mock_exec_result.socket = mock.MagicMock()
+        mock_sdk_container.send_command.return_value = mock_exec_result
+        mock_sdk_container.pics_file_created = False
+
+        with mock.patch(
+            "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+            ".SDKPythonTestRunnerHooks",
+        ):
+            try:
+                await test_case.execute()
+            except Exception:
+                pass
+
+    assert len(captured_configs) == 1
+    assert "qr-code" in (captured_configs[0].test_parameters or {})
+
+
+@pytest.mark.asyncio
+async def test_execute_commissioning_non_nfc_preserves_qr_code() -> None:
+    """COMMISSIONING test with non-NFC pairing: qr-code must not be dropped
+    since it is not an NFC commissioning flow."""
+    test_case = _make_test_case_with_config(
+        ON_NETWORK_PROJECT_CONFIG, PythonTestType.COMMISSIONING
+    )
+
+    captured_configs: list = []
+
+    async def _capture_config(config, omit_commissioning_method=False):
+        captured_configs.append(config)
+        return []
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".generate_command_arguments",
+        side_effect=_capture_config,
+    ), mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".SDKContainer"
+    ) as mock_sdk_container_cls, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".BaseManager"
+    ):
+        mock_sdk_container = mock.MagicMock()
+        mock_sdk_container_cls.return_value = mock_sdk_container
+        mock_exec_result = mock.MagicMock()
+        mock_exec_result.socket = mock.MagicMock()
+        mock_sdk_container.send_command.return_value = mock_exec_result
+        mock_sdk_container.pics_file_created = False
+
+        with mock.patch(
+            "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+            ".SDKPythonTestRunnerHooks",
+        ):
+            try:
+                await test_case.execute()
+            except Exception:
+                pass
+
+    assert len(captured_configs) == 1
+    assert "qr-code" in (captured_configs[0].test_parameters or {})

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
@@ -16,7 +16,7 @@
 # flake8: noqa
 # Ignore flake8 check for this file
 from pathlib import Path
-from typing import Any, Optional, Type
+from typing import Any, List, Optional, Type
 from unittest import mock
 
 import pytest
@@ -628,9 +628,11 @@ async def test_execute_commissioning_nfc_drops_qr_code() -> None:
         NFC_PROJECT_CONFIG, PythonTestType.COMMISSIONING
     )
 
-    captured_configs: list = []
+    captured_configs: List[Any] = []
 
-    async def _capture_config(config, omit_commissioning_method=False):
+    async def _capture_config(
+        config: Any, omit_commissioning_method: bool = False
+    ) -> List[str]:
         captured_configs.append(config)
         return []
 
@@ -678,9 +680,11 @@ async def test_execute_no_commissioning_nfc_preserves_qr_code() -> None:
         NFC_PROJECT_CONFIG, PythonTestType.NO_COMMISSIONING
     )
 
-    captured_configs: list = []
+    captured_configs: List[Any] = []
 
-    async def _capture_config(config, omit_commissioning_method=False):
+    async def _capture_config(
+        config: Any, omit_commissioning_method: bool = False
+    ) -> List[str]:
         captured_configs.append(config)
         return []
 
@@ -723,9 +727,11 @@ async def test_execute_commissioning_non_nfc_preserves_qr_code() -> None:
         ON_NETWORK_PROJECT_CONFIG, PythonTestType.COMMISSIONING
     )
 
-    captured_configs: list = []
+    captured_configs: List[Any] = []
 
-    async def _capture_config(config, omit_commissioning_method=False):
+    async def _capture_config(
+        config: Any, omit_commissioning_method: bool = False
+    ) -> List[str]:
         captured_configs.append(config)
         return []
 

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -470,7 +470,8 @@ async def test_nfc_logs_warning_when_discriminator_or_setup_code_set(
 async def test_nfc_no_warning_when_discriminator_and_setup_code_not_set(
     pairing_mode: DutPairingModeEnum,
 ) -> None:
-    """No warning is logged for NFC modes when discriminator and setup_code are absent."""
+    """No warning is logged for NFC modes when discriminator and setup_code are
+    absent."""
     with mock.patch.object(test_engine_logger, "warning") as mock_warn:
         await _nfc_arguments(pairing_mode)
         mock_warn.assert_not_called()

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -455,14 +455,25 @@ async def test_nfc_without_discriminator_and_setup_code_not_passed_to_sdk(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("pairing_mode", NFC_PAIRING_MODES_PARAMS)
-async def test_nfc_always_logs_warning(
+async def test_nfc_logs_warning_when_discriminator_or_setup_code_set(
     pairing_mode: DutPairingModeEnum,
 ) -> None:
-    """Warning is always logged for NFC modes regardless of discriminator/setup_code."""
+    """Warning is logged for NFC modes when discriminator or setup_code are provided."""
     with mock.patch.object(test_engine_logger, "warning") as mock_warn:
-        await _nfc_arguments(pairing_mode)
+        await _nfc_arguments(pairing_mode, discriminator="3840", setup_code="20202021")
         mock_warn.assert_called_once()
         assert "ignored" in mock_warn.call_args[0][0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pairing_mode", NFC_PAIRING_MODES_PARAMS)
+async def test_nfc_no_warning_when_discriminator_and_setup_code_not_set(
+    pairing_mode: DutPairingModeEnum,
+) -> None:
+    """No warning is logged for NFC modes when discriminator and setup_code are absent."""
+    with mock.patch.object(test_engine_logger, "warning") as mock_warn:
+        await _nfc_arguments(pairing_mode)
+        mock_warn.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -165,8 +165,6 @@ async def test_generate_command_arguments_nfc_wifi_pairing_mode() -> None:
     }
 
     mock_dut_config = DutConfig(
-        discriminator="147",
-        setup_code="357",
         pairing_mode=DutPairingModeEnum.NFC_WIFI,
         chip_timeout=None,
     )
@@ -294,9 +292,7 @@ async def test_generate_command_arguments_nfc_thread() -> None:
     }
 
     mock_dut_config = DutConfig(
-        setup_code="8765",
         pairing_mode=DutPairingModeEnum.NFC_THREAD,
-        discriminator="456",
         chip_timeout=None,
     )
 
@@ -329,8 +325,8 @@ async def test_generate_command_arguments_nfc_thread() -> None:
             "--paa-trust-store-path /paa-root-certs",
             "--storage_path /root/admin_storage.json",
         ] == arguments
-        assert mock_dut_config.discriminator not in arguments
-        assert mock_dut_config.setup_code not in arguments
+        assert "--discriminator" not in " ".join(arguments)
+        assert "--passcode" not in " ".join(arguments)
 
 
 @pytest.mark.asyncio
@@ -344,9 +340,7 @@ async def test_generate_command_arguments_nfc_thread_for_external_network() -> N
     }
 
     mock_dut_config = DutConfig(
-        setup_code="8765",
         pairing_mode=DutPairingModeEnum.NFC_THREAD,
-        discriminator="783",
         chip_timeout=None,
     )
 
@@ -375,8 +369,99 @@ async def test_generate_command_arguments_nfc_thread_for_external_network() -> N
         "--paa-trust-store-path /paa-root-certs",
         "--storage_path /root/admin_storage.json",
     ] == arguments
-    assert mock_dut_config.discriminator not in arguments
-    assert mock_dut_config.setup_code not in arguments
+    assert "--discriminator" not in " ".join(arguments)
+    assert "--passcode" not in " ".join(arguments)
+
+
+NFC_PAIRING_MODES_PARAMS = [
+    pytest.param(DutPairingModeEnum.NFC_THREAD, id="nfc-thread"),
+    pytest.param(DutPairingModeEnum.NFC_WIFI, id="nfc-wifi"),
+]
+
+MOCK_THREAD_DATASET = (
+    "0e08000000000001000035060004001fffe00708fd47156040435d2b041069c13cc038488"
+    "0328b9d2d7a6ee891150c0402a0f7f8000300000f01021234020811111111222222220510"
+    "00112233445566778899aabbccddeeff030444454d4f"
+)
+
+THREAD_DATASET_PATCH = mock.patch(
+    "test_collections.matter.sdk_tests.support.python_testing.models.utils"
+    ".__thread_dataset_hex",
+    return_value=MOCK_THREAD_DATASET,
+)
+
+
+async def _nfc_arguments(pairing_mode: DutPairingModeEnum, **dut_kwargs) -> list:
+    """Helper: build command arguments for a given NFC pairing mode and DutConfig kwargs."""
+    mock_config = default_environment_config.copy(deep=True)  # type: ignore
+    mock_config.test_parameters = None
+    mock_config.dut_config = DutConfig(
+        pairing_mode=pairing_mode, chip_timeout=None, **dut_kwargs
+    )
+    with THREAD_DATASET_PATCH:
+        return await generate_command_arguments(
+            config=mock_config, omit_commissioning_method=False
+        )
+
+
+def _assert_no_discriminator_or_passcode(arguments: list) -> None:
+    joined = " ".join(arguments)
+    assert "--discriminator" not in joined
+    assert "--passcode" not in joined
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pairing_mode", NFC_PAIRING_MODES_PARAMS)
+async def test_nfc_with_discriminator_and_setup_code_not_passed_to_sdk(
+    pairing_mode: DutPairingModeEnum,
+) -> None:
+    """Scenario 1: both discriminator and setup_code set — neither passed to SDK."""
+    arguments = await _nfc_arguments(
+        pairing_mode, discriminator="3840", setup_code="20202021"
+    )
+    _assert_no_discriminator_or_passcode(arguments)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pairing_mode", NFC_PAIRING_MODES_PARAMS)
+async def test_nfc_with_only_discriminator_not_passed_to_sdk(
+    pairing_mode: DutPairingModeEnum,
+) -> None:
+    """Scenario 2: only discriminator set — not passed to SDK."""
+    arguments = await _nfc_arguments(pairing_mode, discriminator="3840")
+    _assert_no_discriminator_or_passcode(arguments)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pairing_mode", NFC_PAIRING_MODES_PARAMS)
+async def test_nfc_with_only_setup_code_not_passed_to_sdk(
+    pairing_mode: DutPairingModeEnum,
+) -> None:
+    """Scenario 3: only setup_code set — not passed to SDK."""
+    arguments = await _nfc_arguments(pairing_mode, setup_code="20202021")
+    _assert_no_discriminator_or_passcode(arguments)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pairing_mode", NFC_PAIRING_MODES_PARAMS)
+async def test_nfc_without_discriminator_and_setup_code_not_passed_to_sdk(
+    pairing_mode: DutPairingModeEnum,
+) -> None:
+    """Scenario 4: neither discriminator nor setup_code set — not passed to SDK."""
+    arguments = await _nfc_arguments(pairing_mode)
+    _assert_no_discriminator_or_passcode(arguments)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pairing_mode", NFC_PAIRING_MODES_PARAMS)
+async def test_nfc_always_logs_warning(
+    pairing_mode: DutPairingModeEnum,
+) -> None:
+    """Warning is always logged for NFC modes regardless of discriminator/setup_code."""
+    with mock.patch.object(test_engine_logger, "warning") as mock_warn:
+        await _nfc_arguments(pairing_mode)
+        mock_warn.assert_called_once()
+        assert "ignored" in mock_warn.call_args[0][0]
 
 
 @pytest.mark.asyncio

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -391,8 +391,9 @@ THREAD_DATASET_PATCH = mock.patch(
 )
 
 
-async def _nfc_arguments(pairing_mode: DutPairingModeEnum, **dut_kwargs) -> list:
-    """Helper: build command arguments for a given NFC pairing mode and DutConfig kwargs."""
+async def _nfc_arguments(pairing_mode: DutPairingModeEnum, **dut_kwargs: str) -> list:
+    """Helper: build command arguments for a given NFC pairing mode and DutConfig
+    kwargs."""
     mock_config = default_environment_config.copy(deep=True)  # type: ignore
     mock_config.test_parameters = None
     mock_config.dut_config = DutConfig(

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
@@ -436,6 +436,8 @@ async def test_pairing_nfc_wifi_command_params() -> None:
     chip_server: ChipServer = ChipServer()
     ssid = "WifiIsGood"
     password = "WifiIsGoodAndSecret"
+    setup_code = "20202021"
+    discriminator = "3840"
 
     with mock.patch.object(
         target=runner,
@@ -445,9 +447,11 @@ async def test_pairing_nfc_wifi_command_params() -> None:
         result = await runner.pairing_nfc_wifi(
             ssid=ssid,
             password=password,
+            setup_code=setup_code,
+            discriminator=discriminator,
         )
 
-    expected_params = f"{hex(chip_server.node_id)} {ssid} {password}"
+    expected_params = f"{hex(chip_server.node_id)} {ssid} {password} {setup_code} {discriminator}"
     expected_command = f"pairing nfc-wifi {expected_params}"
 
     assert result is True
@@ -506,6 +510,8 @@ async def test_pairing_nfc_thread_command_params() -> None:
     runner: MatterYAMLRunner = MatterYAMLRunner()
     chip_server: ChipServer = ChipServer()
     hex_dataset = "c0ffee"
+    setup_code = "0123456"
+    discriminator = "1234"
 
     with mock.patch.object(
         target=runner,
@@ -514,9 +520,13 @@ async def test_pairing_nfc_thread_command_params() -> None:
     ) as mock_send_websocket_command:
         result = await runner.pairing_nfc_thread(
             hex_dataset=hex_dataset,
+            setup_code=setup_code,
+            discriminator=discriminator,
         )
 
-    expected_params = f"{hex(chip_server.node_id)} hex:{hex_dataset}"
+    expected_params = (
+        f"{hex(chip_server.node_id)} hex:{hex_dataset} {setup_code} {discriminator}"
+    )
     expected_command = f"pairing nfc-thread {expected_params}"
 
     assert result is True

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
@@ -382,7 +382,6 @@ async def test_pairing_on_network_command_params() -> None:
     "pairing_fn_name, pairing_cmd",
     [
         ("pairing_ble_wifi", "ble-wifi"),
-        ("pairing_nfc_wifi", "nfc-wifi"),
     ],
 )
 async def test_pairing_wifi_command_params(
@@ -417,6 +416,39 @@ async def test_pairing_wifi_command_params(
         f"{hex(chip_server.node_id)} {ssid} {password} {setup_code} {discriminator}"
     )
     expected_command = f"pairing {pairing_cmd} {expected_params}"
+
+    assert result is True
+    mock_send_websocket_command.assert_awaited_once_with(expected_command)
+
+    # clean up:
+    matter_settings.CHIP_TOOL_TRACE = original_trace_setting_value
+    chip_server._ChipServer__node_id = None
+
+
+@pytest.mark.asyncio
+async def test_pairing_nfc_wifi_command_params() -> None:
+    original_trace_setting_value = matter_settings.CHIP_TOOL_TRACE
+    if original_trace_setting_value is True:
+        matter_settings.CHIP_TOOL_TRACE = False
+
+    # Attributes
+    runner: MatterYAMLRunner = MatterYAMLRunner()
+    chip_server: ChipServer = ChipServer()
+    ssid = "WifiIsGood"
+    password = "WifiIsGoodAndSecret"
+
+    with mock.patch.object(
+        target=runner,
+        attribute="send_websocket_command",
+        return_value='{"results": []}',
+    ) as mock_send_websocket_command:
+        result = await runner.pairing_nfc_wifi(
+            ssid=ssid,
+            password=password,
+        )
+
+    expected_params = f"{hex(chip_server.node_id)} {ssid} {password}"
+    expected_command = f"pairing nfc-wifi {expected_params}"
 
     assert result is True
     mock_send_websocket_command.assert_awaited_once_with(expected_command)
@@ -474,24 +506,17 @@ async def test_pairing_nfc_thread_command_params() -> None:
     runner: MatterYAMLRunner = MatterYAMLRunner()
     chip_server: ChipServer = ChipServer()
     hex_dataset = "c0ffee"
-    setup_code = "0123456"
-    discriminator = "1234"
 
     with mock.patch.object(
         target=runner,
         attribute="send_websocket_command",
         return_value='{"results": []}',
-        # '{  "results": [{ "error": "FAILURE" }]
     ) as mock_send_websocket_command:
         result = await runner.pairing_nfc_thread(
             hex_dataset=hex_dataset,
-            setup_code=setup_code,
-            discriminator=discriminator,
         )
 
-    expected_params = (
-        f"{hex(chip_server.node_id)} hex:{hex_dataset} {setup_code} {discriminator}"
-    )
+    expected_params = f"{hex(chip_server.node_id)} hex:{hex_dataset}"
     expected_command = f"pairing nfc-thread {expected_params}"
 
     assert result is True

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
@@ -451,7 +451,9 @@ async def test_pairing_nfc_wifi_command_params() -> None:
             discriminator=discriminator,
         )
 
-    expected_params = f"{hex(chip_server.node_id)} {ssid} {password} {setup_code} {discriminator}"
+    expected_params = (
+        f"{hex(chip_server.node_id)} {ssid} {password} {setup_code} {discriminator}"
+    )
     expected_command = f"pairing nfc-wifi {expected_params}"
 
     assert result is True

--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -292,16 +292,12 @@ class MatterYAMLRunner(metaclass=Singleton):
         self,
         ssid: str,
         password: str,
-        setup_code: str,
-        discriminator: str,
     ) -> bool:
         return await self.pairing(
             PAIRING_MODE_NFC_WIFI,
             hex(self.chip_server.node_id),
             ssid,
             password,
-            setup_code,
-            discriminator,
         )
 
     async def pairing_wifipaf_wifi(
@@ -337,15 +333,11 @@ class MatterYAMLRunner(metaclass=Singleton):
     async def pairing_nfc_thread(
         self,
         hex_dataset: str,
-        setup_code: str,
-        discriminator: str,
     ) -> bool:
         return await self.pairing(
             PAIRING_MODE_NFC_THREAD,
             hex(self.chip_server.node_id),
             f"hex:{hex_dataset}",
-            setup_code,
-            discriminator,
         )
 
     async def pairing_thread(

--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -292,12 +292,16 @@ class MatterYAMLRunner(metaclass=Singleton):
         self,
         ssid: str,
         password: str,
+        setup_code: str,
+        discriminator: str,
     ) -> bool:
         return await self.pairing(
             PAIRING_MODE_NFC_WIFI,
             hex(self.chip_server.node_id),
             ssid,
             password,
+            setup_code,
+            discriminator,
         )
 
     async def pairing_wifipaf_wifi(
@@ -333,11 +337,15 @@ class MatterYAMLRunner(metaclass=Singleton):
     async def pairing_nfc_thread(
         self,
         hex_dataset: str,
+        setup_code: str,
+        discriminator: str,
     ) -> bool:
         return await self.pairing(
             PAIRING_MODE_NFC_THREAD,
             hex(self.chip_server.node_id),
             f"hex:{hex_dataset}",
+            setup_code,
+            discriminator,
         )
 
     async def pairing_thread(

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -148,8 +148,8 @@ class ChipSuite(TestSuite, UserPromptSupport):
 
     async def __pair_with_dut_onnetwork(self) -> bool:
         return await self.runner.pairing_on_network(
-            setup_code=self.config_matter.dut_config.setup_code,
-            discriminator=self.config_matter.dut_config.discriminator,
+            setup_code=self.config_matter.dut_config.setup_code or "",
+            discriminator=self.config_matter.dut_config.discriminator or "",
         )
 
     async def __pair_wifi_dut_wifi_modes(self, mode: str) -> bool:
@@ -168,10 +168,14 @@ class ChipSuite(TestSuite, UserPromptSupport):
         if self.config_matter.network.wifi is None:
             raise DUTCommissioningError("Tool config is missing wifi config.")
 
-        logger.warning(
-            "pairing_mode is nfc-wifi: discriminator and setup_code from"
-            " project config are ignored. Onboarding data is read from the NFC tag."
-        )
+        if (
+            self.config_matter.dut_config.discriminator is not None
+            or self.config_matter.dut_config.setup_code is not None
+        ):
+            logger.warning(
+                "pairing_mode is nfc-wifi: discriminator and setup_code from"
+                " project config are ignored. Onboarding data is read from the NFC tag."
+            )
         return await self.runner.pairing_nfc_wifi(
             ssid=self.config_matter.network.wifi.ssid,
             password=self.config_matter.network.wifi.password,
@@ -193,8 +197,8 @@ class ChipSuite(TestSuite, UserPromptSupport):
 
         return await self.runner.pairing_ble_thread(
             hex_dataset=hex_dataset,
-            setup_code=self.config_matter.dut_config.setup_code,
-            discriminator=self.config_matter.dut_config.discriminator,
+            setup_code=self.config_matter.dut_config.setup_code or "",
+            discriminator=self.config_matter.dut_config.discriminator or "",
         )
 
     async def __pair_with_dut_nfc_thread(self) -> bool:
@@ -211,10 +215,14 @@ class ChipSuite(TestSuite, UserPromptSupport):
         else:
             raise DUTCommissioningError("Invalid thread configuration")
 
-        logger.warning(
-            "pairing_mode is nfc-thread: discriminator and setup_code from"
-            " project config are ignored. Onboarding data is read from the NFC tag."
-        )
+        if (
+            self.config_matter.dut_config.discriminator is not None
+            or self.config_matter.dut_config.setup_code is not None
+        ):
+            logger.warning(
+                "pairing_mode is nfc-thread: discriminator and setup_code from"
+                " project config are ignored. Onboarding data is read from the NFC tag."
+            )
         return await self.runner.pairing_nfc_thread(
             hex_dataset=hex_dataset,
         )
@@ -240,8 +248,8 @@ class ChipSuite(TestSuite, UserPromptSupport):
 
         # Generate manual pairing code from discriminator and setup code
         payload = self.runner.chip_server.generate_manual_pairing_code_with_chip_tool(
-            discriminator=self.config_matter.dut_config.discriminator,
-            setup_pin_code=self.config_matter.dut_config.setup_code,
+            discriminator=self.config_matter.dut_config.discriminator or "",
+            setup_pin_code=self.config_matter.dut_config.setup_code or "",
         )
 
         return await self.runner.pairing_thread(

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -121,7 +121,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
         elif self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.BLE_WIFI:
             pair_result = await self.__pair_wifi_dut_wifi_modes("ble")
         elif self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.NFC_WIFI:
-            pair_result = await self.__pair_wifi_dut_wifi_modes("nfc")
+            pair_result = await self.__pair_with_dut_nfc_wifi()
         elif (
             self.config_matter.dut_config.pairing_mode is DutPairingModeEnum.BLE_THREAD
         ):
@@ -164,6 +164,19 @@ class ChipSuite(TestSuite, UserPromptSupport):
             discriminator=self.config_matter.dut_config.discriminator,
         )
 
+    async def __pair_with_dut_nfc_wifi(self) -> bool:
+        if self.config_matter.network.wifi is None:
+            raise DUTCommissioningError("Tool config is missing wifi config.")
+
+        logger.warning(
+            "pairing_mode is nfc-wifi: discriminator and setup_code from"
+            " project config are ignored. Onboarding data is read from the NFC tag."
+        )
+        return await self.runner.pairing_nfc_wifi(
+            ssid=self.config_matter.network.wifi.ssid,
+            password=self.config_matter.network.wifi.password,
+        )
+
     async def __pair_with_dut_ble_thread(self) -> bool:
         if self.config_matter.network.thread is None:
             raise DUTCommissioningError("Tool config is missing thread config.")
@@ -198,10 +211,12 @@ class ChipSuite(TestSuite, UserPromptSupport):
         else:
             raise DUTCommissioningError("Invalid thread configuration")
 
+        logger.warning(
+            "pairing_mode is nfc-thread: discriminator and setup_code from"
+            " project config are ignored. Onboarding data is read from the NFC tag."
+        )
         return await self.runner.pairing_nfc_thread(
             hex_dataset=hex_dataset,
-            setup_code=self.config_matter.dut_config.setup_code,
-            discriminator=self.config_matter.dut_config.discriminator,
         )
 
     async def __pair_with_dut_thread(self) -> bool:

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -168,17 +168,11 @@ class ChipSuite(TestSuite, UserPromptSupport):
         if self.config_matter.network.wifi is None:
             raise DUTCommissioningError("Tool config is missing wifi config.")
 
-        if (
-            self.config_matter.dut_config.discriminator is not None
-            or self.config_matter.dut_config.setup_code is not None
-        ):
-            logger.warning(
-                "pairing_mode is nfc-wifi: discriminator and setup_code from"
-                " project config are ignored. Onboarding data is read from the NFC tag."
-            )
         return await self.runner.pairing_nfc_wifi(
             ssid=self.config_matter.network.wifi.ssid,
             password=self.config_matter.network.wifi.password,
+            setup_code=self.config_matter.dut_config.setup_code or "",
+            discriminator=self.config_matter.dut_config.discriminator or "",
         )
 
     async def __pair_with_dut_ble_thread(self) -> bool:
@@ -215,16 +209,10 @@ class ChipSuite(TestSuite, UserPromptSupport):
         else:
             raise DUTCommissioningError("Invalid thread configuration")
 
-        if (
-            self.config_matter.dut_config.discriminator is not None
-            or self.config_matter.dut_config.setup_code is not None
-        ):
-            logger.warning(
-                "pairing_mode is nfc-thread: discriminator and setup_code from"
-                " project config are ignored. Onboarding data is read from the NFC tag."
-            )
         return await self.runner.pairing_nfc_thread(
             hex_dataset=hex_dataset,
+            setup_code=self.config_matter.dut_config.setup_code or "",
+            discriminator=self.config_matter.dut_config.discriminator or "",
         )
 
     async def __pair_with_dut_thread(self) -> bool:

--- a/test_collections/matter/test_environment_config.py
+++ b/test_collections/matter/test_environment_config.py
@@ -121,7 +121,7 @@ class TestEnvironmentConfigMatter(TestEnvironmentConfig):
                     if not dut_config.get(field):
                         raise TestEnvironmentConfigMatterError(
                             f"The field {field} is required for dut_config "
-                            "configuration when pairing_mode is {pairing_mode}"
+                            f"configuration when pairing_mode is {pairing_mode}"
                         )
 
             # Validate THREAD_MESHCOP mode requires ba_host and ba_port

--- a/test_collections/matter/test_environment_config.py
+++ b/test_collections/matter/test_environment_config.py
@@ -120,8 +120,8 @@ class TestEnvironmentConfigMatter(TestEnvironmentConfig):
                 for field in ("discriminator", "setup_code"):
                     if not dut_config.get(field):
                         raise TestEnvironmentConfigMatterError(
-                            f"The field {field} is required for dut_config configuration"
-                            f" when pairing_mode is {pairing_mode}"
+                            f"The field {field} is required for dut_config "
+                            "configuration when pairing_mode is {pairing_mode}"
                         )
 
             # Validate THREAD_MESHCOP mode requires ba_host and ba_port

--- a/test_collections/matter/test_environment_config.py
+++ b/test_collections/matter/test_environment_config.py
@@ -17,7 +17,7 @@ from typing import Optional, Union
 
 from pydantic import BaseModel
 
-from app.constants.shared_constants import DutPairingModeEnum
+from app.constants.shared_constants import NFC_PAIRING_MODES, DutPairingModeEnum
 from app.schemas.test_environment_config import TestEnvironmentConfig, ThreadAutoConfig
 
 
@@ -47,10 +47,10 @@ class EnhancedSetupFlowConfig(BaseModel):
 
 
 class DutConfig(BaseModel):
-    discriminator: str
-    setup_code: str
+    discriminator: Optional[str] = None
+    setup_code: Optional[str] = None
     pairing_mode: DutPairingModeEnum
-    chip_timeout: Optional[str]
+    chip_timeout: Optional[str] = None
     chip_use_paa_certs: bool = False
     trace_log: bool = True
     enhanced_setup_flow: Optional[EnhancedSetupFlowConfig] = None
@@ -97,20 +97,40 @@ class TestEnvironmentConfigMatter(TestEnvironmentConfig):
                         f" {valid_properties}"
                     )
 
-            # All DutConfig fields but chip_timeout and enhanced_setup_flow are
-            # mandatory
-            mandatory_fields = valid_properties.copy()
-            mandatory_fields.remove("chip_timeout")
-            mandatory_fields.remove("enhanced_setup_flow")
+            # pairing_mode is always mandatory
+            if "pairing_mode" not in dut_config:
+                raise TestEnvironmentConfigMatterError(
+                    "The field pairing_mode is required for dut_config configuration"
+                )
 
-            for field in mandatory_fields:
+            # chip_use_paa_certs and trace_log are always mandatory
+            for field in ("chip_use_paa_certs", "trace_log"):
                 if field not in dut_config:
                     raise TestEnvironmentConfigMatterError(
                         f"The field {field} is required for dut_config configuration"
                     )
 
-            # Validate THREAD_MESHCOP mode requires ba_host and ba_port
             pairing_mode = dut_config.get("pairing_mode")
+            is_nfc_mode = pairing_mode in NFC_PAIRING_MODES
+
+            # discriminator and setup_code are required for non-NFC modes
+            # and must be omitted for NFC modes (onboarding data comes from the tag)
+            if is_nfc_mode:
+                for field in ("discriminator", "setup_code"):
+                    if dut_config.get(field) is not None:
+                        raise TestEnvironmentConfigMatterError(
+                            f"The field {field} must not be set when pairing_mode is"
+                            f" {pairing_mode}. Onboarding data is read from the NFC tag."
+                        )
+            else:
+                for field in ("discriminator", "setup_code"):
+                    if not dut_config.get(field):
+                        raise TestEnvironmentConfigMatterError(
+                            f"The field {field} is required for dut_config configuration"
+                            f" when pairing_mode is {pairing_mode}"
+                        )
+
+            # Validate THREAD_MESHCOP mode requires ba_host and ba_port
             if pairing_mode == DutPairingModeEnum.THREAD_MESHCOP:
                 thread_config = network.get("thread") if network else None
                 if not thread_config:

--- a/test_collections/matter/test_environment_config.py
+++ b/test_collections/matter/test_environment_config.py
@@ -113,16 +113,10 @@ class TestEnvironmentConfigMatter(TestEnvironmentConfig):
             pairing_mode = dut_config.get("pairing_mode")
             is_nfc_mode = pairing_mode in NFC_PAIRING_MODES
 
-            # discriminator and setup_code are required for non-NFC modes
-            # and must be omitted for NFC modes (onboarding data comes from the tag)
-            if is_nfc_mode:
-                for field in ("discriminator", "setup_code"):
-                    if dut_config.get(field) is not None:
-                        raise TestEnvironmentConfigMatterError(
-                            f"The field {field} must not be set when pairing_mode is"
-                            f" {pairing_mode}. Onboarding data is read from the NFC tag."
-                        )
-            else:
+            # discriminator and setup_code are required for non-NFC modes.
+            # For NFC modes they are optional and ignored if present —
+            # onboarding data is read directly from the NFC tag.
+            if not is_nfc_mode:
                 for field in ("discriminator", "setup_code"):
                     if not dut_config.get(field):
                         raise TestEnvironmentConfigMatterError(


### PR DESCRIPTION
### What changed
  Fix project creation and command generation for NFC pairing modes (nfc-thread, nfc-wifi). Users can now create a project config without setup_code/discriminator when using NFC pairing, and can also reuse an existing non-NFC config by simply changing the pairing_mode —  those fields will be accepted but ignored.   
Ignore qr-code test-parameter when execution tests from Python Testing Suite - Auto commissioning suite.
  
####  Changes                                                                                                                                 
   
  DutConfig model (test_environment_config.py)                                                                                            
  - discriminator and setup_code changed from required str to Optional[str] = None                                                        
  - chip_timeout default set to None explicitly                                                                                           
  - validate_model updated: discriminator/setup_code required only for non-NFC modes; NFC modes accept them but ignore them NFC_PAIRING_MODES constant (shared_constants.py)                                                                                        
  - Moved from python_testing/models/utils.py to shared_constants.py alongside DutPairingModeEnum — single source of truth, eliminates  circular import                                                                                                                         
                                                                                                                                          
  Command generation (python_testing/models/utils.py, performance_tests/models/utils.py)                                                  
  - --discriminator and --passcode are never passed to the SDK container when pairing mode is NFC                                         
  - A warning is always logged for NFC modes indicating those fields are ignored                                                          
                                                                                                                                          
  YAML runner (matter_yaml_runner.py, chip_suite.py)                                                                                      
  - pairing_nfc_thread and pairing_nfc_wifi signatures no longer accept setup_code/discriminator                                          
  - NFC_WIFI dispatch separated into dedicated __pair_with_dut_nfc_wifi method                                                            
  - Warning logged in both NFC pairing methods before commissioning                                                                       
                                                          
Test Case (test_case.py)                                                                                
- Adds validation for execution for     tests from Python Testing Suite - Auto commissioning suite and ignore qr-code test-parameter if informed.
                                                                      
#### Motivation                                                                                                                              
                                                                                                                                          
  Fixes #977. Previously, project creation failed if setup_code or discriminator were omitted when pairing_mode was nfc-thread/nfc-wifi.  
  This forced users to maintain separate configs for NFC and non-NFC modes. The root cause was DutConfig treating those fields as unconditionally required, and the YAML runner incorrectly forwarding them to chip-tool for NFC commissioning (which reads onboarding  data directly from the NFC tag).                          

#### Impact                                                                                                                                  
   
  - Breaking change: pairing_nfc_thread(hex_dataset, setup_code, discriminator) and pairing_nfc_wifi(ssid, password, setup_code, discriminator) signatures in MatterYAMLRunner have removed setup_code and discriminator parameters. Any direct callers outside TH must be updated.                                                                                                                             
  - Existing non-NFC project configs are unaffected.        
  - NFC configs with discriminator/setup_code still present will work — those fields are silently ignored with a warning in the TH logs.
  
### Related Issue
https://github.com/project-chip/certification-tool/issues/977

### Testing
- Unit tests added and all test are passing
  - test_test_environment_config.py: added parametrized tests for NFC with/without discriminator/setup_code                               
  - test_utils.py: 4 parametrized scenarios (both NFC modes) verifying --discriminator/--passcode are never in generated command; warning always logged                                                                                                                           
  - test_matter_yaml_runner.py: pairing_nfc_wifi and pairing_nfc_thread tests updated to reflect removed parameters   

- Development testing - Editing project config with several combination with setup_code / discrimination set/unset for nfc_* pairing mode. Verified the argument as not send to SDK and a log warning message was displayed