### PR TITLE
[Fix] Reuse of Admin Storage To Skip Commissioning 

### DIFF
--- a/app/container_manager/docker_shell_commands.py
+++ b/app/container_manager/docker_shell_commands.py
@@ -18,7 +18,7 @@ Utility functions to generate shell command equivalents for Docker API operation
 Useful for debugging and understanding what Docker operations are being performed.
 """
 from pathlib import Path
-from typing import Dict, List, Union
+from typing import Dict, List, Optional, Union
 
 # Log message constants
 SHELL_CMD_LOG_PREFIX = "Docker API call equivalent shell command:\n"
@@ -42,7 +42,7 @@ SHELL_SPECIAL_CHARS = [
 ]
 
 
-def escape_shell_arg(arg: str) -> str:
+def escape_shell_arg(arg: Optional[str]) -> str:
     """
     Escape shell argument if it contains spaces or special characters.
 
@@ -50,10 +50,17 @@ def escape_shell_arg(arg: str) -> str:
     are escaped using the pattern: ' becomes '\''
     (close quote, escaped quote, open quote).
 
+    Args:
+        arg: The argument to escape. Docker container/image names can be None
+            (e.g. a Container whose attrs have no "Name" key), so this is
+            tolerated and rendered as an empty string rather than raising.
+
     Returns:
         The argument wrapped in single quotes if it contains special characters,
         otherwise returns the argument unchanged.
     """
+    if arg is None:
+        return ""
     if any(c in arg for c in SHELL_SPECIAL_CHARS):
         # Escape any single quotes: ' becomes '\''
         escaped_arg = arg.replace("'", "'\\''")
@@ -193,7 +200,7 @@ def docker_exec_command(
     return " ".join(cmd_parts)
 
 
-def docker_kill_command(container_name: str) -> str:
+def docker_kill_command(container_name: Optional[str]) -> str:
     """
     Generate docker kill command.
 
@@ -206,7 +213,7 @@ def docker_kill_command(container_name: str) -> str:
     return f"docker kill {escape_shell_arg(container_name)}"
 
 
-def docker_stop_command(container_name: str) -> str:
+def docker_stop_command(container_name: Optional[str]) -> str:
     """
     Generate docker stop command.
 
@@ -219,7 +226,7 @@ def docker_stop_command(container_name: str) -> str:
     return f"docker stop {escape_shell_arg(container_name)}"
 
 
-def docker_rm_command(container_name: str, force: bool = False) -> str:
+def docker_rm_command(container_name: Optional[str], force: bool = False) -> str:
     """
     Generate docker rm command.
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 from enum import Enum
-from typing import Type, TypeVar
+from typing import Optional, Type, TypeVar
 
 from app.constants.shared_constants import DutPairingModeEnum
 from app.schemas.test_environment_config import ThreadAutoConfig
@@ -58,6 +58,7 @@ class PythonTestSuite(TestSuite):
     suite_name: str
     sdk_container: SDKContainer = SDKContainer(logger)
     border_router: ThreadBorderRouter = ThreadBorderRouter()
+    matter_config: Optional[TestEnvironmentConfigMatter] = None
 
     @classmethod
     def class_factory(
@@ -118,14 +119,16 @@ class PythonTestSuite(TestSuite):
     async def cleanup(self) -> None:
         logger.info("Suite Cleanup")
 
-        matter_config = getattr(self, "matter_config", None)
-        if matter_config is not None and self.sdk_container.is_running():
+        if self.matter_config is not None and self.sdk_container.is_running():
             try:
                 logger.info(
                     "Capturing latest admin_storage.json snapshot from container"
                 )
-                capture_admin_storage_file(matter_config, logger)
+                capture_admin_storage_file(self.matter_config, logger)
             except Exception as e:
+                # Deliberately broad Exception.
+                # The ideia is to never block container/border-router teardown below,
+                # so don't narrow this to specific exception types.
                 logger.warning(f"Could not capture admin_storage.json snapshot: {e}")
 
         logger.info("Stopping SDK container")
@@ -138,6 +141,7 @@ class PythonTestSuite(TestSuite):
 class CommissioningPythonTestSuite(PythonTestSuite, UserPromptSupport):
     async def setup(self) -> None:
         await super().setup()
+        assert self.matter_config is not None
 
         # If in BLE-Thread, NFC-Thread, or THREAD_MESHCOP mode and a Thread Auto-Config
         # was provided by the user, start a new OTBR container app with the according

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -30,6 +30,7 @@ from ...sdk_container import SDKContainer
 from ...utils import PromptOption, prompt_for_commissioning_mode
 from .utils import (
     DUTCommissioningError,
+    capture_admin_storage_file,
     commission_device,
     should_perform_new_commissioning,
 )
@@ -116,6 +117,16 @@ class PythonTestSuite(TestSuite):
 
     async def cleanup(self) -> None:
         logger.info("Suite Cleanup")
+
+        matter_config = getattr(self, "matter_config", None)
+        if matter_config is not None and self.sdk_container.is_running():
+            try:
+                logger.info(
+                    "Capturing latest admin_storage.json snapshot from container"
+                )
+                capture_admin_storage_file(matter_config, logger)
+            except Exception as e:
+                logger.warning(f"Could not capture admin_storage.json snapshot: {e}")
 
         logger.info("Stopping SDK container")
         self.sdk_container.destroy()

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -207,6 +207,17 @@ def __copy_admin_storage_file(
     )
 
 
+def capture_admin_storage_file(
+    config: TestEnvironmentConfigMatter,
+    logger: loguru.Logger,
+) -> None:
+    """Re-capture admin_storage.json from the still-running container to the host
+    snapshot, so the snapshot reflects the message counters as they stood at the end
+    of this run rather than only as they stood right after the last commissioning.
+    """
+    __copy_admin_storage_file(config, logger)
+
+
 def log_test_output_file(logger: loguru.Logger) -> None:
     """Log the entire content of test_output.txt file.
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -273,7 +273,10 @@ async def commission_device(
     logger.info("---- End of commissioning test output ----")
 
     # Copy admin_storage.json file from container, in case the user wants to
-    # reuse this information in the next execution
+    # reuse this information in the next execution. This duplicates the capture
+    # PythonTestSuite.cleanup() does unconditionally at the end of the suite run,
+    # but is kept intentionally: if the container is torn down abnormally before
+    # cleanup() runs, this is the only snapshot that survives.
     __copy_admin_storage_file(config, logger)
 
 

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
@@ -478,6 +478,37 @@ async def test_cleanup_captures_admin_storage_before_destroy() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cleanup_skips_capture_when_container_not_running() -> None:
+    """If the container already died mid-suite, cleanup should skip the capture
+    attempt (nothing to copy from) rather than attempting it against a dead
+    container, but should still tear down the container and border router."""
+    suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
+        suite_type=SuiteType.COMMISSIONING,
+        name="SomeSuite",
+        python_test_version="Some version",
+        mandatory=False,
+    )
+    suite_instance = suite_class(TestSuiteExecution())
+    suite_instance.matter_config = mock.Mock()
+
+    with mock.patch.object(
+        target=suite_instance.sdk_container, attribute="is_running", return_value=False
+    ), mock.patch.object(
+        target=suite_instance.sdk_container, attribute="destroy"
+    ) as mock_destroy, mock.patch.object(
+        target=suite_instance.border_router, attribute="destroy_device"
+    ) as mock_destroy_device, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".capture_admin_storage_file"
+    ) as mock_capture:
+        await suite_instance.cleanup()
+
+    mock_capture.assert_not_called()
+    mock_destroy.assert_called_once()
+    mock_destroy_device.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_cleanup_skips_capture_when_matter_config_not_set() -> None:
     """If setup failed before matter_config was assigned, cleanup should skip the
     capture attempt (no config to resolve a storage path from) but still tear down

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
@@ -445,6 +445,97 @@ async def test_should_perform_new_commissioning_yes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_cleanup_captures_admin_storage_before_destroy() -> None:
+    """Issue #1070: cleanup should re-capture admin_storage.json from the
+    still-running container before the container is destroyed, so the host
+    snapshot reflects this run's advanced message counters, not just the
+    counters from the original commissioning."""
+    suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
+        suite_type=SuiteType.COMMISSIONING,
+        name="SomeSuite",
+        python_test_version="Some version",
+        mandatory=False,
+    )
+    suite_instance = suite_class(TestSuiteExecution())
+    suite_instance.matter_config = mock.Mock()
+
+    with mock.patch.object(
+        target=suite_instance.sdk_container, attribute="is_running", return_value=True
+    ), mock.patch.object(
+        target=suite_instance.sdk_container, attribute="destroy"
+    ) as mock_destroy, mock.patch.object(
+        target=suite_instance.border_router, attribute="destroy_device"
+    ), mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".capture_admin_storage_file"
+    ) as mock_capture:
+        await suite_instance.cleanup()
+
+    mock_capture.assert_called_once_with(
+        suite_instance.matter_config, test_engine_logger
+    )
+    mock_destroy.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_skips_capture_when_matter_config_not_set() -> None:
+    """If setup failed before matter_config was assigned, cleanup should skip the
+    capture attempt (no config to resolve a storage path from) but still tear down
+    the container and border router."""
+    suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
+        suite_type=SuiteType.COMMISSIONING,
+        name="SomeSuite",
+        python_test_version="Some version",
+        mandatory=False,
+    )
+    suite_instance = suite_class(TestSuiteExecution())
+
+    with mock.patch.object(
+        target=suite_instance.sdk_container, attribute="destroy"
+    ) as mock_destroy, mock.patch.object(
+        target=suite_instance.border_router, attribute="destroy_device"
+    ) as mock_destroy_device, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".capture_admin_storage_file"
+    ) as mock_capture:
+        await suite_instance.cleanup()
+
+    mock_capture.assert_not_called()
+    mock_destroy.assert_called_once()
+    mock_destroy_device.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_cleanup_still_destroys_container_when_capture_fails() -> None:
+    """A capture failure must never prevent container/border-router teardown, and
+    must not be reported as a suite-level error."""
+    suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
+        suite_type=SuiteType.COMMISSIONING,
+        name="SomeSuite",
+        python_test_version="Some version",
+        mandatory=False,
+    )
+    suite_instance = suite_class(TestSuiteExecution())
+    suite_instance.matter_config = mock.Mock()
+
+    with mock.patch.object(
+        target=suite_instance.sdk_container, attribute="is_running", return_value=True
+    ), mock.patch.object(
+        target=suite_instance.sdk_container, attribute="destroy"
+    ) as mock_destroy, mock.patch.object(
+        target=suite_instance.border_router, attribute="destroy_device"
+    ) as mock_destroy_device, mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".capture_admin_storage_file",
+        side_effect=RuntimeError("boom"),
+    ):
+        await suite_instance.cleanup()
+
+    mock_destroy.assert_called_once()
+    mock_destroy_device.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_should_perform_new_commissioning_no() -> None:
     """Test that when should_perform_new_commissioning returns False,
     the setup process skips the new commissioning.

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -31,6 +31,7 @@ from ...python_testing.models.utils import (
     EXECUTABLE,
     RUNNER_CLASS_PATH,
     DUTCommissioningError,
+    capture_admin_storage_file,
     commission_device,
     generate_command_arguments,
 )
@@ -561,6 +562,37 @@ async def test_commission_device_failure() -> None:
         expected_command, prefix=EXECUTABLE, is_stream=True, is_socket=False
     )
     mock_handle_logs.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests for capture_admin_storage_file (re-snapshot at suite cleanup, issue #1070)
+# ---------------------------------------------------------------------------
+
+
+def test_capture_admin_storage_file_copies_from_container() -> None:
+    sdk_container: SDKContainer = SDKContainer()
+
+    with mock.patch.object(
+        target=sdk_container, attribute="copy_file_from_container"
+    ) as mock_copy:
+        capture_admin_storage_file(
+            default_environment_config, test_engine_logger  # type: ignore
+        )
+
+    mock_copy.assert_called_once()
+
+
+def test_capture_admin_storage_file_propagates_exceptions() -> None:
+    sdk_container: SDKContainer = SDKContainer()
+
+    with mock.patch.object(
+        target=sdk_container,
+        attribute="copy_file_from_container",
+        side_effect=RuntimeError("boom"),
+    ), pytest.raises(RuntimeError):
+        capture_admin_storage_file(
+            default_environment_config, test_engine_logger  # type: ignore
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes: https://github.com/project-chip/certification-tool/issues/1070
---

## Description

  Fixes the `admin_storage.json` counter-staleness half of #1070.

  `admin_storage.json` was only ever snapshotted to the host right after a fresh commissioning. Any test suite run that reused a previous commissioning restored that same original snapshot — never one reflecting counters as they stood after
  later test activity. This caused the DUT to see message counters go backwards on reuse, which it correctly (and problematically, for us) flags as a replay.

  This PR makes the harness re-capture `admin_storage.json` from the container at the end of every suite run (suite `cleanup()`, right before the container is destroyed), in addition to the existing capture right after commissioning. The host
  snapshot now always reflects the most recently advanced counters, whether or not that run recommissioned.

  ### Changes
  - `utils.py`: new `capture_admin_storage_file()`, a public wrapper around the existing private copy helper.
  - `test_suite.py`: `PythonTestSuite.cleanup()` now calls it before `sdk_container.destroy()`, guarded against `matter_config` never being set, and wrapped so a capture failure can never block teardown or fail the run.
  - Unit tests covering the happy path, the skip-when-unset case, and the capture-fails-but-teardown-still-runs case.

  ## Validation against the reported repro (TC-ACE-1.6 / TC-SC-5.2)

  Manually re-tested this fix against the exact reproduction in the issue (run once, then reuse commissioning, then run again). Findings, in case they're useful to whoever picks this up next:

  - **With this fix applied, and using a side-loaded copy of `TC_ACE_1_6.py` patched to de-duplicate its `GroupcastTesting` event waits, all runs pass reliably** — fresh commissioning and reused commissioning alike.
  - **This fix alone, against the unmodified upstream `TC_ACE_1_6.py`/`TC_SC_5_2.py`, is not sufficient.** Those scripts have a separate, pre-existing bug: several steps call the plain `wait_for_event_report(...)` on the `GroupcastTesting` 
  event, which pops whatever event is next in the queue without checking it actually corresponds to the command that step just sent. Real-hardware multicast delivery can produce duplicate events for a single group command, and those duplicates 
  sit in the queue and get consumed by a *later*, unrelated step — producing intermittent, non-deterministic failures unrelated to this counter-staleness bug.

    This isn't speculation on our part — the script's own author already flags it, twice:

    > "NOTE: WARNING - Multicast is not always reliable when testing over Wi-Fi, and the test currently does not implement retries. If the test fails (likely due to timeouts on operations such as receiving events), Try the test again from 
  factory reset a few times." (`TC_ACE_1_6.py`, module header)

    > "Duplicate events could occur from step 20d, as this is an event emitted from a point where the message cannot be decrypted (because of no group keys being present)... duplicate groupcast testing events can occur in certain cases (i.e. 
  when testing over multiple networks). This safely filters through potential duplicate events from the previous steps." (`TC_ACE_1_6.py`, step 20g)

    Step 20g has a working fix for exactly this (`wait_for_event_report_with_duplication`) — it's just not applied to the other affected call sites in either script. Full write-up with logs and the exact patch tested is attached to the issue.

  **This PR is the complete fix for what's addressable in this repo.** The event-duplication issue lives in the upstream SDK's test scripts (`connectedhomeip/src/python_testing`), not here, and per the header comment above, the SDK authors 
  already know retries are sometimes needed on real Wi-Fi hardware — there's nothing further to change on the certification-tool-backend side for that half of the problem.

  A generalized version of the dedup fix (filter on "current = the result this step expects, previous = anything else," applied uniformly across all the affected `GroupcastTesting` waits in both scripts) was validated locally and resolves the 
  intermittent failures. It's included in the linked write-up as a suggestion for the SDK scripts team to evaluate — it's their call whether it fits the test's intent, not something we're asserting should be merged as-is.

Attaching my **custom** version of the TC_ACE_1.6 to be verified if needed:
[TC_ACE_1_6_custom.py](https://github.com/user-attachments/files/31075561/TC_ACE_1_6_custom.py)