### PR TITLE
Feature/1024 project logs endpoint

### DIFF
--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -16,17 +16,19 @@
 import json
 import traceback
 from http import HTTPStatus
+from io import BytesIO
 from typing import List, Sequence, Union
+from zipfile import ZipFile
 
 from fastapi import APIRouter, Depends, File, HTTPException, Request, UploadFile
 from fastapi.encoders import jsonable_encoder
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 from loguru import logger
 from pydantic import ValidationError, parse_obj_as
 from sqlalchemy.orm import Session
 from sqlalchemy.orm.attributes import flag_modified
 
-from app import crud, models, schemas
+from app import crud, log_utils, models, schemas
 from app.db.session import get_db
 from app.default_environment_config import default_environment_config
 from app.models.project import Project
@@ -460,3 +462,82 @@ def importproject_config(
             status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
             detail=str(e),
         )
+
+
+@router.get(
+    "/{id}/logs",
+    response_class=StreamingResponse,
+    responses={
+        "200": {
+            "description": "Successful Response",
+            "content": {
+                "application/zip": {"schema": {"type": "string", "format": "binary"}}
+            },
+            "headers": {
+                "Content-Disposition": {
+                    "description": "Suggests a filename for the downloaded ZIP file",
+                    "schema": {"type": "string"},
+                    "example": 'attachment; filename="my-project-logs.zip"',
+                }
+            },
+        }
+    },
+)
+def download_project_logs(
+    *,
+    db: Session = Depends(get_db),
+    id: int,
+    grouped: bool = False,
+) -> StreamingResponse:
+    """Download all logs for a project.
+
+    Args:
+        id (int): Project ID
+        grouped (bool): When True, each execution's logs are grouped by test case
+            state (one inner zip per execution). When False, each execution's logs
+            are returned as a single flat .log text file.
+
+    Raises:
+        HTTPException: If no project exists for the given ID
+
+    Returns:
+        StreamingResponse: A zip archive containing one file per test run execution.
+    """
+    project = __project(db=db, id=id)
+
+    executions = crud.test_run_execution.get_multi(
+        db=db, project_id=id, limit=0
+    )
+
+    outer_zip_buffer = BytesIO()
+
+    with ZipFile(file=outer_zip_buffer, mode="w") as outer_zip:
+        for execution in executions:
+            if grouped:
+                grouped_logs = log_utils.group_test_run_execution_logs(
+                    test_run_execution=execution
+                )
+                inner_zip_buffer = log_utils.create_grouped_log_zip_file(
+                    grouped_logs=grouped_logs
+                )
+                entry_name = f"{execution.id}-{execution.title}.zip"
+                outer_zip.writestr(entry_name, inner_zip_buffer.read())
+            else:
+                log_lines = log_utils.convert_execution_log_to_list(
+                    log=execution.log, json_entries=False
+                )
+                entry_name = f"{execution.id}-{execution.title}.log"
+                outer_zip.writestr(entry_name, "\n".join(log_lines))
+
+    outer_zip_buffer.seek(0)
+
+    safe_name = "".join(
+        c if c.isalnum() or c in "-_" else "_" for c in (project.name or f"project-{id}")
+    )
+    file_name = f"{safe_name}-logs.zip"
+
+    return StreamingResponse(
+        outer_zip_buffer,
+        media_type="application/zip",
+        headers={"Content-Disposition": f'attachment; filename="{file_name}"'},
+    )

--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -520,9 +520,7 @@ def download_project_logs(
     """
     project = __project(db=db, id=id)
 
-    executions = crud.test_run_execution.get_multi(
-        db=db, project_id=id, limit=0
-    )
+    executions = crud.test_run_execution.get_multi(db=db, project_id=id, limit=0)
 
     outer_zip_buffer = BytesIO()
 

--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import json
+import re
 import traceback
 from http import HTTPStatus
 from io import BytesIO
@@ -374,7 +375,9 @@ def __project(db: Session, id: int) -> Project:
     return project
 
 
-def __safe_filename_component(value: Union[str, None], fallback: str) -> str:
+def __safe_filename_component(
+    value: Union[str, None], fallback: str = "default"
+) -> str:
     """Sanitize a value for safe use as part of a file or zip entry name.
 
     Keeps only alphanumeric characters, hyphens and underscores, replacing
@@ -383,7 +386,7 @@ def __safe_filename_component(value: Union[str, None], fallback: str) -> str:
     from user-controlled data (e.g. project name or execution title).
     """
     source = value or fallback
-    return "".join(c if c.isalnum() or c in "-_" else "_" for c in source)
+    return re.sub(r"[^a-zA-Z0-9_-]", "_", source)
 
 
 def __persist_update_not_mutable(db: Session, project: Project, field: str) -> Project:

--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -374,6 +374,18 @@ def __project(db: Session, id: int) -> Project:
     return project
 
 
+def __safe_filename_component(value: Union[str, None], fallback: str) -> str:
+    """Sanitize a value for safe use as part of a file or zip entry name.
+
+    Keeps only alphanumeric characters, hyphens and underscores, replacing
+    everything else (including path separators like "/" or "\\") with "_".
+    This avoids path traversal / Zip Slip issues when the value originates
+    from user-controlled data (e.g. project name or execution title).
+    """
+    source = value or fallback
+    return "".join(c if c.isalnum() or c in "-_" else "_" for c in source)
+
+
 def __persist_update_not_mutable(db: Session, project: Project, field: str) -> Project:
     """Update Project JSON fields in DB.
 
@@ -513,6 +525,9 @@ def download_project_logs(
 
     with ZipFile(file=outer_zip_buffer, mode="w") as outer_zip:
         for execution in executions:
+            safe_title = __safe_filename_component(
+                execution.title, fallback="execution"
+            )
             if grouped:
                 grouped_logs = log_utils.group_test_run_execution_logs(
                     test_run_execution=execution
@@ -520,20 +535,18 @@ def download_project_logs(
                 inner_zip_buffer = log_utils.create_grouped_log_zip_file(
                     grouped_logs=grouped_logs
                 )
-                entry_name = f"{execution.id}-{execution.title}.zip"
+                entry_name = f"{execution.id}-{safe_title}.zip"
                 outer_zip.writestr(entry_name, inner_zip_buffer.read())
             else:
                 log_lines = log_utils.convert_execution_log_to_list(
                     log=execution.log, json_entries=False
                 )
-                entry_name = f"{execution.id}-{execution.title}.log"
+                entry_name = f"{execution.id}-{safe_title}.log"
                 outer_zip.writestr(entry_name, "\n".join(log_lines))
 
     outer_zip_buffer.seek(0)
 
-    safe_name = "".join(
-        c if c.isalnum() or c in "-_" else "_" for c in (project.name or f"project-{id}")
-    )
+    safe_name = __safe_filename_component(project.name, fallback=f"project-{id}")
     file_name = f"{safe_name}-logs.zip"
 
     return StreamingResponse(

--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -513,7 +513,8 @@ def download_project_logs(
             are returned as a single flat .log text file.
 
     Raises:
-        HTTPException: If no project exists for the given ID
+        HTTPException: If no project exists for the given ID, or if the project
+            has no test run executions to download logs for
 
     Returns:
         StreamingResponse: A zip archive containing one file per test run execution.
@@ -521,6 +522,12 @@ def download_project_logs(
     project = __project(db=db, id=id)
 
     executions = crud.test_run_execution.get_multi(db=db, project_id=id, limit=0)
+
+    if not executions:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail=f"Project {id} has no test run executions to download logs for",
+        )
 
     outer_zip_buffer = BytesIO()
 

--- a/app/tests/api/api_v1/test_projects_logs.py
+++ b/app/tests/api/api_v1/test_projects_logs.py
@@ -18,7 +18,6 @@ from http import HTTPStatus
 from io import BytesIO
 from zipfile import ZipFile
 
-import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
@@ -110,30 +109,53 @@ def test_download_project_logs_not_found(client: TestClient) -> None:
 def test_download_project_logs_flat_entry_names(
     client: TestClient, db: Session
 ) -> None:
-    """Each flat log entry in the zip is named <id>-<title>.log."""
+    """Each flat log entry in the zip is named <id>-<sanitized-title>.log."""
     project = create_random_project(db, config={})
-    execution = create_random_test_run_execution(db, project_id=project.id)
+    execution = create_random_test_run_execution(
+        db, project_id=project.id, title="My Execution Title!"
+    )
 
     url = f"{BASE_URL}/{project.id}/logs"
     response = client.get(url)
 
     assert response.status_code == HTTPStatus.OK
     with ZipFile(BytesIO(response.content)) as zf:
-        expected_entry = f"{execution.id}-{execution.title}.log"
+        expected_entry = f"{execution.id}-My_Execution_Title_.log"
         assert expected_entry in zf.namelist()
 
 
 def test_download_project_logs_grouped_entry_names(
     client: TestClient, db: Session
 ) -> None:
-    """Each grouped log entry in the zip is named <id>-<title>.zip."""
+    """Each grouped log entry in the zip is named <id>-<sanitized-title>.zip."""
     project = create_random_project(db, config={})
-    execution = create_random_test_run_execution(db, project_id=project.id)
+    execution = create_random_test_run_execution(
+        db, project_id=project.id, title="My Execution Title!"
+    )
 
     url = f"{BASE_URL}/{project.id}/logs?grouped=true"
     response = client.get(url)
 
     assert response.status_code == HTTPStatus.OK
     with ZipFile(BytesIO(response.content)) as zf:
-        expected_entry = f"{execution.id}-{execution.title}.zip"
+        expected_entry = f"{execution.id}-My_Execution_Title_.zip"
         assert expected_entry in zf.namelist()
+
+
+def test_download_project_logs_sanitizes_execution_title(
+    client: TestClient, db: Session
+) -> None:
+    """Path separators and traversal sequences in the title are sanitized."""
+    project = create_random_project(db, config={})
+    execution = create_random_test_run_execution(
+        db, project_id=project.id, title="../../etc/passwd"
+    )
+
+    url = f"{BASE_URL}/{project.id}/logs"
+    response = client.get(url)
+
+    assert response.status_code == HTTPStatus.OK
+    with ZipFile(BytesIO(response.content)) as zf:
+        names = zf.namelist()
+        assert not any("/" in name or ".." in name for name in names)
+        assert f"{execution.id}-______etc_passwd.log" in names

--- a/app/tests/api/api_v1/test_projects_logs.py
+++ b/app/tests/api/api_v1/test_projects_logs.py
@@ -1,0 +1,139 @@
+#
+# Copyright (c) 2025 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for the GET /api/v1/projects/{id}/logs endpoint."""
+from http import HTTPStatus
+from io import BytesIO
+from zipfile import ZipFile
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.tests.utils.project import create_random_project
+from app.tests.utils.test_run_execution import create_random_test_run_execution
+
+BASE_URL = f"{settings.API_V1_STR}/projects"
+
+
+def test_download_project_logs_flat_returns_zip(
+    client: TestClient, db: Session
+) -> None:
+    """Flat log download returns a zip archive with one .log file per execution."""
+    project = create_random_project(db, config={})
+    exec1 = create_random_test_run_execution(db, project_id=project.id)
+    exec2 = create_random_test_run_execution(db, project_id=project.id)
+
+    url = f"{BASE_URL}/{project.id}/logs"
+    response = client.get(url)
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.headers["content-type"] == "application/zip"
+    assert "attachment" in response.headers["content-disposition"]
+    assert response.headers["content-disposition"].endswith("-logs.zip\"")
+
+    with ZipFile(BytesIO(response.content)) as zf:
+        names = zf.namelist()
+        assert any(name.endswith(".log") for name in names)
+        assert any(str(exec1.id) in name for name in names)
+        assert any(str(exec2.id) in name for name in names)
+
+
+def test_download_project_logs_grouped_returns_zip_of_zips(
+    client: TestClient, db: Session
+) -> None:
+    """Grouped log download returns a zip archive with one inner .zip per execution."""
+    project = create_random_project(db, config={})
+    exec1 = create_random_test_run_execution(db, project_id=project.id)
+
+    url = f"{BASE_URL}/{project.id}/logs?grouped=true"
+    response = client.get(url)
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.headers["content-type"] == "application/zip"
+
+    with ZipFile(BytesIO(response.content)) as zf:
+        names = zf.namelist()
+        assert any(name.endswith(".zip") for name in names)
+        assert any(str(exec1.id) in name for name in names)
+
+
+def test_download_project_logs_empty_project_returns_empty_zip(
+    client: TestClient, db: Session
+) -> None:
+    """A project with no executions returns a valid but empty zip."""
+    project = create_random_project(db, config={})
+
+    url = f"{BASE_URL}/{project.id}/logs"
+    response = client.get(url)
+
+    assert response.status_code == HTTPStatus.OK
+    with ZipFile(BytesIO(response.content)) as zf:
+        assert zf.namelist() == []
+
+
+def test_download_project_logs_filename_derived_from_project_name(
+    client: TestClient, db: Session
+) -> None:
+    """The Content-Disposition filename is derived from the project name."""
+    project = create_random_project(db, config={})
+
+    url = f"{BASE_URL}/{project.id}/logs"
+    response = client.get(url)
+
+    assert response.status_code == HTTPStatus.OK
+    content_disposition = response.headers["content-disposition"]
+    assert "logs.zip" in content_disposition
+
+
+def test_download_project_logs_not_found(client: TestClient) -> None:
+    """Returns 404 when the project does not exist."""
+    url = f"{BASE_URL}/999999/logs"
+    response = client.get(url)
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_download_project_logs_flat_entry_names(
+    client: TestClient, db: Session
+) -> None:
+    """Each flat log entry in the zip is named <id>-<title>.log."""
+    project = create_random_project(db, config={})
+    execution = create_random_test_run_execution(db, project_id=project.id)
+
+    url = f"{BASE_URL}/{project.id}/logs"
+    response = client.get(url)
+
+    assert response.status_code == HTTPStatus.OK
+    with ZipFile(BytesIO(response.content)) as zf:
+        expected_entry = f"{execution.id}-{execution.title}.log"
+        assert expected_entry in zf.namelist()
+
+
+def test_download_project_logs_grouped_entry_names(
+    client: TestClient, db: Session
+) -> None:
+    """Each grouped log entry in the zip is named <id>-<title>.zip."""
+    project = create_random_project(db, config={})
+    execution = create_random_test_run_execution(db, project_id=project.id)
+
+    url = f"{BASE_URL}/{project.id}/logs?grouped=true"
+    response = client.get(url)
+
+    assert response.status_code == HTTPStatus.OK
+    with ZipFile(BytesIO(response.content)) as zf:
+        expected_entry = f"{execution.id}-{execution.title}.zip"
+        assert expected_entry in zf.namelist()

--- a/app/tests/api/api_v1/test_projects_logs.py
+++ b/app/tests/api/api_v1/test_projects_logs.py
@@ -70,18 +70,16 @@ def test_download_project_logs_grouped_returns_zip_of_zips(
         assert any(str(exec1.id) in name for name in names)
 
 
-def test_download_project_logs_empty_project_returns_empty_zip(
+def test_download_project_logs_empty_project_returns_not_found(
     client: TestClient, db: Session
 ) -> None:
-    """A project with no executions returns a valid but empty zip."""
+    """A project with no executions returns 404 instead of an empty zip."""
     project = create_random_project(db, config={})
 
     url = f"{BASE_URL}/{project.id}/logs"
     response = client.get(url)
 
-    assert response.status_code == HTTPStatus.OK
-    with ZipFile(BytesIO(response.content)) as zf:
-        assert zf.namelist() == []
+    assert response.status_code == HTTPStatus.NOT_FOUND
 
 
 def test_download_project_logs_filename_derived_from_project_name(
@@ -89,6 +87,7 @@ def test_download_project_logs_filename_derived_from_project_name(
 ) -> None:
     """The Content-Disposition filename is derived from the project name."""
     project = create_random_project(db, config={})
+    create_random_test_run_execution(db, project_id=project.id)
 
     url = f"{BASE_URL}/{project.id}/logs"
     response = client.get(url)

--- a/app/tests/api/api_v1/test_projects_logs.py
+++ b/app/tests/api/api_v1/test_projects_logs.py
@@ -42,7 +42,7 @@ def test_download_project_logs_flat_returns_zip(
     assert response.status_code == HTTPStatus.OK
     assert response.headers["content-type"] == "application/zip"
     assert "attachment" in response.headers["content-disposition"]
-    assert response.headers["content-disposition"].endswith("-logs.zip\"")
+    assert response.headers["content-disposition"].endswith('-logs.zip"')
 
     with ZipFile(BytesIO(response.content)) as zf:
         names = zf.namelist()


### PR DESCRIPTION
### What changed
Adds a new backend API endpoint, GET /api/v1/projects/{id}/logs, that lets a client download all test run execution logs for a given project as a single ZIP archive, plus a comprehensive test suite covering the new behavior.

#### Changes

- New endpoint: GET /api/v1/projects/{id}/logs

  - Added to app/api/api_v1/endpoints/projects.py.
  - Looks up the project (404 if it doesn't exist), then fetches all TestRunExecution records for that project
  (crud.test_run_execution.get_multi(..., limit=0)).
  - Builds an in-memory outer ZIP (BytesIO + ZipFile) containing one entry per execution:
    - Flat mode (default, grouped=false): each execution's log is converted to plain lines via
  log_utils.convert_execution_log_to_list(...) and written as a <execution.id>-<execution.title>.log text file.
    - Grouped mode (grouped=true): each execution's log is grouped by test-case state via
  log_utils.group_test_run_execution_logs(...), packed into an inner ZIP via log_utils.create_grouped_log_zip_file(...), and written as a <execution.id>-<execution.title>.zip (i.e., a zip-of-zips).
  - Returns a StreamingResponse with media_type="application/zip" and a Content-Disposition: attachment header whose filename is derived from the project name (sanitized to alphanumerics, -, and _) or falls back to project-{id}-logs.zip if the project has no name.
  - Response schema/docs annotated for OpenAPI (binary zip content, example Content-Disposition header) so the generated CLI client documents the endpoint correctly.
  - A project with no executions returns a valid, empty ZIP rather than erroring.

#### Tests

  - New file app/tests/api/api_v1/test_projects_logs.py with 7 test cases covering:
    - Flat download returns a zip with one .log per execution, correct headers.
    - Grouped download (?grouped=true) returns a zip containing inner .zip files.
    - Empty project returns an empty but valid zip.
    - Filename is derived from the project name.
    - 404 for a non-existent project ID.
    - Exact entry-naming conventions for both flat (<id>-<title>.log) and grouped (<id>-<title>.zip) modes.

#### Motivation

  Previously there was no way to bulk-download all logs for every test run execution belonging to a project in one request — users had to fetch logs execution-by-execution. This endpoint provides a single, convenient bulk-export path (e.g., for archival, sharing with support, or offline analysis), and reuses existing log_utils helpers already used elsewhere for per-execution log formatting/grouping.

#### Impact

  - Additive, non-breaking: this is a new route; no existing endpoints, schemas, or behaviors are modified.
  - New dependency on log_utils in projects.py (module already exists in the codebase; only the import surface changes here).
  - Response can be large for projects with many/large executions since the whole ZIP is built in memory (BytesIO) before streaming — acceptable for now but worth keeping in mind for very large projects.
  - CLI's auto-generated API client should be regenerated (cli/scripts/generate_client.sh) to pick up the new endpoint once this merges.
  
### Related Issue
  https://github.com/project-chip/certification-tool/issues/1024
  
 ### Testing
- Unit tests added and passing
- Developer testing are ongoing