### PR TITLE
Fix: use thread-meshcop pairing mode for THREAD_MESHCOP config (#1043)

### DIFF
--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
@@ -564,7 +564,7 @@ async def test_pairing_thread_command_params_with_ba_params() -> None:
         f"{hex(chip_server.node_id)} hex:{hex_dataset} {payload} "
         f"--thread-ba-host {ba_host} --thread-ba-port {ba_port}"
     )
-    expected_command = f"pairing code-thread {expected_params}"
+    expected_command = f"pairing thread-meshcop {expected_params}"
 
     assert result is True
     mock_send_websocket_command.assert_awaited_once_with(expected_command)
@@ -598,7 +598,7 @@ async def test_pairing_thread_command_params_without_ba_params() -> None:
         )
 
     expected_params = f"{hex(chip_server.node_id)} hex:{hex_dataset} {payload}"
-    expected_command = f"pairing code-thread {expected_params}"
+    expected_command = f"pairing thread-meshcop {expected_params}"
 
     assert result is True
     mock_send_websocket_command.assert_awaited_once_with(expected_command)
@@ -638,7 +638,7 @@ async def test_pairing_thread_command_params_with_only_ba_host() -> None:
         f"{hex(chip_server.node_id)} hex:{hex_dataset} {payload} "
         f"--thread-ba-host {ba_host}"
     )
-    expected_command = f"pairing code-thread {expected_params}"
+    expected_command = f"pairing thread-meshcop {expected_params}"
 
     assert result is True
     mock_send_websocket_command.assert_awaited_once_with(expected_command)
@@ -678,7 +678,7 @@ async def test_pairing_thread_command_params_with_only_ba_port() -> None:
         f"{hex(chip_server.node_id)} hex:{hex_dataset} {payload} "
         f"--thread-ba-port {ba_port}"
     )
-    expected_command = f"pairing code-thread {expected_params}"
+    expected_command = f"pairing thread-meshcop {expected_params}"
 
     assert result is True
     mock_send_websocket_command.assert_awaited_once_with(expected_command)

--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -61,7 +61,7 @@ PAIRING_MODE_NFC_WIFI = "nfc-wifi"
 PAIRING_MODE_BLE_THREAD = "ble-thread"
 PAIRING_MODE_WIFIPAF_WIFI = "wifipaf-wifi"
 PAIRING_MODE_NFC_THREAD = "nfc-thread"
-PAIRING_MODE_THREAD = "code-thread"
+PAIRING_MODE_THREAD = "thread-meshcop"
 PAIRING_MODE_UNPAIR = "unpair"
 
 # Websocket runner


### PR DESCRIPTION
## Summary

Fixes #1043 — TC-ACL-2.1 (and any test using `thread-meshcop` pairing mode) executed chip-tool's `pairing code-thread` instead of `pairing thread-meshcop`, despite the project config specifying `"pairing_mode": "thread-meshcop"`.

## Root cause

`PAIRING_MODE_THREAD` in `matter_yaml_runner.py` was hardcoded to `"code-thread"` instead of `"thread-meshcop"`. This constant is used by `pairing_thread()`, which is the method invoked when `dut_config.pairing_mode` is `DutPairingModeEnum.THREAD_MESHCOP`.

chip-tool only registers the `--thread-ba-host` / `--thread-ba-port` options for the `thread-meshcop` subcommand (see `PairingCommand.h`) — the `code-thread` subcommand doesn't know about them. So when `pairing_thread()` sent `code-thread` with those two flags attached, chip-tool's argument parser rejected the command:

```
CHIP:TOO InitArgs: Optional argument 192.168.0.104 does not exist.
```

The command silently failed, no pairing result was ever returned, and the test hung until timeout (~60s) before being cancelled.

## Fix

- `matter_yaml_runner.py`: `PAIRING_MODE_THREAD = "code-thread"` → `"thread-meshcop"`
- `test_matter_yaml_runner.py`: updated 4 assertions that expected the (buggy) `code-thread` command string to expect `thread-meshcop` instead.

## Testing

- Updated unit tests to assert the corrected command string.
- Manually verified against the log attached to #1043: with this fix, the executed command now matches the configured `pairing_mode`, and chip-tool accepts the `--thread-ba-host`/`--thread-ba-port` flags.
  
  ### Related Issue
  https://github.com/project-chip/certification-tool/issues/1043
