### PR TITLE
Fix flake8, black and isort linting issues

### DIFF
--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -14,12 +14,9 @@
 # limitations under the License.
 #
 import json
-import os
-from datetime import datetime
 from http import HTTPStatus
 from typing import Any
 
-import requests
 from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, UploadFile
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -45,7 +42,6 @@ from app.utils import (
 )
 from app.version import version_information
 from test_collections.matter.sdk_tests.support.chip.chip_server import ChipServer
-from test_collections.matter.test_environment_config import TestEnvironmentConfigMatter
 
 router = APIRouter()
 
@@ -652,4 +648,3 @@ def import_test_run_execution(
             status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
             detail=str(error),
         )
-

--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -25,6 +25,7 @@ from app.test_engine.models.test_declarations import (
     TestCollectionDeclaration,
 )
 from app.test_engine.test_script_manager import test_script_manager
+
 PICS_PLAT_CERT = "PLAT.CERT"
 PICS_PLAT_CERT_DERIVED = "PLAT.CERT.TESTS.DONE"
 

--- a/app/test_engine/test_script_manager.py
+++ b/app/test_engine/test_script_manager.py
@@ -211,8 +211,8 @@ class TestScriptManager(object, metaclass=Singleton):
             test_cases = []
 
             test_cases = self.__pending_test_cases_for_iterations(
-                    test_case=test_case_declaration, iterations=iterations
-                )
+                test_case=test_case_declaration, iterations=iterations
+            )
             suite_test_cases.extend(test_cases)
 
         return suite_test_cases
@@ -323,17 +323,15 @@ class TestScriptManager(object, metaclass=Singleton):
         test_suite.test_cases = []
 
         for test_case_execution in test_case_executions:
-                # TODO: request correct TestCase from TestScriptManager
-                test_case_declaration = self.__test_case_declaration(
-                    test_case_execution.public_id,
-                    test_suite_declaration=test_suite_declaration,
-                )
-                TestCaseClass = test_case_declaration.class_ref
-                test_case = TestCaseClass(test_case_execution=test_case_execution)
-                self.create_pending_teststeps_execution(
-                    db, test_case, test_case_execution
-                )
-                test_suite.test_cases.append(test_case)
+            # TODO: request correct TestCase from TestScriptManager
+            test_case_declaration = self.__test_case_declaration(
+                test_case_execution.public_id,
+                test_suite_declaration=test_suite_declaration,
+            )
+            TestCaseClass = test_case_declaration.class_ref
+            test_case = TestCaseClass(test_case_execution=test_case_execution)
+            self.create_pending_teststeps_execution(db, test_case, test_case_execution)
+            test_suite.test_cases.append(test_case)
 
     def create_pending_teststeps_execution(
         self,

--- a/app/test_engine/test_script_manager.py
+++ b/app/test_engine/test_script_manager.py
@@ -328,8 +328,8 @@ class TestScriptManager(object, metaclass=Singleton):
                 test_case_execution.public_id,
                 test_suite_declaration=test_suite_declaration,
             )
-            TestCaseClass = test_case_declaration.class_ref
-            test_case = TestCaseClass(test_case_execution=test_case_execution)
+            test_case_class = test_case_declaration.class_ref
+            test_case = test_case_class(test_case_execution=test_case_execution)
             self.create_pending_teststeps_execution(db, test_case, test_case_execution)
             test_suite.test_cases.append(test_case)
 

--- a/test_collections/matter/sdk_tests/support/sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/sdk_container.py
@@ -64,6 +64,7 @@ LOCAL_RPC_PYTHON_TESTING_PATH = Path(
 )
 DOCKER_RPC_PYTHON_TESTING_PATH = "/root/python_testing/scripts/sdk/matter_testing_infrastructure/chip/testing/test_harness_client.py"  # noqa
 
+
 class SDKContainerNotRunning(Exception):
     """Raised when we attempt to use the docker container, but it is not running"""
 


### PR DESCRIPTION
- Remove unused imports (os, datetime, requests, TestEnvironmentConfigMatter) from test_run_executions.py
- Remove trailing blank line at end of test_run_executions.py
- Fix over-indented loop body in test_script_manager.py after Performance Tests branch removal
- Add missing blank line before class in sdk_container.py (E302)
- Add missing blank line after imports in pics_applicable_test_cases.py to satisfy isort