### PR TITLE
Fix: remove incompatible nodejs/npm/cspell install from Dockerfile (cherry-pick #340)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,12 +61,6 @@ RUN curl -sSL https://install.python-poetry.org | python3 - && \
 # Install Docker
 RUN curl -sSL https://get.docker.com/ | sh
 
-# Install nodejs, npm and spell checker
-RUN curl -sL https://deb.nodesource.com/setup_20.x | bash -
-RUN apt-get install -y nodejs
-RUN npm install -g npm@latest
-RUN npm install -g cspell@latest
-
 # Allow installing dev dependencies to run tests
 # Copy poetry dependecy files and install dependencies
 # We copy install dependencies before copying all app source to reuse the dependency install step in docker.


### PR DESCRIPTION
## Description

Cherry-picks the Dockerfile fix from #340 (`v2.15.1-develop`) onto `v2.16-develop`.

`npm install -g npm@latest` now resolves to an npm release requiring Node >=22.22.2, incompatible with the Node 20.x installed in the `Dockerfile`, breaking the backend image build with `npm error EBADENGINE` (#1044).

Spell checking already runs independently in CI via `streetsidesoftware/cspell-action` (`.github/workflows/spell-check.yml`), and `scripts/lint.sh` — the only in-repo consumer of the `cspell` CLI — is only ever invoked by developers locally, never at container build or runtime. So node/npm/cspell don't need to be baked into the runtime image at all.

Note: `v2.16-develop` already has the separate `CommissionDeviceTest` import fix (#335), so only the Dockerfile change from #340 is cherry-picked here — the rest of #340 (flake8 cleanup, import fix) is either already present or not applicable to this branch.

## Type of change

- [x] Bug fix

## Related issue

Fixes #1044

## Testing

Cherry-picked cleanly, no conflicts. Docker not available in this dev environment — requesting a fresh install/build run to confirm.
