### PR TITLE
[CP] Improve OTBR startup/shutdown reliability and diagnostics (#1071) (#348)

### DIFF
--- a/app/container_manager/container_manager.py
+++ b/app/container_manager/container_manager.py
@@ -31,6 +31,7 @@ from app.container_manager.docker_shell_commands import (
     docker_kill_command,
     docker_rm_command,
     docker_run_command,
+    docker_stop_command,
 )
 from app.core.config import settings
 from app.singleton import Singleton
@@ -55,13 +56,35 @@ class ContainerManager(object, metaclass=Singleton):
 
         return container
 
-    def destroy(self, container: Container) -> None:
+    def destroy(self, container: Container, graceful: bool = False) -> None:
+        """Stop and remove a container.
+
+        By default this kills the container immediately (existing behavior, used by
+        most callers that don't need the process inside to shut down cleanly).
+        Pass `graceful=True` to try a normal stop (SIGTERM, falling back to SIGKILL
+        after Docker's stop timeout) first, so the process inside has a chance to
+        release any host resources it holds (e.g. a serial device) before removal.
+        """
         if self.is_running(container):
-            # Log equivalent shell command for kill
-            if settings.ENABLE_CONTAINER_LOGS:
-                shell_cmd = docker_kill_command(container.name)
-                logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
-            container.kill()
+            if graceful:
+                if settings.ENABLE_CONTAINER_LOGS:
+                    shell_cmd = docker_stop_command(container.name)
+                    logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
+                try:
+                    container.stop()
+                except docker.errors.APIError as error:
+                    logger.warning(
+                        f"Graceful stop failed for container '{container.name}', "
+                        f"falling back to kill: {error}"
+                    )
+                    graceful = False
+
+            if not graceful:
+                # Log equivalent shell command for kill
+                if settings.ENABLE_CONTAINER_LOGS:
+                    shell_cmd = docker_kill_command(container.name)
+                    logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
+                container.kill()
 
         # Log equivalent shell command for remove
         if settings.ENABLE_CONTAINER_LOGS:
@@ -75,6 +98,30 @@ class ContainerManager(object, metaclass=Singleton):
         except NotFound:
             logger.info(f"Did not find container by id or name: {id_or_name}.")
             return None
+
+    def remove_containers_for_image(self, docker_image_tag: str) -> None:
+        """Gracefully stop and remove any (running or stopped) container created
+        from the given image.
+
+        Used to clear out containers that a previous, no-longer-tracked instance of
+        this process left behind (e.g. after a crash or a failed start_device()
+        call), which would otherwise hold onto host resources (like an RCP serial
+        device) and block a new container from starting.
+
+        Note: this matches ANY container built from this image, host-wide, not just
+        ones this process created — acceptable here because these OTBR images are
+        dedicated to Test Harness use, but worth keeping in mind if this is ever
+        reused for a shared/general-purpose image.
+        """
+        stale_containers = self.__client.containers.list(
+            all=True, filters={"ancestor": docker_image_tag}
+        )
+        for container in stale_containers:
+            logger.warning(
+                f"Removing leftover container '{container.name}' "
+                f"({container.short_id}) for image {docker_image_tag}."
+            )
+            self.destroy(container, graceful=True)
 
     def is_running(self, container: Container) -> bool:
         # NOTE: we need to get a new container reference to get updated status.

--- a/app/container_manager/docker_shell_commands.py
+++ b/app/container_manager/docker_shell_commands.py
@@ -206,6 +206,19 @@ def docker_kill_command(container_name: str) -> str:
     return f"docker kill {escape_shell_arg(container_name)}"
 
 
+def docker_stop_command(container_name: str) -> str:
+    """
+    Generate docker stop command.
+
+    Args:
+        container_name: Name or ID of the container
+
+    Returns:
+        String representation of equivalent shell command
+    """
+    return f"docker stop {escape_shell_arg(container_name)}"
+
+
 def docker_rm_command(container_name: str, force: bool = False) -> str:
     """
     Generate docker rm command.

--- a/app/tests/container_manager/test_container_manager.py
+++ b/app/tests/container_manager/test_container_manager.py
@@ -20,7 +20,7 @@ import pytest
 from docker.errors import NotFound
 
 from app.container_manager.container_manager import container_manager
-from app.tests.utils.docker import Container, make_fake_container
+from app.tests.utils.docker import FAKE_ID, Container, make_fake_container
 
 DEFAULT_MOUNT_SRC = "/test/path/chip-cert-tool/backend"
 DEFAULT_MOUNT_WORKING_DIR = "/app"
@@ -80,6 +80,79 @@ def test_container_is_not_running() -> None:
         return_value=make_fake_container({"State": {"Status": "stopped"}}),
     ):
         assert container_manager.is_running(Container()) is False
+
+
+def test_destroy_kills_by_default() -> None:
+    container = make_fake_container({"Id": FAKE_ID, "State": {"Status": "running"}})
+    with mock.patch.object(container, "kill") as kill, mock.patch.object(
+        container, "stop"
+    ) as stop, mock.patch.object(container, "remove") as remove, mock.patch(
+        "app.container_manager.container_manager.get_container",
+        return_value=container,
+    ):
+        container_manager.destroy(container)
+        kill.assert_called_once()
+        stop.assert_not_called()
+        remove.assert_called_once_with(force=True)
+
+
+def test_destroy_graceful_stops_instead_of_kill() -> None:
+    container = make_fake_container({"Id": FAKE_ID, "State": {"Status": "running"}})
+    with mock.patch.object(container, "kill") as kill, mock.patch.object(
+        container, "stop"
+    ) as stop, mock.patch.object(container, "remove") as remove, mock.patch(
+        "app.container_manager.container_manager.get_container",
+        return_value=container,
+    ):
+        container_manager.destroy(container, graceful=True)
+        stop.assert_called_once()
+        kill.assert_not_called()
+        remove.assert_called_once_with(force=True)
+
+
+def test_destroy_graceful_falls_back_to_kill_on_stop_failure() -> None:
+    from docker.errors import APIError
+
+    container = make_fake_container({"Id": FAKE_ID, "State": {"Status": "running"}})
+    with mock.patch.object(
+        container, "stop", side_effect=APIError("stop failed")
+    ), mock.patch.object(container, "kill") as kill, mock.patch.object(
+        container, "remove"
+    ) as remove, mock.patch(
+        "app.container_manager.container_manager.get_container",
+        return_value=container,
+    ):
+        container_manager.destroy(container, graceful=True)
+        kill.assert_called_once()
+        remove.assert_called_once_with(force=True)
+
+
+def test_remove_containers_for_image_removes_stale_containers() -> None:
+    stale_container = make_fake_container(
+        {"Id": FAKE_ID, "State": {"Status": "running"}}
+    )
+    with mock.patch.object(stale_container, "stop") as stop, mock.patch.object(
+        stale_container, "remove"
+    ) as remove, mock.patch(
+        "docker.models.containers.ContainerCollection.list",
+        return_value=[stale_container],
+    ), mock.patch(
+        "app.container_manager.container_manager.get_container",
+        return_value=stale_container,
+    ):
+        container_manager.remove_containers_for_image("org/image:tag")
+        # remove_containers_for_image always destroys gracefully.
+        stop.assert_called_once()
+        remove.assert_called_once_with(force=True)
+
+
+def test_remove_containers_for_image_no_stale_containers() -> None:
+    with mock.patch(
+        "docker.models.containers.ContainerCollection.list",
+        return_value=[],
+    ):
+        # Should simply do nothing when there is nothing to clean up.
+        container_manager.remove_containers_for_image("org/image:tag")
 
 
 def test_get_working_dir() -> None:

--- a/test_collections/matter/scripts/OTBR/otbr_start.sh
+++ b/test_collections/matter/scripts/OTBR/otbr_start.sh
@@ -52,6 +52,16 @@ print_script_step "Removing 'otbr-chip' container"
 docker stop otbr-chip > /dev/null 2>&1
 docker rm otbr-chip > /dev/null 2>&1
 
+# Also remove any other leftover container from the OTBR image (e.g. one started by
+# the Test Harness itself via otbr_manager.py, which doesn't use the 'otbr-chip' name).
+# A stale container like this can still be holding the RCP serial device, which makes
+# otbr-agent fail to attach in the container we're about to start (see #1071).
+STALE_OTBR_CONTAINERS=$(sudo docker ps -aq --filter "ancestor=$BR_IMAGE")
+if [ -n "$STALE_OTBR_CONTAINERS" ]; then
+	echo "$STALE_OTBR_CONTAINERS" | xargs -r sudo docker stop > /dev/null 2>&1
+	echo "$STALE_OTBR_CONTAINERS" | xargs -r sudo docker rm -f > /dev/null 2>&1
+fi
+
 if docker images | grep $BR_IMAGE_BASE | grep $BR_IMAGE_TAG;
 then
 	echo "otbr image "$BR_IMAGE" already installed"
@@ -60,13 +70,36 @@ else
 	docker pull $BR_IMAGE || exit 1
 fi
 
+print_script_step "Checking Thread RCP device"
+RCP_DEVICE="/dev/ttyACM0"
+if [ ! -e "$RCP_DEVICE" ]; then
+	echo "ERROR: $RCP_DEVICE not found. Is the Thread RCP dongle plugged in?" >&2
+	echo "If it was just plugged in/out, wait a few seconds for it to enumerate and try again." >&2
+	exit 1
+fi
+
 print_script_step "Starting 'otbr-chip' container"
 AVAHI_PATH=$ROOT_DIR/backend/app/otbr_manager/avahi
 sudo modprobe ip6table_filter || exit 1
-sudo docker run --privileged -d --network host --name otbr-chip -e NAT64=1 -e DNS64=0 -e WEB_GUI=0 -v $AVAHI_PATH:/etc/avahi -v /dev/ttyACM0:/dev/radio $BR_IMAGE --radio-url spinel+hdlc+uart:///dev/radio?uart-baudrate=115200 -B $BR_INTERFACE || exit 1
+sudo docker run --privileged -d --network host --name otbr-chip -e NAT64=1 -e DNS64=0 -e WEB_GUI=0 -v $AVAHI_PATH:/etc/avahi -v $RCP_DEVICE:/dev/radio $BR_IMAGE --radio-url spinel+hdlc+uart:///dev/radio?uart-baudrate=115200 -B $BR_INTERFACE || exit 1
 
-print_script_step "Waiting 10 seconds to give the the docker container enough time to start up..."
-sleep 10
+print_script_step "Waiting for the OTBR agent to become ready..."
+OTBR_READY_TIMEOUT=30
+OTBR_READY=0
+for ((i = 0; i < OTBR_READY_TIMEOUT; i++)); do
+	if sudo docker exec otbr-chip ot-ctl state > /dev/null 2>&1; then
+		OTBR_READY=1
+		break
+	fi
+	sleep 1
+done
+
+if [ $OTBR_READY -eq 0 ]; then
+	echo "ERROR: otbr-agent did not become ready within ${OTBR_READY_TIMEOUT}s." >&2
+	echo "Dumping 'otbr-chip' container logs for diagnosis:" >&2
+	sudo docker logs otbr-chip
+	exit 1
+fi
 
 BR_CHANNEL_HEX=$(printf '%02x' $BR_CHANNEL)
 BR_PANID="5b${BR_VARIANT}" # The 2-byte Personal Area Network ID is a unique Thread identifier
@@ -96,7 +129,11 @@ print_script_step "Setting up Thread Network"
 for i in "${BR_PARAMS[@]}"
 do
         printf "Param: '$i'"
-        sudo docker exec -t otbr-chip ot-ctl $i || exit 1
+        if ! sudo docker exec -t otbr-chip ot-ctl $i; then
+                echo "ERROR: 'ot-ctl $i' failed. Dumping 'otbr-chip' container logs for diagnosis:" >&2
+                sudo docker logs otbr-chip
+                exit 1
+        fi
 done
 
 BR_SIMPLE_DATASET="00030000"${BR_CHANNEL_HEX}"0208"${BR_EXTPANID}"0510"${BR_NETWORKKEY}"0102"${BR_PANID}

--- a/test_collections/matter/scripts/OTBR/otbr_stop.sh
+++ b/test_collections/matter/scripts/OTBR/otbr_stop.sh
@@ -24,6 +24,10 @@ print_start_of_script
 print_script_step "Stoping OTBR service"
 sudo docker exec -t otbr-chip ot-ctl srp server disable
 sleep 2
-sudo docker kill otbr-chip
+# Use a graceful stop (SIGTERM, falling back to SIGKILL after the timeout) rather
+# than 'docker kill' so otbr-agent has a chance to release the RCP serial device
+# cleanly. A hard kill can leave the RCP in a state that otbr_start.sh's next
+# run fails to attach to (see #1071).
+sudo docker stop otbr-chip
 
 print_end_of_script

--- a/test_collections/matter/sdk_tests/support/otbr_manager/otbr_manager.py
+++ b/test_collections/matter/sdk_tests/support/otbr_manager/otbr_manager.py
@@ -132,6 +132,12 @@ class ThreadBorderRouter(metaclass=Singleton):
         self.__load_config(config)
         logger.info(f"Starting OTBR via docker image: {self.__docker_image}")
 
+        # Remove any leftover OTBR container not tracked by this instance (e.g. left
+        # behind by a previous failed start_device() call, or a backend restart that
+        # dropped the in-memory reference). Otherwise it can still be holding the RCP
+        # serial device, causing the new container's otbr-agent to fail to attach.
+        container_manager.remove_containers_for_image(self.__docker_image)
+
         # Async return when the container is running
         self.__otbr_docker = await container_manager.create_container(
             self.__docker_image, self.run_parameters
@@ -235,5 +241,9 @@ class ThreadBorderRouter(metaclass=Singleton):
         if self.is_running():
             self._send_command("service otbr-firewall stop", prefix="")
 
-        container_manager.destroy(self.__otbr_docker)
+        # Graceful stop (rather than a hard kill) so otbr-agent has a chance to
+        # release the RCP serial device cleanly before the container is removed.
+        # A hard kill can leave the RCP in a state that the next start_device()
+        # call fails to attach to (see #1071).
+        container_manager.destroy(self.__otbr_docker, graceful=True)
         self.__otbr_docker = None


### PR DESCRIPTION
## Summary

Cherry-pick of #348 (merged into `v2.15.1-develop`) onto `v2.16-develop`.

Cherry-picked commit: bda4662cee936a18fbdad977b1cef3f6a72f66a0

Note: #348's history included a mesh-local-prefix fix that was later reverted after it was found not to fix the issue it was targeting (confirmed on `v2.15.1-develop` testing) — that revert is included in the squashed commit, so the net diff here only contains the confirmed diagnostics/orphan-cleanup changes, same as what's on `v2.15.1-develop` now.

`v2.16-develop` already had an `srp server enable` step (#342) in the same functions touched by this change; cherry-pick applied cleanly with both changes coexisting (verified `srp server enable` still runs before `dataset active -x` / the readiness sleep, matching the original ordering).

See #348 for full original description and review history.

## Related

project-chip/certification-tool#1071