### PR TITLE
Fix: remove incompatible nodejs/npm/cspell install from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,12 +61,6 @@ RUN curl -sSL https://install.python-poetry.org | python3 - && \
 # Install Docker
 RUN curl -sSL https://get.docker.com/ | sh
 
-# Install nodejs, npm and spell checker
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
-RUN apt-get install -y nodejs
-RUN npm install -g npm@latest
-RUN npm install -g cspell@latest
-
 # Allow installing dev dependencies to run tests
 # Copy poetry dependecy files and install dependencies
 # We copy install dependencies before copying all app source to reuse the dependency install step in docker.

--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -14,12 +14,9 @@
 # limitations under the License.
 #
 import json
-import os
-from datetime import datetime
 from http import HTTPStatus
 from typing import Any
 
-import requests
 from fastapi import APIRouter, BackgroundTasks, Depends, File, HTTPException, UploadFile
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import JSONResponse, StreamingResponse
@@ -45,7 +42,6 @@ from app.utils import (
 )
 from app.version import version_information
 from test_collections.matter.sdk_tests.support.chip.chip_server import ChipServer
-from test_collections.matter.test_environment_config import TestEnvironmentConfigMatter
 
 router = APIRouter()
 
@@ -652,4 +648,3 @@ def import_test_run_execution(
             status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
             detail=str(error),
         )
-

--- a/app/pics_applicable_test_cases.py
+++ b/app/pics_applicable_test_cases.py
@@ -25,6 +25,7 @@ from app.test_engine.models.test_declarations import (
     TestCollectionDeclaration,
 )
 from app.test_engine.test_script_manager import test_script_manager
+
 PICS_PLAT_CERT = "PLAT.CERT"
 PICS_PLAT_CERT_DERIVED = "PLAT.CERT.TESTS.DONE"
 

--- a/app/test_engine/test_script_manager.py
+++ b/app/test_engine/test_script_manager.py
@@ -211,8 +211,8 @@ class TestScriptManager(object, metaclass=Singleton):
             test_cases = []
 
             test_cases = self.__pending_test_cases_for_iterations(
-                    test_case=test_case_declaration, iterations=iterations
-                )
+                test_case=test_case_declaration, iterations=iterations
+            )
             suite_test_cases.extend(test_cases)
 
         return suite_test_cases
@@ -323,17 +323,15 @@ class TestScriptManager(object, metaclass=Singleton):
         test_suite.test_cases = []
 
         for test_case_execution in test_case_executions:
-                # TODO: request correct TestCase from TestScriptManager
-                test_case_declaration = self.__test_case_declaration(
-                    test_case_execution.public_id,
-                    test_suite_declaration=test_suite_declaration,
-                )
-                TestCaseClass = test_case_declaration.class_ref
-                test_case = TestCaseClass(test_case_execution=test_case_execution)
-                self.create_pending_teststeps_execution(
-                    db, test_case, test_case_execution
-                )
-                test_suite.test_cases.append(test_case)
+            # TODO: request correct TestCase from TestScriptManager
+            test_case_declaration = self.__test_case_declaration(
+                test_case_execution.public_id,
+                test_suite_declaration=test_suite_declaration,
+            )
+            TestCaseClass = test_case_declaration.class_ref
+            test_case = TestCaseClass(test_case_execution=test_case_execution)
+            self.create_pending_teststeps_execution(db, test_case, test_case_execution)
+            test_suite.test_cases.append(test_case)
 
     def create_pending_teststeps_execution(
         self,

--- a/test_collections/matter/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/rpc_client/test_harness_client.py
@@ -23,7 +23,7 @@ import sys
 from contextlib import redirect_stdout
 from multiprocessing.managers import BaseManager
 
-from matter.testing.commissioning import CommissionDeviceTest
+from matter.testing.CommissioningPreTest import CommissionDeviceTest
 from matter.testing.matter_testing import MatterTestConfig
 from matter.testing.runner import (
     TestStep,

--- a/test_collections/matter/sdk_tests/support/sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/sdk_container.py
@@ -64,6 +64,7 @@ LOCAL_RPC_PYTHON_TESTING_PATH = Path(
 )
 DOCKER_RPC_PYTHON_TESTING_PATH = "/root/python_testing/scripts/sdk/matter_testing_infrastructure/chip/testing/test_harness_client.py"  # noqa
 
+
 class SDKContainerNotRunning(Exception):
     """Raised when we attempt to use the docker container, but it is not running"""
 


### PR DESCRIPTION
## Description

Removes the `nodejs`/`npm`/`cspell` install step from the backend `Dockerfile`. `npm install -g npm@latest` now resolves to an npm release that requires Node >=22.22.2, incompatible with the Node 20.x installed a few lines above — this broke the backend image build with `npm error EBADENGINE` (see #1044).

Spell checking already runs independently in CI via `streetsidesoftware/cspell-action` (`.github/workflows/spell-check.yml`), and `scripts/lint.sh` — the only in-repo consumer of the `cspell` CLI — is only ever invoked by developers locally, never at container build or runtime. So node/npm/cspell don't need to be baked into the runtime image at all.

## Type of change

- [x] Bug fix

## Related issue

Fixes [#1044](https://github.com/project-chip/certification-tool/issues/1044)

## Testing

Removed the four `RUN` lines; no other script in the repo (build, prestart, CI) references `nodejs`/`npm`/`cspell` inside the container. Requesting a fresh image build/install run to confirm the fix (Docker not available in this dev environment).
