### PR TITLE
Fix ModuleNotFoundError - matter.testing.CommissioningPreTest

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
@@ -23,7 +23,7 @@ import sys
 from contextlib import redirect_stdout
 from multiprocessing.managers import BaseManager
 
-from matter.testing.CommissioningPreTest import CommissionDeviceTest
+from matter.testing.commissioning import CommissionDeviceTest
 from matter.testing.matter_testing import MatterTestConfig
 from matter.testing.runner import (
     TestStep,


### PR DESCRIPTION
Fix ModuleNotFoundError - matter.testing.CommissioningPreTest

Fixes: https://github.com/project-chip/certification-tool/issues/997