### PR TITLE
[Refactor] Use the sdk container for PICS file parsing

### DIFF
--- a/app/api/api_v1/endpoints/projects.py
+++ b/app/api/api_v1/endpoints/projects.py
@@ -233,8 +233,8 @@ def unarchive_project(
     return crud.project.unarchive(db=db, db_obj=__project(db=db, id=id))
 
 
-def __upload_pics(file: UploadFile, db: Session, project: Project) -> Project:
-    cluster = PICSParser.parse(file=file.file)
+async def __upload_pics(file: UploadFile, db: Session, project: Project) -> Project:
+    cluster = await PICSParser.parse(file=file.file)
 
     project.pics.clusters[cluster.name] = cluster
 
@@ -282,7 +282,7 @@ async def upload_pics(
         if file and file.filename and file.filename.startswith(DMP_TEST_SKIP_FILENAME):
             return __persist_dmp_test_skip(file=file, db=db, project=project)
         else:
-            return __upload_pics(file=file, db=db, project=project)
+            return await __upload_pics(file=file, db=db, project=project)
     except PICSError as e:
         raise HTTPException(
             status_code=HTTPStatus.UNPROCESSABLE_ENTITY,

--- a/app/container_manager/container_manager.py
+++ b/app/container_manager/container_manager.py
@@ -185,7 +185,7 @@ class ContainerManager(object, metaclass=Singleton):
             logger.error(f"Unexpected error: {e}")
             raise
 
-    def copy_file_to_container(
+    def copy_archive_to_container(
         self,
         container: Container,
         host_file_path: Path,
@@ -224,5 +224,40 @@ class ContainerManager(object, metaclass=Singleton):
             logger.error(f"Unexpected error: {e}")
             raise
 
+    def copy_file_to_container(
+            self,
+            container: Container,
+            host_file_path: Path,
+            destination_container_path: Path,
+        ) -> None:
+            try:
+                if settings.ENABLE_CONTAINER_LOGS:
+                    logger.info(
+                        "### File Copy: HOST->CONTAINER"
+                        f" From Host Path: {str(host_file_path)}"
+                        f" To Container Path: {destination_container_path}"
+                        f" Container Name: {str(container.name)}"
+                    )
+
+                    shell_cmd = docker_cp_to_container_command(
+                        container.name, host_file_path, destination_container_path
+                    )
+                    logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
+
+                tar_stream = io.BytesIO()
+
+                with tarfile.open(fileobj=tar_stream, mode="w") as tar_out:
+                    tar_out.add(host_file_path, arcname=host_file_path.name)
+
+                # Prepare the tar file
+                tar_stream.seek(0)
+                container.put_archive(f"{destination_container_path.parent}", tar_stream)
+
+            except docker.errors.APIError as e:
+                logger.error(f"Error while accessing the Docker API: {e}")
+                raise
+            except Exception as e:
+                logger.error(f"Unexpected error: {e}")
+                raise
 
 container_manager: ContainerManager = ContainerManager()

--- a/app/container_manager/container_manager.py
+++ b/app/container_manager/container_manager.py
@@ -206,6 +206,7 @@ class ContainerManager(object, metaclass=Singleton):
                 logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
 
             tar_stream = io.BytesIO()
+            # tarfile.open can handle regular files, but `getmembers` will fail for non-archives
             with tarfile.open(f"{host_file_path}", mode="r") as tar_in:
                 with tarfile.open(fileobj=tar_stream, mode="w") as tar_out:
                     for member in tar_in.getmembers():
@@ -225,39 +226,40 @@ class ContainerManager(object, metaclass=Singleton):
             raise
 
     def copy_file_to_container(
-            self,
-            container: Container,
-            host_file_path: Path,
-            destination_container_path: Path,
-        ) -> None:
-            try:
-                if settings.ENABLE_CONTAINER_LOGS:
-                    logger.info(
-                        "### File Copy: HOST->CONTAINER"
-                        f" From Host Path: {str(host_file_path)}"
-                        f" To Container Path: {destination_container_path}"
-                        f" Container Name: {str(container.name)}"
-                    )
+        self,
+        container: Container,
+        host_file_path: Path,
+        destination_container_path: Path,
+    ) -> None:
+        try:
+            if settings.ENABLE_CONTAINER_LOGS:
+                logger.info(
+                    "### File Copy: HOST->CONTAINER"
+                    f" From Host Path: {str(host_file_path)}"
+                    f" To Container Path: {destination_container_path}"
+                    f" Container Name: {str(container.name)}"
+                )
 
-                    shell_cmd = docker_cp_to_container_command(
-                        container.name, host_file_path, destination_container_path
-                    )
-                    logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
+                shell_cmd = docker_cp_to_container_command(
+                    container.name, host_file_path, destination_container_path
+                )
+                logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
 
-                tar_stream = io.BytesIO()
+            tar_stream = io.BytesIO()
 
-                with tarfile.open(fileobj=tar_stream, mode="w") as tar_out:
-                    tar_out.add(host_file_path, arcname=host_file_path.name)
+            with tarfile.open(fileobj=tar_stream, mode="w") as tar_out:
+                tar_out.add(host_file_path, arcname=destination_container_path.name)
 
-                # Prepare the tar file
-                tar_stream.seek(0)
-                container.put_archive(f"{destination_container_path.parent}", tar_stream)
+            # Prepare the tar file
+            tar_stream.seek(0)
+            container.put_archive(f"{destination_container_path.parent}", tar_stream)
 
-            except docker.errors.APIError as e:
-                logger.error(f"Error while accessing the Docker API: {e}")
-                raise
-            except Exception as e:
-                logger.error(f"Unexpected error: {e}")
-                raise
+        except docker.errors.APIError as e:
+            logger.error(f"Error while accessing the Docker API: {e}")
+            raise
+        except Exception as e:
+            logger.error(f"Unexpected error: {e}")
+            raise
+
 
 container_manager: ContainerManager = ContainerManager()

--- a/app/container_manager/container_manager.py
+++ b/app/container_manager/container_manager.py
@@ -206,7 +206,8 @@ class ContainerManager(object, metaclass=Singleton):
                 logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
 
             tar_stream = io.BytesIO()
-            # tarfile.open can handle regular files, but `getmembers` will fail for non-archives
+            # tarfile.open can handle regular files, but `getmembers`
+            # will fail for non-archives
             with tarfile.open(f"{host_file_path}", mode="r") as tar_in:
                 with tarfile.open(fileobj=tar_stream, mode="w") as tar_out:
                     for member in tar_in.getmembers():

--- a/app/pics/pics_parser.py
+++ b/app/pics/pics_parser.py
@@ -15,7 +15,6 @@
 #
 import xml.etree.ElementTree as ET
 from typing import IO
-from xml.etree.ElementTree import Element
 
 from loguru import logger
 
@@ -26,44 +25,59 @@ class PICSParser:
     """Parse PICS XML file"""
 
     @classmethod
-    def parse(cls, file: IO) -> PICSCluster:
-        logger.debug(f"Begin parsing {file.name}")
-        root_element = cls.__find_root_element(file=file)
-        cluster_name = cls.__text_for_element_child(root_element, "name")
-        cluster: PICSCluster = PICSCluster(name=cluster_name)
+    def __get_text_for_element(cls, file: IO, element_name: str) -> str:
+        text: str = ""
+        for _, elem in ET.iterparse(file):
+            if elem.tag == element_name:
+                text = elem.text
+                break
 
-        for pics_item_element in root_element.iter("picsItem"):
-            pics_item = cls.__pics_item(pics_item_element)
-            cluster.items[pics_item.number] = pics_item
-
-        logger.debug(f"Total PICS found - {len(cluster.items.keys())}")
-        return cluster
-
-    @classmethod
-    def __find_root_element(cls, file: IO) -> Element:
-        root_element = ET.parse(file).getroot()
-        # Verify that root element tag is on of the supported ones.
-        if root_element.tag not in ["clusterPICS", "generalPICS"]:
-            raise PICSError("Parser failed to find root tag")
-        return root_element
+        if text:
+            file.seek(0) # reset the file
+            return text
+        else:
+            raise PICSError(f"Unable to locate element {element_name}")
 
     @classmethod
-    def __text_for_element_child(
-        cls, parent_element: Element, element_name: str
-    ) -> str:
-        logger.debug(f"Finding element {element_name}")
-        element = parent_element.find(element_name)
-        if element is None:
-            raise PICSError(f"Parser failed to find element {element_name}")
-        if element.text is None:
-            raise PICSError(
-                f"Parser failed to find text field in element {element_name}"
+    async def parse(cls, file: IO) -> PICSCluster:
+        """Parse PICS XML using the sdk container by getting the command string from parse_pics_command"""
+        from test_collections.matter.sdk_tests.support.pics import parse_pics_command, PICS_FILE_PATH
+        from test_collections.matter.sdk_tests.support.sdk_container import SDKContainer
+        from json import loads
+        from pathlib import Path
+
+        # Unfortunately, we still have to do some parsing here to get the cluster name.
+        # Tests don't care about this, but the test harness uses it for display/update purposes.
+        cluster_name = cls.__get_text_for_element(file, "name")
+        logger.debug(f"Parsed cluster name {cluster_name}")
+
+        TMP_PICS_PATH = Path(PICS_FILE_PATH+".xml")
+
+        result = None
+        async with SDKContainer() as sdk_container:
+            # make a local copy of the file contents
+            with open(TMP_PICS_PATH, "wb") as outfile:
+                outfile.write(file.read())
+
+            sdk_container.copy_file_to_container(TMP_PICS_PATH, TMP_PICS_PATH)
+            prefix, cmd = parse_pics_command()
+            logger.debug(f"Executing command: {prefix} {cmd}")
+
+            result = sdk_container.send_command(
+                command = cmd, prefix = prefix
             )
-        return element.text
 
-    @classmethod
-    def __pics_item(cls, element: Element) -> PICSItem:
-        supported = cls.__text_for_element_child(element, "support")
-        is_supported = supported.lower() == "true"
-        item_number = cls.__text_for_element_child(element, "itemNumber")
-        return PICSItem(number=item_number, enabled=is_supported)
+            # cleanup
+            TMP_PICS_PATH.unlink(missing_ok=True)
+
+        # output parsing/coercing
+        output: str = result.output.decode('utf-8')
+        if result and 0 != result.exit_code:
+            raise PICSError(
+                f"Parser failed to read file: {output}"
+            )
+        logger.debug(f"Command result: {output}")
+
+        raw_dict: dict[str, bool] = loads(output)
+        pics_dict: dict[str, PICSItem] = {k: PICSItem(number = k, enabled = v) for k, v in raw_dict.items()}
+        return PICSCluster(name=cluster_name, items=pics_dict)

--- a/app/pics/pics_parser.py
+++ b/app/pics/pics_parser.py
@@ -33,7 +33,7 @@ class PICSParser:
                 break
 
         if text:
-            file.seek(0) # reset the file
+            file.seek(0)  # reset the file
             return text
         else:
             raise PICSError(f"Unable to locate element {element_name}")
@@ -46,38 +46,45 @@ class PICSParser:
         from json import loads
         from pathlib import Path
 
-        # Unfortunately, we still have to do some parsing here to get the cluster name.
-        # Tests don't care about this, but the test harness uses it for display/update purposes.
-        cluster_name = cls.__get_text_for_element(file, "name")
-        logger.debug(f"Parsed cluster name {cluster_name}")
+        TMP_PICS_PATH = Path(PICS_FILE_PATH+f"{id(file)}.xml")
 
-        TMP_PICS_PATH = Path(PICS_FILE_PATH+".xml")
+        sdk_container = SDKContainer()
+        await sdk_container.start()
+        try:
+            # Unfortunately, we still have to do some parsing here to get the cluster name.
+            # Tests don't care about this, but the test harness uses it for display/update purposes.
+            cluster_name = cls.__get_text_for_element(file, "name")
+            logger.debug(f"Parsed cluster name {cluster_name}")
 
-        result = None
-        async with SDKContainer() as sdk_container:
             # make a local copy of the file contents
+            content = file.read()
+            if isinstance(content, str):
+                content = content.encode('utf-8')
             with open(TMP_PICS_PATH, "wb") as outfile:
-                outfile.write(file.read())
+                outfile.write(content)
 
             sdk_container.copy_file_to_container(TMP_PICS_PATH, TMP_PICS_PATH)
-            prefix, cmd = parse_pics_command()
+            prefix, cmd = parse_pics_command(TMP_PICS_PATH)
             logger.debug(f"Executing command: {prefix} {cmd}")
 
             result = sdk_container.send_command(
-                command = cmd, prefix = prefix
+                command=cmd, prefix=prefix
             )
 
             # cleanup
             TMP_PICS_PATH.unlink(missing_ok=True)
 
-        # output parsing/coercing
-        output: str = result.output.decode('utf-8')
-        if result and 0 != result.exit_code:
-            raise PICSError(
-                f"Parser failed to read file: {output}"
-            )
-        logger.debug(f"Command result: {output}")
+            # output parsing/coercing
+            if result and 0 != result.exit_code:
+                raise PICSError(
+                    f"Parser failed to read file: {result.output.decode('utf-8')}"
+                )
+            output: str = result.output.decode('utf-8')
+            logger.debug(f"Command result: {output}")
 
-        raw_dict: dict[str, bool] = loads(output)
-        pics_dict: dict[str, PICSItem] = {k: PICSItem(number = k, enabled = v) for k, v in raw_dict.items()}
-        return PICSCluster(name=cluster_name, items=pics_dict)
+            raw_dict: dict[str, bool] = loads(output)
+            pics_dict: dict[str, PICSItem] = {k: PICSItem(
+                number=k, enabled=v) for k, v in raw_dict.items()}
+            return PICSCluster(name=cluster_name, items=pics_dict)
+        finally:
+            sdk_container.destroy()

--- a/app/pics/pics_parser.py
+++ b/app/pics/pics_parser.py
@@ -41,12 +41,19 @@ class PICSParser:
     @classmethod
     async def parse(cls, file: IO) -> PICSCluster:
         """Parse PICS XML using the sdk container by getting the command string from parse_pics_command"""
-        from test_collections.matter.sdk_tests.support.pics import parse_pics_command, PICS_FILE_PATH
-        from test_collections.matter.sdk_tests.support.sdk_container import SDKContainer
         from json import loads
         from pathlib import Path
 
-        TMP_PICS_PATH = Path(PICS_FILE_PATH+f"{id(file)}.xml")
+        from test_collections.matter.sdk_tests.support.exec_run_in_container import (
+            ExecResultExtended,
+        )
+        from test_collections.matter.sdk_tests.support.pics import (
+            PICS_FILE_PATH,
+            parse_pics_command,
+        )
+        from test_collections.matter.sdk_tests.support.sdk_container import SDKContainer
+
+        TMP_PICS_PATH = Path(PICS_FILE_PATH + f"{id(file)}.xml")
 
         sdk_container = SDKContainer()
         await sdk_container.start()
@@ -59,7 +66,7 @@ class PICSParser:
             # make a local copy of the file contents
             content = file.read()
             if isinstance(content, str):
-                content = content.encode('utf-8')
+                content = content.encode("utf-8")
             with open(TMP_PICS_PATH, "wb") as outfile:
                 outfile.write(content)
 
@@ -67,7 +74,7 @@ class PICSParser:
             prefix, cmd = parse_pics_command(TMP_PICS_PATH)
             logger.debug(f"Executing command: {prefix} {cmd}")
 
-            result = sdk_container.send_command(
+            result: ExecResultExtended = sdk_container.send_command(
                 command=cmd, prefix=prefix
             )
 
@@ -79,12 +86,13 @@ class PICSParser:
                 raise PICSError(
                     f"Parser failed to read file: {result.output.decode('utf-8')}"
                 )
-            output: str = result.output.decode('utf-8')
+            output: str = result.output.decode("utf-8")
             logger.debug(f"Command result: {output}")
 
             raw_dict: dict[str, bool] = loads(output)
-            pics_dict: dict[str, PICSItem] = {k: PICSItem(
-                number=k, enabled=v) for k, v in raw_dict.items()}
+            pics_dict: dict[str, PICSItem] = {
+                k: PICSItem(number=k, enabled=v) for k, v in raw_dict.items()
+            }
             return PICSCluster(name=cluster_name, items=pics_dict)
         finally:
             sdk_container.destroy()

--- a/app/tests/pics/test_pics_parser.py
+++ b/app/tests/pics/test_pics_parser.py
@@ -19,11 +19,11 @@ from app.pics.pics_parser import PICSParser
 from app.schemas.pics import PICSError
 
 
-def test_pics_parser() -> None:
+async def test_pics_parser() -> None:
     pics_file = (
         Path(__file__).parent.parent.parent / "tests" / "utils" / "test_pics.xml"
     )
-    cluster = PICSParser.parse(file=pics_file.open())
+    cluster = await PICSParser.parse(file=pics_file.open())
 
     assert cluster is not None
     assert cluster.name == "On/Off"
@@ -35,7 +35,7 @@ def test_pics_parser() -> None:
     assert cluster.items["OO.S.C00"].enabled is True
 
 
-def test_pics_parser_with_errors() -> None:
+async def test_pics_parser_with_errors() -> None:
     # test pics parse with invalid root tag
     pics_file = (
         Path(__file__).parent.parent.parent
@@ -45,7 +45,7 @@ def test_pics_parser_with_errors() -> None:
     )
 
     try:
-        PICSParser.parse(file=pics_file.open())
+        await PICSParser.parse(file=pics_file.open())
 
     except Exception as e:
         assert isinstance(e, PICSError)
@@ -59,7 +59,7 @@ def test_pics_parser_with_errors() -> None:
     )
 
     try:
-        PICSParser.parse(file=pics_file.open())
+        await PICSParser.parse(file=pics_file.open())
 
     except Exception as e:
         assert isinstance(e, PICSError)
@@ -73,7 +73,7 @@ def test_pics_parser_with_errors() -> None:
     )
 
     try:
-        PICSParser.parse(file=pics_file.open())
+        await PICSParser.parse(file=pics_file.open())
 
     except Exception as e:
         assert isinstance(e, PICSError)

--- a/test_collections/matter/sdk_tests/support/pics.py
+++ b/test_collections/matter/sdk_tests/support/pics.py
@@ -22,7 +22,9 @@ PICS_FILE_PATH = "/var/tmp/pics"
 ECHO_COMMAND = "echo"
 PYTHON_COMMAND = "python3"
 PYTHON_OPTION = "-c"
-PICS_PARSER_DOCKER_PATH = "python_testing/scripts/sdk/matter_testing_infrastructure/matter/testing/pics"
+PICS_PARSER_DOCKER_PATH = (
+    "python_testing/scripts/sdk/matter_testing_infrastructure/matter/testing/pics"
+)
 # List of default PICS which needs to set specifically in TH are added here.
 # These PICS are applicable for CI / Chip tool testing purposes only.
 # These PICS are unknown / not visible to external users.
@@ -63,7 +65,7 @@ def set_pics_command(pics: PICS) -> tuple[str, str]:
     return (prefix, cmd)
 
 
-def parse_pics_command(tmp_file_name) -> tuple[str, str]:
+def parse_pics_command(tmp_file_name: str) -> tuple[str, str]:
     prefix = f"{PYTHON_COMMAND} {PYTHON_OPTION}"
     PARSE_PICS_MINI_SCRIPT = f"""
 import importlib

--- a/test_collections/matter/sdk_tests/support/pics.py
+++ b/test_collections/matter/sdk_tests/support/pics.py
@@ -62,14 +62,15 @@ def set_pics_command(pics: PICS) -> tuple[str, str]:
 
     return (prefix, cmd)
 
-def parse_pics_command() -> tuple[str, str]:
+
+def parse_pics_command(tmp_file_name) -> tuple[str, str]:
     prefix = f"{PYTHON_COMMAND} {PYTHON_OPTION}"
     PARSE_PICS_MINI_SCRIPT = f"""
 import importlib
 import json
 pics_util = importlib.import_module('{PICS_PARSER_DOCKER_PATH}'.replace('/','.'))
 
-pics = pics_util.parse_pics_xml(open('{PICS_FILE_PATH}'+'.xml').read())
+pics = pics_util.parse_pics_xml(open('{tmp_file_name}').read())
 print(json.dumps(pics))
 """
 

--- a/test_collections/matter/sdk_tests/support/pics.py
+++ b/test_collections/matter/sdk_tests/support/pics.py
@@ -20,6 +20,9 @@ SHELL_PATH = "/bin/sh"
 SHELL_OPTION = "-c"
 PICS_FILE_PATH = "/var/tmp/pics"
 ECHO_COMMAND = "echo"
+PYTHON_COMMAND = "python3"
+PYTHON_OPTION = "-c"
+PICS_PARSER_DOCKER_PATH = "python_testing/scripts/sdk/matter_testing_infrastructure/matter/testing/pics"
 # List of default PICS which needs to set specifically in TH are added here.
 # These PICS are applicable for CI / Chip tool testing purposes only.
 # These PICS are unknown / not visible to external users.
@@ -57,4 +60,18 @@ def set_pics_command(pics: PICS) -> tuple[str, str]:
     prefix = f"{SHELL_PATH} {SHELL_OPTION}"
     cmd = f"\"{ECHO_COMMAND} '{pics_codes}' > {PICS_FILE_PATH}\""
 
+    return (prefix, cmd)
+
+def parse_pics_command() -> tuple[str, str]:
+    prefix = f"{PYTHON_COMMAND} {PYTHON_OPTION}"
+    PARSE_PICS_MINI_SCRIPT = f"""
+import importlib
+import json
+pics_util = importlib.import_module('{PICS_PARSER_DOCKER_PATH}'.replace('/','.'))
+
+pics = pics_util.parse_pics_xml(open('{PICS_FILE_PATH}'+'.xml').read())
+print(json.dumps(pics))
+"""
+
+    cmd = '"' + PARSE_PICS_MINI_SCRIPT + '"'
     return (prefix, cmd)

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -304,7 +304,7 @@ async def should_perform_new_commissioning(
 
             storage_path = __retrieve_storage_path(config)
 
-            sdk_container.copy_file_to_container(
+            sdk_container.copy_archive_to_container(
                 host_file_path=ADMIN_STORAGE_FILE_HOST,
                 destination_container_path=storage_path,
             )

--- a/test_collections/matter/sdk_tests/support/sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/sdk_container.py
@@ -35,6 +35,8 @@ from test_collections.matter.config import matter_settings
 from .exec_run_in_container import ExecResultExtended, exec_run_in_container
 from .pics import set_pics_command
 
+REPO_ROOT = Path(__file__).resolve().parents[5]
+
 # Trace mount
 LOCAL_LOGS_PATH = Path("/var/tmp")
 DOCKER_LOGS_PATH = "/logs"
@@ -219,6 +221,13 @@ class SDKContainer(metaclass=Singleton):
             container_manager.destroy(self.__container)
         self.__container = None
 
+    async def __aenter__(self):
+        await self.start()
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.destroy()
+
     def send_command(
         self,
         command: Union[str, list],
@@ -311,6 +320,15 @@ class SDKContainer(metaclass=Singleton):
             container_file_path=container_file_path,
             destination_path=destination_path,
             destination_file_name=destination_file_name,
+        )
+
+    def copy_archive_to_container(
+        self, host_file_path: Path, destination_container_path: Path
+    ) -> None:
+        container_manager.copy_archive_to_container(
+            container=self.__container,
+            host_file_path=host_file_path,
+            destination_container_path=destination_container_path,
         )
 
     def copy_file_to_container(

--- a/test_collections/matter/sdk_tests/support/sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/sdk_container.py
@@ -221,13 +221,6 @@ class SDKContainer(metaclass=Singleton):
             container_manager.destroy(self.__container)
         self.__container = None
 
-    async def __aenter__(self):
-        await self.start()
-        return self
-
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        self.destroy()
-
     def send_command(
         self,
         command: Union[str, list],


### PR DESCRIPTION
The purpose of this PR is to reduce the number of places that we parse PICS files. A forthcoming PR for the CLI will also remove parsing there in favor of calling the backend API. Eventually, this should make it easier to support parsing different types of PICS files, like zipped archives, without reduplicated code in 3 different place