### PR TITLE
Release v2.15.1+summer2026

### DIFF
--- a/.version_information
+++ b/.version_information
@@ -1,1 +1,1 @@
-v2.15.1-beta1+summer2026
+v2.15.1+summer2026

--- a/test_collections/matter/config.py
+++ b/test_collections/matter/config.py
@@ -23,9 +23,9 @@ class MatterSettings(BaseSettings):
 
     # SDK Docker Image
     SDK_DOCKER_IMAGE: str = "connectedhomeip/chip-cert-bins"
-    SDK_DOCKER_TAG: str = "df8bd0308caa0680e2a78cda724a959e5b385205"
+    SDK_DOCKER_TAG: str = "e91ea83caae4adb1871aa4bbe93c4be2dd9e1abf"
     # SDK SHA: used to fetch tests (YAML and Python) from SDK.
-    SDK_SHA: str = "df8bd0308caa0680e2a78cda724a959e5b385205"
+    SDK_SHA: str = "e91ea83caae4adb1871aa4bbe93c4be2dd9e1abf"
 
     class Config:
         case_sensitive = True


### PR DESCRIPTION
## Description

Cuts release branch for v2.15.1+summer2026.

- Bumps `.version_information` to `v2.15.1+summer2026`
- Bumps `SDK_DOCKER_TAG` / `SDK_SHA` to `e91ea83caae4adb1871aa4bbe93c4be2dd9e1abf`