### PR TITLE
CI - Fix spellcheck and Flake8 failures affecting all pull requests

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -8,4 +8,5 @@ per-file-ignores =
     test_collections/manual_tests/**/*:E501,W291
     test_collections/app1_tests/**/*:E501
     test_collections/semi_automated_tests/**/*:E501
+    test_collections/matter/python_tests/**/*:E501
     alembic/versions/**/*:E128,W293,F401

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,6 +1,9 @@
 name: "Check spelling"
 on: # rebuild any PRs and main branch changes
-  pull_request_target:
+  # pull_request (not pull_request_target) so the job checks out and scans the
+  # PR content; with pull_request_target the default checkout is the base
+  # branch, so PR runs were scanning main instead of the PR
+  pull_request:
     types: [opened, synchronize, reopened]
   push:
     branches:

--- a/cspell.json
+++ b/cspell.json
@@ -117,7 +117,12 @@
         "PAVST",
         "WEBRTCR",
         "ZONEMGMT",
-        "APPDEVTYPEID"
+        "APPDEVTYPEID",
+        "astext",
+        "asname",
+        "TLSCERT",
+        "JFADMIN",
+        "AABBCCDD"
     ],
     "allowCompoundWords": true,
     "ignorePaths": [


### PR DESCRIPTION
#### Summary

Fixes an issue where the spellcheck and Flake8 CI jobs failed on every pull request regardless of its content (the cspell dictionary was missing five code identifiers used in tracked files, Flake8 linted the `python_tests` submodule content, which carries long lines in `tcdd13.py` and is maintained in its own repository, and the spellcheck workflow ran on `pull_request_target` with a default checkout, so PR runs scanned the base branch instead of the PR), by adding the identifiers to the cspell `ignoreWords` list, ignoring `E501` for the submodule path in the Flake8 configuration, and triggering the spellcheck workflow on `pull_request` so it checks out and scans the PR content.

#### Included in this PR

- Added `astext`, `asname`, `TLSCERT`, `JFADMIN` and `AABBCCDD` to the spellcheck ignore list (`cspell.json`)
- Ignored `E501` for the `python_tests` submodule path, following the existing `per-file-ignores` entries for other test collections (`.flake8`)
- Changed the spellcheck workflow trigger from `pull_request_target` to `pull_request` so PR runs check out and scan the PR content instead of the base branch (`spell-check.yml`)

Note for reviewers: the spellcheck check on this PR stays red because `pull_request_target` runs use the base branch's workflow definition and tree; all three fixes take effect once merged.

#### Testing

Flake8 with the repository configuration (9 pre-existing violations before the change, none after)
```
python -m flake8 .
```

