### PR TITLE
[Fix] Prefer operational_dataset_hex over live OTBR dataset in ThreadAutoConfig

### DIFF
--- a/app/schemas/test_environment_config.py
+++ b/app/schemas/test_environment_config.py
@@ -36,6 +36,7 @@ class ThreadAutoConfig(BaseModel):
     otbr_docker_image: Optional[str]
     ba_host: Optional[str] = None
     ba_port: Optional[int] = None
+    operational_dataset_hex: Optional[str] = None
 
 
 class TestEnvironmentConfigError(Exception):

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -274,15 +274,18 @@ async def __thread_dataset_hex(
     if isinstance(thread_config, ThreadExternalConfig):
         hex_dataset = thread_config.operational_dataset_hex
     elif isinstance(thread_config, ThreadAutoConfig):
-        border_router: ThreadBorderRouter = ThreadBorderRouter()
+        if thread_config.operational_dataset_hex:
+            hex_dataset = thread_config.operational_dataset_hex
+        else:
+            border_router: ThreadBorderRouter = ThreadBorderRouter()
 
-        # Expecting false as the OTBR is started in the suite's setup.
-        # Either way, if true, we try to start and configure the container in case
-        # there's no OTBR application running.
-        if await border_router.start_device(thread_config):
-            await border_router.form_thread_topology()
+            # Expecting false as the OTBR is started in the suite's setup.
+            # Either way, if true, we try to start and configure the container in case
+            # there's no OTBR application running.
+            if await border_router.start_device(thread_config):
+                await border_router.form_thread_topology()
 
-        hex_dataset = border_router.active_dataset
+            hex_dataset = border_router.active_dataset
 
     return hex_dataset
 


### PR DESCRIPTION
Fixes NFC-Thread commissioning failures (TC-DD-3.23, TC-DD-3.24) where the Thread dataset passed to the SDK diverged from the dataset encoded in the NFC tag, causing ContinueCommissioningAfterConnectNetworkRequest to time out on FindOperationalForStayActive.

#### Changes

- backend/app/schemas/test_environment_config.py
  - Added operational_dataset_hex: Optional[str] = None to ThreadAutoConfig
  
- backend/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
  - In __thread_dataset_hex(), when ThreadAutoConfig has operational_dataset_hex set, use it directly instead of querying the live OTBR via ot-ctl dataset active -x
  
#### Motivation
  When a project config contains ThreadAutoConfig fields (rcp_serial_path, dataset, etc.) alongside operational_dataset_hex, Pydantic was silently dropping operational_dataset_hex because the field was not declared on the model. As a result, __thread_dataset_hex() always fell through to border_router.active_dataset, which queries the live OTBR and may return a different dataset than what the NFC tag was programmed with. The DUT would join a Thread network the TH controller didn't know about, and operational mDNS discovery would time out after 45 seconds.

This was confirmed by testing: creating a new CLI project via scripts populated the config with the full ThreadAutoConfig shape plus operational_dataset_hex. The hex was dropped by Pydantic, the live OTBR returned a mismatched dataset, and commissioning failed. Using a config with only operational_dataset_hex (matching the GUI project shape) passed in all scenarios.

#### Impact

  - No breaking changes. The fix is purely additive — operational_dataset_hex is optional with a None default, so existing ThreadAutoConfig configs without the field are unaffected.
  - When operational_dataset_hex is not set, behaviour is identical to before: the live OTBR dataset is fetched via active_dataset.
  - Fixes TC-DD-3.23 and TC-DD-3.24 for CLI projects configured with ThreadAutoConfig + operational_dataset_hex.
  
  
### Releated Issue
[#1004](https://github.com/project-chip/certification-tool/issues/1004

### Testing
Unit tests passing

Requesting originator to test in PRs branch - Waiting for feedbacks



