### PR TITLE
Release v2.15.1-beta1+summer2026

### DIFF
--- a/.version_information
+++ b/.version_information
@@ -1,1 +1,1 @@
-v2.15+spring2026
+v2.15.1-beta1+summer2026

--- a/test_collections/matter/config.py
+++ b/test_collections/matter/config.py
@@ -23,9 +23,9 @@ class MatterSettings(BaseSettings):
 
     # SDK Docker Image
     SDK_DOCKER_IMAGE: str = "connectedhomeip/chip-cert-bins"
-    SDK_DOCKER_TAG: str = "ad9cf715421da92c3e6fb17c3086b900cf281c5b"
+    SDK_DOCKER_TAG: str = "df8bd0308caa0680e2a78cda724a959e5b385205"
     # SDK SHA: used to fetch tests (YAML and Python) from SDK.
-    SDK_SHA: str = "ad9cf715421da92c3e6fb17c3086b900cf281c5b"
+    SDK_SHA: str = "df8bd0308caa0680e2a78cda724a959e5b385205"
 
     class Config:
         case_sensitive = True


### PR DESCRIPTION
## Description

Cuts the release branch for `v2.15.1-beta1+summer2026`.

- Bumps `.version_information` to `v2.15.1-beta1+summer2026`
- Pins SDK to `df8bd0308caa0680e2a78cda724a959e5b385205` (both `SDK_DOCKER_TAG` and `SDK_SHA` in `test_collections/matter/config.py`)

## Type of change

- [x] Release

## Testing

No code changes beyond version/SDK pin bump.