### PR TITLE
[Fixup] Annotate grouped log download for api generation

### DIFF
--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -495,7 +495,25 @@ def download_log(
     )
 
 
-@router.get("/{id}/grouped-log", response_class=StreamingResponse)
+@router.get(
+    "/{id}/grouped-log",
+    response_class=StreamingResponse,
+    responses={
+        "200": {
+            "description": "Successful Response",
+            "content": {
+                "application/zip": {"schema": {"type": "string", "format": "binary"}}
+            },
+            "headers": {
+                "Content-Disposition": {
+                    "description": "Suggests a filename for the downloaded ZIP file",
+                    "schema": {"type": "string"},
+                    "example": 'attachment; filename="archive.zip"',
+                }
+            },
+        }
+    },
+)
 def download_grouped_log(
     *,
     db: Session = Depends(get_db),


### PR DESCRIPTION
This is a companion PR to https://github.com/project-chip/certification-tool-cli/pull/82 so that the `openapi.json` generated by the backend matches the one in the CLI repo.

The content type of the 200 response needed to be known by the API generation script in order to properly pass on the bytes, but `StreamingResponse`s in FastAPI don't have their content type inferred, so manual annotations needed to be added.

With this change, the output of `http://localhost/api/v1/openapi.json` is now:
```
...
    "/api/v1/test_run_executions/{id}/grouped-log": {
      "get": {
        "tags": [
          "test_run_executions"
        ],
        "summary": "Download Grouped Log",
        "description": "Download the logs from a test run, grouped by test case state.\n\nArgs:\n    id (int): ID of the TestRunExectution the log is requested for\n\nRaises:\n    HTTPException: If there's no TestRunExectution with the given ID\n\nReturns:\n    StreamingResponse: .zip file containing: one file with the list of test cases\n    for each state; one file with the logs from the executed test suites; one file\n    per state with the logs from all test cases that finished with that state",
        "operationId": "download_grouped_log_api_v1_test_run_executions__id__grouped_log_get",
        "parameters": [
          {
            "required": true,
            "schema": {
              "title": "Id",
              "type": "integer"
            },
            "name": "id",
            "in": "path"
          }
        ],
        "responses": {
          "200": {
            "description": "Successful Response",
            "headers": {
              "Content-Disposition": {
                "description": "Suggests a filename for the downloaded ZIP file",
                "schema": {
                  "type": "string"
                },
                "example": "attachment; filename=\"archive.zip\""
              }
            },
            "content": {
              "application/zip": {
                "schema": {
                  "type": "string",
                  "format": "binary"
                }
              }
            }
          },
          "422": {
            "description": "Validation Error",
            "content": {
              "application/json": {
                "schema": {
                  "$ref": "#/components/schemas/HTTPValidationError"
                }
              }
            }
          }
        }
      }
    },
...
```

Note that, when actually hitting the API manually, the response was already matching the annotations here (content type and filename hints etc.), but FastAPI simply would not document it fully. 