### PR TITLE
Default order_by column to id when attribute is invalid

### DIFF
--- a/app/crud/crud_test_run_execution.py
+++ b/app/crud/crud_test_run_execution.py
@@ -85,11 +85,9 @@ class CRUDTestRunExecution(
                 )
             )
 
-        column = (
-            getattr(self.model, order_by, self.model.id)
-            if order_by
-            else self.model.id
-        )
+        column = getattr(self.model, order_by, None) if order_by else None
+        if column is None or not hasattr(column, "desc"):
+            column = self.model.id
         if sort_order == "desc":
             query = query.order_by(column.desc())
         else:

--- a/app/crud/crud_test_run_execution.py
+++ b/app/crud/crud_test_run_execution.py
@@ -85,7 +85,11 @@ class CRUDTestRunExecution(
                 )
             )
 
-        column = self.model.id if order_by is None else getattr(self.model, order_by)
+        column = (
+            getattr(self.model, order_by, self.model.id)
+            if order_by
+            else self.model.id
+        )
         if sort_order == "desc":
             query = query.order_by(column.desc())
         else:


### PR DESCRIPTION
## Summary
- In [crud_test_run_execution.py:88](app/crud/crud_test_run_execution.py#L88), pass `self.model.id` as the default to `getattr` so an invalid `order_by` falls back to ordering by id instead of raising `AttributeError`.

Fixes #322

## Test plan
- [ ] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)