### PR TITLE
Rename python testing suite names

### DIFF
--- a/alembic/versions/b1f9e3d7c2a5_rename_python_suite_commissioning_.py
+++ b/alembic/versions/b1f9e3d7c2a5_rename_python_suite_commissioning_.py
@@ -1,0 +1,130 @@
+"""Rename Python Testing Suite commissioning suite names
+
+Revision ID: b1f9e3d7c2a5
+Revises: a16c8c20cd36
+Create Date: 2026-05-18 00:00:00.000000
+
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "b1f9e3d7c2a5"
+down_revision = "a16c8c20cd36"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Rename "Python Testing Suite" -> "Python Testing Suite - Auto commissioning"
+    op.execute(
+        "Update testsuiteexecution "
+        "set public_id='Python Testing Suite - Auto commissioning' "
+        "where public_id='Python Testing Suite'"
+    )
+    op.execute(
+        "Update testsuitemetadata "
+        "set public_id='Python Testing Suite - Auto commissioning', "
+        "title='Python Testing Suite - Auto commissioning', "
+        "description='Python Testing Suite - Auto commissioning' "
+        "where public_id='Python Testing Suite'"
+    )
+
+    # Rename "Python Testing Suite - No commissioning"
+    #     -> "Python Testing Suite - No auto commissioning"
+    op.execute(
+        "Update testsuiteexecution "
+        "set public_id='Python Testing Suite - No auto commissioning' "
+        "where public_id='Python Testing Suite - No commissioning'"
+    )
+    op.execute(
+        "Update testsuitemetadata "
+        "set public_id='Python Testing Suite - No auto commissioning', "
+        "title='Python Testing Suite - No auto commissioning', "
+        "description='Python Testing Suite - No auto commissioning' "
+        "where public_id='Python Testing Suite - No commissioning'"
+    )
+
+    # Handle custom variants (with "-custom" suffix)
+    op.execute(
+        "Update testsuiteexecution "
+        "set public_id='Python Testing Suite - Auto commissioning-custom' "
+        "where public_id='Python Testing Suite-custom'"
+    )
+    op.execute(
+        "Update testsuitemetadata "
+        "set public_id='Python Testing Suite - Auto commissioning-custom', "
+        "title='Python Testing Suite - Auto commissioning-custom', "
+        "description='Python Testing Suite - Auto commissioning-custom' "
+        "where public_id='Python Testing Suite-custom'"
+    )
+    op.execute(
+        "Update testsuiteexecution "
+        "set public_id='Python Testing Suite - No auto commissioning-custom' "
+        "where public_id='Python Testing Suite - No commissioning-custom'"
+    )
+    op.execute(
+        "Update testsuitemetadata "
+        "set public_id='Python Testing Suite - No auto commissioning-custom', "
+        "title='Python Testing Suite - No auto commissioning-custom', "
+        "description='Python Testing Suite - No auto commissioning-custom' "
+        "where public_id='Python Testing Suite - No commissioning-custom'"
+    )
+
+
+def downgrade():
+    # Revert "Python Testing Suite - Auto commissioning" -> "Python Testing Suite"
+    op.execute(
+        "Update testsuiteexecution "
+        "set public_id='Python Testing Suite' "
+        "where public_id='Python Testing Suite - Auto commissioning'"
+    )
+    op.execute(
+        "Update testsuitemetadata "
+        "set public_id='Python Testing Suite', "
+        "title='Python Testing Suite', "
+        "description='Python Testing Suite' "
+        "where public_id='Python Testing Suite - Auto commissioning'"
+    )
+
+    # Revert "Python Testing Suite - No auto commissioning"
+    #     -> "Python Testing Suite - No commissioning"
+    op.execute(
+        "Update testsuiteexecution "
+        "set public_id='Python Testing Suite - No commissioning' "
+        "where public_id='Python Testing Suite - No auto commissioning'"
+    )
+    op.execute(
+        "Update testsuitemetadata "
+        "set public_id='Python Testing Suite - No commissioning', "
+        "title='Python Testing Suite - No commissioning', "
+        "description='Python Testing Suite - No commissioning' "
+        "where public_id='Python Testing Suite - No auto commissioning'"
+    )
+
+    # Revert custom variants
+    op.execute(
+        "Update testsuiteexecution "
+        "set public_id='Python Testing Suite-custom' "
+        "where public_id='Python Testing Suite - Auto commissioning-custom'"
+    )
+    op.execute(
+        "Update testsuitemetadata "
+        "set public_id='Python Testing Suite-custom', "
+        "title='Python Testing Suite-custom', "
+        "description='Python Testing Suite-custom' "
+        "where public_id='Python Testing Suite - Auto commissioning-custom'"
+    )
+    op.execute(
+        "Update testsuiteexecution "
+        "set public_id='Python Testing Suite - No commissioning-custom' "
+        "where public_id='Python Testing Suite - No auto commissioning-custom'"
+    )
+    op.execute(
+        "Update testsuitemetadata "
+        "set public_id='Python Testing Suite - No commissioning-custom', "
+        "title='Python Testing Suite - No commissioning-custom', "
+        "description='Python Testing Suite - No commissioning-custom' "
+        "where public_id='Python Testing Suite - No auto commissioning-custom'"
+    )

--- a/alembic/versions/b1f9e3d7c2a5_rename_python_suite_commissioning_.py
+++ b/alembic/versions/b1f9e3d7c2a5_rename_python_suite_commissioning_.py
@@ -5,6 +5,8 @@ Revises: a16c8c20cd36
 Create Date: 2026-05-18 00:00:00.000000
 
 """
+# flake8: noqa
+# Ignore flake8 check for this file
 
 from alembic import op
 

--- a/alembic/versions/b1f9e3d7c2a5_rename_python_suite_commissioning_.py
+++ b/alembic/versions/b1f9e3d7c2a5_rename_python_suite_commissioning_.py
@@ -17,114 +17,44 @@ depends_on = None
 
 
 def upgrade():
-    # Rename "Python Testing Suite" -> "Python Testing Suite - Auto commissioning"
-    op.execute(
-        "Update testsuiteexecution "
-        "set public_id='Python Testing Suite - Auto commissioning' "
-        "where public_id='Python Testing Suite'"
-    )
-    op.execute(
-        "Update testsuitemetadata "
-        "set public_id='Python Testing Suite - Auto commissioning', "
-        "title='Python Testing Suite - Auto commissioning', "
-        "description='Python Testing Suite - Auto commissioning' "
-        "where public_id='Python Testing Suite'"
-    )
+    renames = {
+        "Python Testing Suite": "Python Testing Suite - Auto commissioning",
+        "Python Testing Suite - No commissioning": "Python Testing Suite - No auto commissioning",
+        "Python Testing Suite-custom": "Python Testing Suite - Auto commissioning-custom",
+        "Python Testing Suite - No commissioning-custom": "Python Testing Suite - No auto commissioning-custom",
+    }
 
-    # Rename "Python Testing Suite - No commissioning"
-    #     -> "Python Testing Suite - No auto commissioning"
-    op.execute(
-        "Update testsuiteexecution "
-        "set public_id='Python Testing Suite - No auto commissioning' "
-        "where public_id='Python Testing Suite - No commissioning'"
-    )
-    op.execute(
-        "Update testsuitemetadata "
-        "set public_id='Python Testing Suite - No auto commissioning', "
-        "title='Python Testing Suite - No auto commissioning', "
-        "description='Python Testing Suite - No auto commissioning' "
-        "where public_id='Python Testing Suite - No commissioning'"
-    )
-
-    # Handle custom variants (with "-custom" suffix)
-    op.execute(
-        "Update testsuiteexecution "
-        "set public_id='Python Testing Suite - Auto commissioning-custom' "
-        "where public_id='Python Testing Suite-custom'"
-    )
-    op.execute(
-        "Update testsuitemetadata "
-        "set public_id='Python Testing Suite - Auto commissioning-custom', "
-        "title='Python Testing Suite - Auto commissioning-custom', "
-        "description='Python Testing Suite - Auto commissioning-custom' "
-        "where public_id='Python Testing Suite-custom'"
-    )
-    op.execute(
-        "Update testsuiteexecution "
-        "set public_id='Python Testing Suite - No auto commissioning-custom' "
-        "where public_id='Python Testing Suite - No commissioning-custom'"
-    )
-    op.execute(
-        "Update testsuitemetadata "
-        "set public_id='Python Testing Suite - No auto commissioning-custom', "
-        "title='Python Testing Suite - No auto commissioning-custom', "
-        "description='Python Testing Suite - No auto commissioning-custom' "
-        "where public_id='Python Testing Suite - No commissioning-custom'"
-    )
+    for old_id, new_id in renames.items():
+        # Update metadata first to satisfy potential foreign key constraints
+        op.execute(
+            f"UPDATE testsuitemetadata "
+            f"SET public_id='{new_id}', title='{new_id}', description='{new_id}' "
+            f"WHERE public_id='{old_id}'"
+        )
+        op.execute(
+            f"UPDATE testsuiteexecution "
+            f"SET public_id='{new_id}' "
+            f"WHERE public_id='{old_id}'"
+        )
 
 
 def downgrade():
-    # Revert "Python Testing Suite - Auto commissioning" -> "Python Testing Suite"
-    op.execute(
-        "Update testsuiteexecution "
-        "set public_id='Python Testing Suite' "
-        "where public_id='Python Testing Suite - Auto commissioning'"
-    )
-    op.execute(
-        "Update testsuitemetadata "
-        "set public_id='Python Testing Suite', "
-        "title='Python Testing Suite', "
-        "description='Python Testing Suite' "
-        "where public_id='Python Testing Suite - Auto commissioning'"
-    )
+    renames = {
+        "Python Testing Suite - Auto commissioning": "Python Testing Suite",
+        "Python Testing Suite - No auto commissioning": "Python Testing Suite - No commissioning",
+        "Python Testing Suite - Auto commissioning-custom": "Python Testing Suite-custom",
+        "Python Testing Suite - No auto commissioning-custom": "Python Testing Suite - No commissioning-custom",
+    }
 
-    # Revert "Python Testing Suite - No auto commissioning"
-    #     -> "Python Testing Suite - No commissioning"
-    op.execute(
-        "Update testsuiteexecution "
-        "set public_id='Python Testing Suite - No commissioning' "
-        "where public_id='Python Testing Suite - No auto commissioning'"
-    )
-    op.execute(
-        "Update testsuitemetadata "
-        "set public_id='Python Testing Suite - No commissioning', "
-        "title='Python Testing Suite - No commissioning', "
-        "description='Python Testing Suite - No commissioning' "
-        "where public_id='Python Testing Suite - No auto commissioning'"
-    )
-
-    # Revert custom variants
-    op.execute(
-        "Update testsuiteexecution "
-        "set public_id='Python Testing Suite-custom' "
-        "where public_id='Python Testing Suite - Auto commissioning-custom'"
-    )
-    op.execute(
-        "Update testsuitemetadata "
-        "set public_id='Python Testing Suite-custom', "
-        "title='Python Testing Suite-custom', "
-        "description='Python Testing Suite-custom' "
-        "where public_id='Python Testing Suite - Auto commissioning-custom'"
-    )
-    op.execute(
-        "Update testsuiteexecution "
-        "set public_id='Python Testing Suite - No commissioning-custom' "
-        "where public_id='Python Testing Suite - No auto commissioning-custom'"
-    )
-    op.execute(
-        "Update testsuitemetadata "
-        "set public_id='Python Testing Suite - No commissioning-custom', "
-        "title='Python Testing Suite - No commissioning-custom', "
-        "description='Python Testing Suite - No commissioning-custom' "
-        "where public_id='Python Testing Suite - No auto commissioning-custom'"
-    )
+    for old_id, new_id in renames.items():
+        # Update metadata first to satisfy potential foreign key constraints
+        op.execute(
+            f"UPDATE testsuitemetadata "
+            f"SET public_id='{new_id}', title='{new_id}', description='{new_id}' "
+            f"WHERE public_id='{old_id}'"
+        )
+        op.execute(
+            f"UPDATE testsuiteexecution "
+            f"SET public_id='{new_id}' "
+            f"WHERE public_id='{old_id}'"
+        )

--- a/test_collections/matter/sdk_tests/support/python_testing/sdk_python_tests.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/sdk_python_tests.py
@@ -66,12 +66,12 @@ def _init_test_suites(
             mandatory=True,
         ),
         SuiteType.COMMISSIONING: PythonSuiteDeclaration(
-            name="Python Testing Suite" + version,
+            name="Python Testing Suite - Auto commissioning" + version,
             suite_type=SuiteType.COMMISSIONING,
             version=python_test_version,
         ),
         SuiteType.NO_COMMISSIONING: PythonSuiteDeclaration(
-            name="Python Testing Suite - No commissioning" + version,
+            name="Python Testing Suite - No auto commissioning" + version,
             suite_type=SuiteType.NO_COMMISSIONING,
             version=python_test_version,
         ),

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_sdk_python_collection.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_sdk_python_collection.py
@@ -54,8 +54,13 @@ def test_automated_suite(python_test_collection: PythonCollectionDeclaration) ->
     expected_automated_test_cases = 2
 
     # Assert automated tests cases
-    assert "Python Testing Suite" in python_test_collection.test_suites.keys()
-    automated_suite = python_test_collection.test_suites["Python Testing Suite"]
+    assert (
+        "Python Testing Suite - Auto commissioning"
+        in python_test_collection.test_suites.keys()
+    )
+    automated_suite = python_test_collection.test_suites[
+        "Python Testing Suite - Auto commissioning"
+    ]
     assert len(automated_suite.test_cases) == expected_automated_test_cases
 
     type_count = dict.fromkeys(MatterTestType, 0)


### PR DESCRIPTION
### Summary
  
  Renames the Python Testing Suite categories to use clearer, more descriptive names that better reflect what each suite actually does. Adds a database migration to update
  existing test run execution records so that historical data remains intact after the rename.

#### Changes

-   sdk_python_tests.py — Updated the two suite name strings in _init_test_suites():
    - "Python Testing Suite" → "Python Testing Suite - Auto commissioning"
    - "Python Testing Suite - No commissioning" → "Python Testing Suite - No auto commissioning"

  **Both the plain and -custom suffixed variants are covered.**

-   test_sdk_python_collection.py — Updated test assertions to reference the new suite names.

-   alembic/versions/b1f9e3d7c2a5_rename_python_suite_commissioning_.py — New Alembic migration that updates testsuiteexecution.public_id and testsuitemetadata.public_id / title /
   description for all affected rows, including -custom variants. A downgrade() path is included to revert the rename if needed.

####  Motivation

  The original names were ambiguous — "Python Testing Suite" gave no indication that commissioning was involved, and "No commissioning" was easy to misread as "nothing was commissioned yet" rather than "commissioning is handled externally." The new names ("Auto commissioning" / "No auto commissioning") make the distinction explicit and consistent with the language used elsewhere in the tool.

  Without the migration, the left panel in the UI would appear empty for any existing test run execution, because the frontend and backend use the suite public_id as a key to reconstruct execution state, and the DB would still hold the old names.

####  Impact
  - Breaking for existing DB records if the migration is not run — the left panel will be blank for historical executions until alembic upgrade head is applied.
  - No API contract changes; the rename is internal to suite metadata.
  - Custom test suites (side-loaded with -custom suffix) are also migrated, so they are not affected.

### Related Issue
https://github.com/project-chip/certification-tool/issues/978

### Testing

- Unit tests were updated and they are all passing

- UI displays the renamed Python suites
<img width="473" height="269" alt="Screenshot 2026-05-18 at 18 48 54" src="https://github.com/user-attachments/assets/4587e68b-5979-4923-a87c-9feea6f5f03d" />

<img width="512" height="270" alt="Screenshot 2026-05-18 at 18 49 00" src="https://github.com/user-attachments/assets/0dd902f8-ac4a-4333-bff3-ebb51a12723f" />


- Old execution displays the renamed suite name