### PR TITLE
Specify utf-8 encoding when reading module source files

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
@@ -225,8 +225,9 @@ def _is_matter_base_test_class(
                 try:
                     abs_path = str(candidate.resolve())
                     if abs_path not in _module_cache:
-                        with open(candidate, "r", encoding="utf-8") as f:
-                            _module_cache[abs_path] = ast.parse(f.read())
+                        _module_cache[abs_path] = ast.parse(
+                            candidate.read_text(encoding="utf-8")
+                        )
                     imported_module = _module_cache[abs_path]
 
                     # Use the absolute path as the cycle-guard key so that

--- a/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py
@@ -225,7 +225,7 @@ def _is_matter_base_test_class(
                 try:
                     abs_path = str(candidate.resolve())
                     if abs_path not in _module_cache:
-                        with open(candidate, "r") as f:
+                        with open(candidate, "r", encoding="utf-8") as f:
                             _module_cache[abs_path] = ast.parse(f.read())
                     imported_module = _module_cache[abs_path]
 


### PR DESCRIPTION
## Summary
- Add `encoding=\"utf-8\"` to the `open()` call in [list_python_tests_classes.py](test_collections/matter/sdk_tests/support/python_testing/list_python_tests_classes.py#L228) so module source parsing does not depend on the platform's default locale.

Fixes #323

## Test plan
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)