### PR TITLE
Add nfc-ethernet DUT pairing mode for python_testing suites

### DIFF
--- a/app/constants/shared_constants.py
+++ b/app/constants/shared_constants.py
@@ -61,6 +61,7 @@ class DutPairingModeEnum(str, Enum):
     ON_NETWORK = "onnetwork"
     BLE_WIFI = "ble-wifi"
     NFC_WIFI = "nfc-wifi"
+    NFC_ETHERNET = "nfc-ethernet"
     BLE_THREAD = "ble-thread"
     WIFIPAF_WIFI = "wifipaf-wifi"
     NFC_THREAD = "nfc-thread"
@@ -69,5 +70,6 @@ class DutPairingModeEnum(str, Enum):
 
 NFC_PAIRING_MODES = {
     DutPairingModeEnum.NFC_WIFI.value,
+    DutPairingModeEnum.NFC_ETHERNET.value,
     DutPairingModeEnum.NFC_THREAD.value,
 }

--- a/test_collections/matter/sdk_tests/support/tests/matter/test_test_environment_config.py
+++ b/test_collections/matter/sdk_tests/support/tests/matter/test_test_environment_config.py
@@ -330,7 +330,7 @@ def test_create_config_matter_with_non_thread_modes_no_ba_params_succeeds(
     assert config_matter.dut_config.pairing_mode == pairing_mode
 
 
-@pytest.mark.parametrize("pairing_mode", ["nfc-thread", "nfc-wifi"])
+@pytest.mark.parametrize("pairing_mode", ["nfc-thread", "nfc-wifi", "nfc-ethernet"])
 def test_create_config_matter_nfc_without_discriminator_and_setup_code_succeeds(
     pairing_mode: str,
 ) -> None:
@@ -369,7 +369,7 @@ def test_create_config_matter_nfc_without_discriminator_and_setup_code_succeeds(
     assert config_matter.dut_config.setup_code is None
 
 
-@pytest.mark.parametrize("pairing_mode", ["nfc-thread", "nfc-wifi"])
+@pytest.mark.parametrize("pairing_mode", ["nfc-thread", "nfc-wifi", "nfc-ethernet"])
 def test_create_config_matter_nfc_with_discriminator_succeeds(
     pairing_mode: str,
 ) -> None:
@@ -405,7 +405,7 @@ def test_create_config_matter_nfc_with_discriminator_succeeds(
     assert config_matter.dut_config.discriminator == "3840"
 
 
-@pytest.mark.parametrize("pairing_mode", ["nfc-thread", "nfc-wifi"])
+@pytest.mark.parametrize("pairing_mode", ["nfc-thread", "nfc-wifi", "nfc-ethernet"])
 def test_create_config_matter_nfc_with_setup_code_succeeds(
     pairing_mode: str,
 ) -> None:

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -188,6 +188,43 @@ async def test_generate_command_arguments_nfc_wifi_pairing_mode() -> None:
 
 
 @pytest.mark.asyncio
+async def test_generate_command_arguments_nfc_ethernet_pairing_mode() -> None:
+    # Mock config
+    mock_config = default_environment_config.copy(deep=True)  # type: ignore
+
+    mock_config.test_parameters = {
+        "paa-trust-store-path": "/paa-root-certs",
+        "storage_path": "/root/admin_storage.json",
+    }
+
+    mock_dut_config = DutConfig(
+        pairing_mode=DutPairingModeEnum.NFC_ETHERNET,
+        chip_timeout=None,
+    )
+
+    mock_config.dut_config = mock_dut_config
+
+    arguments = await generate_command_arguments(
+        config=mock_config, omit_commissioning_method=False
+    )
+
+    # NFC-Ethernet needs neither --wifi-* nor --thread-dataset-hex arguments,
+    # since Ethernet devices don't require network credentials to commission.
+    assert [
+        "--trace-to json:log",
+        f"--commissioning-method {DutPairingModeEnum.NFC_ETHERNET.value}",
+        "--paa-trust-store-path /paa-root-certs",
+        "--storage_path /root/admin_storage.json",
+        "--int-arg",
+        "NFC_Reader_index:0",
+    ] == arguments
+    assert "--discriminator" not in " ".join(arguments)
+    assert "--passcode" not in " ".join(arguments)
+    assert "--wifi-ssid" not in " ".join(arguments)
+    assert "--thread-dataset-hex" not in " ".join(arguments)
+
+
+@pytest.mark.asyncio
 async def test_generate_command_arguments_ble_thread() -> None:
     # Mock config
     mock_config = default_environment_config.copy(deep=True)  # type: ignore
@@ -382,6 +419,7 @@ async def test_generate_command_arguments_nfc_thread_for_external_network() -> N
 NFC_PAIRING_MODES_PARAMS = [
     pytest.param(DutPairingModeEnum.NFC_THREAD, id="nfc-thread"),
     pytest.param(DutPairingModeEnum.NFC_WIFI, id="nfc-wifi"),
+    pytest.param(DutPairingModeEnum.NFC_ETHERNET, id="nfc-ethernet"),
 ]
 
 MOCK_THREAD_DATASET = (


### PR DESCRIPTION
## Summary

Adds `nfc-ethernet` as a valid DUT pairing mode for **python_testing (SDK) tests only**, so the Test Harness can commission Matter-over-Ethernet devices via NFC.

## Background

- Upstream connectedhomeip PR [project-chip/connectedhomeip#43613](https://github.com/project-chip/connectedhomeip/pull/43613) (adds `nfc-ethernet` to chip-tool) is still **open**, so YAML/chip-tool-based tests can't use this mode yet.
- The companion PR [project-chip/connectedhomeip#43657](https://github.com/project-chip/connectedhomeip/pull/43657) ("Add nfc-ethernet in Python controller") is **merged** and present in our `connectedhomeip` submodule, so python_testing (SDK) tests can already accept `nfc-ethernet` as a `--commissioning-method` — this PR just exposes/maps it in the TH's config/dispatch layer.

## Changes

- `app/constants/shared_constants.py`: added `NFC_ETHERNET = "nfc-ethernet"` to `DutPairingModeEnum` and to `NFC_PAIRING_MODES`.
- `generate_command_arguments()` in `python_testing/models/utils.py` needed **no code change**: nfc-ethernet isn't part of the wifi/thread pairing-mode tuples, so it falls straight through to the existing NFC handling that suppresses `--discriminator`/`--passcode` and injects `NFC_Reader_index`.
- `test_suite.py` OTBR setup needed no change: nfc-ethernet is not in the BLE_THREAD/NFC_THREAD/THREAD_MESHCOP tuple that triggers OTBR startup.
- Added test coverage mirroring existing nfc-wifi/nfc-thread tests:
  - `test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py`
  - `test_collections/matter/sdk_tests/support/tests/matter/test_test_environment_config.py`

## Out of scope

- YAML/chip-tool test support — blocked on upstream connectedhomeip#43613, which is still under review.

Related: project-chip/certification-tool#1067