### PR TITLE
Add POST /test_collections/rescan endpoint for in-process test discovery

### DIFF
--- a/app/api/api_v1/endpoints/test_collections.py
+++ b/app/api/api_v1/endpoints/test_collections.py
@@ -13,11 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from http import HTTPStatus
 from typing import Any
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
+from loguru import logger
 
 from app.schemas import TestCollections
+from app.schemas.test_runner_status import TestRunnerState
+from app.test_engine import TEST_ENGINE_BUSY_MESSAGE
+from app.test_engine.test_runner import TestRunner
 from app.test_engine.test_script_manager import test_script_manager
 
 router = APIRouter()
@@ -28,6 +33,36 @@ def read_test_collections() -> Any:
     """
     Retrieve available test collections.
     """
+
+    return {
+        "test_collections": {
+            k: v.as_dict() for k, v in test_script_manager.test_collections.items()
+        }
+    }
+
+
+@router.post("/rescan", response_model=TestCollections)
+async def rescan_test_collections() -> Any:
+    """
+    Re-run test collection discovery/registration in-process.
+
+    This picks up newly added or edited side-loaded test scripts without
+    requiring a backend restart. Returns the refreshed list of test
+    collections.
+    """
+    if TestRunner().state != TestRunnerState.IDLE:
+        raise HTTPException(
+            status_code=HTTPStatus.CONFLICT, detail=TEST_ENGINE_BUSY_MESSAGE
+        )
+
+    try:
+        await test_script_manager.rescan()
+    except Exception as e:
+        logger.error(f"Failed to rescan test collections: {e}")
+        raise HTTPException(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            detail=f"Failed to rescan test collections: {e}",
+        )
 
     return {
         "test_collections": {

--- a/app/test_engine/test_script_manager.py
+++ b/app/test_engine/test_script_manager.py
@@ -127,20 +127,27 @@ class TestScriptManager(object, metaclass=Singleton):
         previous_test_collections = self.test_collections
 
         try:
+            # This import only fails with ImportError when the python_testing
+            # package itself doesn't expose initialize_python_tests (e.g.
+            # DRY_RUN mode, where .test_manager is never imported). It must
+            # stay isolated from the call below: an ImportError raised while
+            # *running* initialize_python_tests() (e.g. a bad import in a
+            # side-loaded script) means initialization genuinely failed and
+            # must trigger the rollback in the except block further down,
+            # not be mistaken for "module not available".
             from test_collections.matter.sdk_tests.support.python_testing import (
                 initialize_python_tests,
             )
+        except ImportError as e:
+            logging.warning(f"Python testing module not available: {e}")
+            self.test_collections = self._discover_test_collections()
+            return
 
+        try:
             await initialize_python_tests()
             self.test_collections = self._discover_test_collections()
             self._python_tests_initialized = True
 
-        except ImportError as e:
-            # Handle case where python_testing module is not available
-            # (e.g., DRY_RUN mode). Non-Python test collections can still be
-            # rediscovered.
-            logging.warning(f"Python testing module not available: {e}")
-            self.test_collections = self._discover_test_collections()
         except Exception as e:
             logging.error(f"Failed to rescan test collections: {e}")
             self.test_collections = previous_test_collections

--- a/app/test_engine/test_script_manager.py
+++ b/app/test_engine/test_script_manager.py
@@ -112,6 +112,40 @@ class TestScriptManager(object, metaclass=Singleton):
             logging.error(f"Failed to initialize Python tests: {e}")
             raise
 
+    async def rescan(self) -> None:
+        """
+        Re-run test collection discovery/registration in-process.
+
+        This re-generates the Python test JSON files (picking up side-loaded
+        additions/edits to custom test scripts) and re-discovers all test
+        collections, without requiring a backend restart.
+
+        If rescanning fails, the previously loaded test collections are kept
+        so the backend remains usable, and the error is re-raised for the
+        caller to report.
+        """
+        previous_test_collections = self.test_collections
+
+        try:
+            from test_collections.matter.sdk_tests.support.python_testing import (
+                initialize_python_tests,
+            )
+
+            await initialize_python_tests()
+            self.test_collections = self._discover_test_collections()
+            self._python_tests_initialized = True
+
+        except ImportError as e:
+            # Handle case where python_testing module is not available
+            # (e.g., DRY_RUN mode). Non-Python test collections can still be
+            # rediscovered.
+            logging.warning(f"Python testing module not available: {e}")
+            self.test_collections = self._discover_test_collections()
+        except Exception as e:
+            logging.error(f"Failed to rescan test collections: {e}")
+            self.test_collections = previous_test_collections
+            raise
+
     def _discover_test_collections(self) -> dict[str, TestCollectionDeclaration]:
         if "pytest" in sys.modules:
             # In test environment, discover all collections (same as conftest.py)

--- a/app/tests/api/api_v1/test_collections.py
+++ b/app/tests/api/api_v1/test_collections.py
@@ -14,10 +14,20 @@
 # limitations under the License.
 #
 from http import HTTPStatus
+from unittest.mock import AsyncMock, patch
 
+import pytest
 from fastapi.testclient import TestClient
+from httpx import AsyncClient
+from sqlalchemy.orm import Session
 
 from app.core.config import settings
+from app.test_engine import TEST_ENGINE_BUSY_MESSAGE
+from app.test_engine.test_runner import TestRunner
+from app.test_engine.test_script_manager import test_script_manager
+from app.tests.utils.test_run_execution import (
+    create_test_run_execution_with_some_test_cases,
+)
 
 
 def test_read_available_test_collections(client: TestClient) -> None:
@@ -36,3 +46,62 @@ def test_read_available_test_collections(client: TestClient) -> None:
     assert "TestSuiteExpected" in test_suites
     test_suite_expected = test_suites["TestSuiteExpected"]
     assert "metadata" in test_suite_expected
+
+
+def test_rescan_test_collections(client: TestClient) -> None:
+    with patch.object(
+        test_script_manager, "rescan", new_callable=AsyncMock
+    ) as mock_rescan:
+        response = client.post(
+            f"{settings.API_V1_STR}/test_collections/rescan",
+        )
+
+    mock_rescan.assert_awaited_once()
+    assert response.status_code == HTTPStatus.OK
+
+    content = response.json()
+    assert "test_collections" in content
+    assert "tool_unit_tests" in content["test_collections"]
+
+
+@pytest.mark.asyncio
+async def test_rescan_test_collections_busy(
+    async_client: AsyncClient, db: Session
+) -> None:
+    test_run_execution = create_test_run_execution_with_some_test_cases(db=db)
+
+    # Load a test run so the Test Engine (singleton) is no longer IDLE.
+    test_runner = TestRunner()
+    test_runner.load_test_run(test_run_execution.id)
+    try:
+        response = await async_client.post(
+            f"{settings.API_V1_STR}/test_collections/rescan",
+        )
+
+        assert response.status_code == HTTPStatus.CONFLICT
+        content = response.json()
+        assert content["detail"] == TEST_ENGINE_BUSY_MESSAGE
+    finally:
+        test_runner.abort_testing()
+
+
+def test_rescan_test_collections_failure_keeps_previous_collections(
+    client: TestClient,
+) -> None:
+    previous_collections = dict(test_script_manager.test_collections)
+
+    with patch.object(
+        test_script_manager,
+        "rescan",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("boom"),
+    ):
+        response = client.post(
+            f"{settings.API_V1_STR}/test_collections/rescan",
+        )
+
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY
+    content = response.json()
+    assert "Failed to rescan test collections" in content["detail"]
+    # Previously loaded test collections remain available.
+    assert test_script_manager.test_collections == previous_collections

--- a/app/tests/test_engine/test_script_manager.py
+++ b/app/tests/test_engine/test_script_manager.py
@@ -171,20 +171,47 @@ async def test_rescan_keeps_previous_collections_on_failure(
 
 @pytest.mark.asyncio
 async def test_rescan_handles_missing_python_testing_module(
-    restore_test_collections: None,
+    restore_test_collections: None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    """If the python_testing package doesn't expose initialize_python_tests
+    (e.g. DRY_RUN mode), rescan() should not raise: non-Python collections
+    are still discovered."""
     expected_collections = {"tool_unit_tests": MagicMock()}
 
-    with patch(
-        "test_collections.matter.sdk_tests.support.python_testing."
-        "initialize_python_tests",
-        side_effect=ImportError("python_testing not available"),
-    ), patch.object(
+    import test_collections.matter.sdk_tests.support.python_testing as python_testing
+
+    monkeypatch.delattr(python_testing, "initialize_python_tests")
+
+    with patch.object(
         test_script_manager,
         "_discover_test_collections",
         return_value=expected_collections,
     ):
-        # Should not raise, non-Python collections are still discovered.
         await test_script_manager.rescan()
 
     assert test_script_manager.test_collections == expected_collections
+
+
+@pytest.mark.asyncio
+async def test_rescan_keeps_previous_collections_on_import_error(
+    restore_test_collections: None,
+) -> None:
+    """An ImportError raised while *running* initialize_python_tests() (e.g.
+    a bad import inside a side-loaded script) must be treated as a rescan
+    failure, not mistaken for the python_testing-module-not-available case:
+    the previous test collections must be restored and the error re-raised.
+    """
+    previous_collections = {"tool_unit_tests": MagicMock()}
+
+    with patch.object(
+        test_script_manager, "test_collections", previous_collections
+    ), patch(
+        "test_collections.matter.sdk_tests.support.python_testing."
+        "initialize_python_tests",
+        new_callable=AsyncMock,
+        side_effect=ImportError("bad import in side-loaded script"),
+    ):
+        with pytest.raises(ImportError, match="bad import in side-loaded script"):
+            await test_script_manager.rescan()
+
+        assert test_script_manager.test_collections == previous_collections

--- a/app/tests/test_engine/test_script_manager.py
+++ b/app/tests/test_engine/test_script_manager.py
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+from typing import Generator
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 
 from app.test_engine.test_script_manager import (
@@ -21,6 +24,18 @@ from app.test_engine.test_script_manager import (
     TestSuiteNotFound,
     test_script_manager,
 )
+
+
+@pytest.fixture
+def restore_test_collections() -> Generator:
+    """Save and restore test_script_manager.test_collections around a test.
+
+    test_script_manager is a singleton shared across the test session, so
+    tests that call rescan() must not leak mutated state to other tests.
+    """
+    saved_collections = test_script_manager.test_collections
+    yield
+    test_script_manager.test_collections = saved_collections
 
 
 @pytest.mark.asyncio
@@ -108,3 +123,68 @@ async def test_validate_test_selection_invalid_test_case() -> None:
     }
     with pytest.raises(TestCaseNotFound):
         test_script_manager.validate_test_selection(selected_tests)
+
+
+@pytest.mark.asyncio
+async def test_rescan_refreshes_test_collections(
+    restore_test_collections: None,
+) -> None:
+    expected_collections = {"tool_unit_tests": MagicMock()}
+
+    with patch(
+        "test_collections.matter.sdk_tests.support.python_testing."
+        "initialize_python_tests",
+        new_callable=AsyncMock,
+    ) as mock_init, patch.object(
+        test_script_manager,
+        "_discover_test_collections",
+        return_value=expected_collections,
+    ):
+        await test_script_manager.rescan()
+
+    mock_init.assert_awaited_once()
+    assert test_script_manager.test_collections == expected_collections
+    assert test_script_manager._python_tests_initialized is True
+
+
+@pytest.mark.asyncio
+async def test_rescan_keeps_previous_collections_on_failure(
+    restore_test_collections: None,
+) -> None:
+    previous_collections = {"tool_unit_tests": MagicMock()}
+
+    with patch.object(
+        test_script_manager, "test_collections", previous_collections
+    ), patch(
+        "test_collections.matter.sdk_tests.support.python_testing."
+        "initialize_python_tests",
+        new_callable=AsyncMock,
+        side_effect=RuntimeError("side-loaded script is invalid"),
+    ):
+        with pytest.raises(RuntimeError, match="side-loaded script is invalid"):
+            await test_script_manager.rescan()
+
+        # Previously loaded test collections must remain available so the
+        # backend keeps working without needing a restart.
+        assert test_script_manager.test_collections == previous_collections
+
+
+@pytest.mark.asyncio
+async def test_rescan_handles_missing_python_testing_module(
+    restore_test_collections: None,
+) -> None:
+    expected_collections = {"tool_unit_tests": MagicMock()}
+
+    with patch(
+        "test_collections.matter.sdk_tests.support.python_testing."
+        "initialize_python_tests",
+        side_effect=ImportError("python_testing not available"),
+    ), patch.object(
+        test_script_manager,
+        "_discover_test_collections",
+        return_value=expected_collections,
+    ):
+        # Should not raise, non-Python collections are still discovered.
+        await test_script_manager.rescan()
+
+    assert test_script_manager.test_collections == expected_collections


### PR DESCRIPTION
## Summary

Implements https://github.com/project-chip/certification-tool/issues/1083 for Matter v1.7 TE2.

Registering a side-loaded test script currently requires a full backend container restart
(`docker exec` to re-run discovery, `docker restart`, then poll until the service is back up).
This PR adds a `POST /api/v1/test_collections/rescan` endpoint that re-runs test-collection
discovery/registration in-process, without restarting the backend.

## Changes

- `TestScriptManager.rescan()` (`app/test_engine/test_script_manager.py`): re-runs
  `initialize_python_tests()` (regenerates the Python test JSON via the SDK container, picking
  up side-loaded script changes) and re-discovers all test collections. On failure, the
  previously loaded collections are kept instead of leaving the manager empty, so the backend
  keeps working without a restart. Degrades gracefully in `DRY_RUN` mode where the
  `python_testing` module isn't importable.
- `POST /api/v1/test_collections/rescan` (`app/api/api_v1/endpoints/test_collections.py`):
  - Returns `409 Conflict` if the Test Engine isn't idle (mirrors the existing
    `/abort-testing` busy-check pattern).
  - Returns `422 Unprocessable Entity` with the failure detail if rescanning throws.
  - Otherwise returns `200 OK` with the refreshed `TestCollections`.

## Testing

- Unit tests for `TestScriptManager.rescan()`: success, failure-keeps-previous-collections,
  and missing-`python_testing`-module cases.
- API tests for the new endpoint: success, busy (409), and failure (422, keeping prior
  collections) cases.
- `black`, `isort`, `flake8`, `mypy` all pass on the changed files (no new findings beyond two
  pre-existing, unrelated errors confirmed present on the base branch).
- Full `pytest` suite (Docker/DB-dependent) was not run in the authoring environment; please
  run `./scripts/test-local.sh` before merge.

## Test Plan (from the issue)

- [ ] Add a new side-loaded test script, call the rescan endpoint, confirm the new test case
      appears in `GET /api/v1/test_collections/` without a backend restart.
- [ ] Add a malformed side-loaded script, call rescan, confirm a clear error is returned and
      previously loaded test collections remain available.
- [ ] Rescan with no script changes, confirm the full existing set of test collections
      (matter, sample_tests, etc.) is unchanged.