### PR TITLE
Fix v2.16-beta1+spring2026 referenced versions

### DIFF
--- a/.version_information
+++ b/.version_information
@@ -1,1 +1,1 @@
-v2.16-beta1+spring2026
+v2.16-beta1+summer2026


### PR DESCRIPTION
Fix v2.16-beta1+spring2026 referenced versions

Related Issue: https://github.com/project-chip/certification-tool/issues/1032