### PR TITLE
Cherry-pick #346 + #358: mandatory test sideloading + duplicate-test fix

### DIFF
--- a/test_collections/matter/sdk_tests/support/python_testing/sdk_python_tests.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/sdk_python_tests.py
@@ -131,7 +131,10 @@ def __parse_python_tests(
             and collection_type != CollectionType.MANDATORY
         ):
             suites[SuiteType.NO_COMMISSIONING].add_test_case(test_case)
-        elif collection_type != CollectionType.MANDATORY:
+        elif (
+            python_test_type != PythonTestType.MANDATORY
+            and collection_type != CollectionType.MANDATORY
+        ):
             suites[SuiteType.LEGACY].add_test_case(test_case)
 
     return [s for s in list(suites.values()) if len(s.test_cases) != 0]

--- a/test_collections/matter/sdk_tests/support/python_testing/sdk_python_tests.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/sdk_python_tests.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+from enum import Enum
 from pathlib import Path
 from typing import Optional
 
@@ -98,8 +99,14 @@ def _parse_python_script_to_test_case_declarations(
     ]
 
 
+class CollectionType(Enum):
+    NON_MANDATORY = 0
+    MANDATORY = 1
+    ALL = 2
+
+
 def __parse_python_tests(
-    python_test_version: str, mandatory: bool, tests_file_path: Path
+    python_test_version: str, collection_type: CollectionType, tests_file_path: Path
 ) -> list[PythonSuiteDeclaration]:
     suites = _init_test_suites(python_test_version)
 
@@ -109,32 +116,44 @@ def __parse_python_tests(
 
     for test_case in test_cases:
         python_test_type = test_case.class_ref.python_test.python_test_type
-        if mandatory:
-            if python_test_type == PythonTestType.MANDATORY:
-                suites[SuiteType.MANDATORY].add_test_case(test_case)
-        else:
-            if python_test_type == PythonTestType.COMMISSIONING:
-                suites[SuiteType.COMMISSIONING].add_test_case(test_case)
-            elif python_test_type == PythonTestType.NO_COMMISSIONING:
-                suites[SuiteType.NO_COMMISSIONING].add_test_case(test_case)
-            elif python_test_type != PythonTestType.MANDATORY:
-                suites[SuiteType.LEGACY].add_test_case(test_case)
+        if (
+            python_test_type == PythonTestType.MANDATORY
+            and collection_type != CollectionType.NON_MANDATORY
+        ):
+            suites[SuiteType.MANDATORY].add_test_case(test_case)
+        elif (
+            python_test_type == PythonTestType.COMMISSIONING
+            and collection_type != CollectionType.MANDATORY
+        ):
+            suites[SuiteType.COMMISSIONING].add_test_case(test_case)
+        elif (
+            python_test_type == PythonTestType.NO_COMMISSIONING
+            and collection_type != CollectionType.MANDATORY
+        ):
+            suites[SuiteType.NO_COMMISSIONING].add_test_case(test_case)
+        elif collection_type != CollectionType.MANDATORY:
+            suites[SuiteType.LEGACY].add_test_case(test_case)
 
     return [s for s in list(suites.values()) if len(s.test_cases) != 0]
 
 
 def __sdk_python_test_collection(
-    name: str, python_test_folder: SDKTestFolder, mandatory: bool, tests_file_path: Path
+    name: str,
+    python_test_folder: SDKTestFolder,
+    collection_type: CollectionType,
+    tests_file_path: Path,
 ) -> PythonCollectionDeclaration:
     collection = PythonCollectionDeclaration(
-        name=name, folder=python_test_folder, mandatory=mandatory
+        name=name,
+        folder=python_test_folder,
+        mandatory=collection_type == CollectionType.MANDATORY,
     )
 
     python_test_version = python_test_folder.version
 
     suites = __parse_python_tests(
         python_test_version=python_test_version,
-        mandatory=mandatory,
+        collection_type=collection_type,
         tests_file_path=tests_file_path,
     )
 
@@ -153,7 +172,7 @@ def sdk_python_test_collection(
     return __sdk_python_test_collection(
         name="SDK Python Tests",
         python_test_folder=python_test_folder,
-        mandatory=False,
+        collection_type=CollectionType.NON_MANDATORY,
         tests_file_path=tests_file_path,
     )
 
@@ -166,7 +185,7 @@ def sdk_mandatory_python_test_collection(
     return __sdk_python_test_collection(
         name="Mandatory SDK Python Tests",
         python_test_folder=python_test_folder,
-        mandatory=True,
+        collection_type=CollectionType.MANDATORY,
         tests_file_path=tests_file_path,
     )
 
@@ -213,7 +232,9 @@ def _create_custom_python_test_collection(
     )
 
     suites = __parse_python_tests(
-        python_test_version="custom", mandatory=False, tests_file_path=tests_file_path
+        python_test_version="custom",
+        collection_type=CollectionType.ALL,
+        tests_file_path=tests_file_path,
     )
 
     for suite in suites:

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_script/mandatory_tests_info.json
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_script/mandatory_tests_info.json
@@ -1,0 +1,35 @@
+{
+    "sdk_sha": "aabbccddeeff11223344556677889900",
+    "tests": [
+        {
+            "class_name": "TC_SameClass",
+            "desc": "TC TC_SameClass description 1",
+            "function": "test_TC_SC_1_1",
+            "path": "sdk/TC_SameClass",
+            "pics": [],
+            "steps": [
+                {
+                    "description": "Step 1",
+                    "expectation": "",
+                    "is_commissioning": false,
+                    "test_plan_number": 1
+                }
+            ]
+        },
+        {
+            "class_name": "TC_DeviceConformance",
+            "desc": "TC_IDM_10_2 description",
+            "function": "test_TC_IDM_10_2",
+            "path": "sdk/TC_DeviceConformance",
+            "pics": [],
+            "steps": [
+                {
+                    "description": "Run entire test",
+                    "expectation": "",
+                    "is_commissioning": false,
+                    "test_plan_number": 1
+                }
+            ]
+        }
+    ]
+}

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_sdk_python_collection.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_sdk_python_collection.py
@@ -26,7 +26,10 @@ from ...python_testing.models.test_declarations import (
     PythonCaseDeclaration,
     PythonCollectionDeclaration,
 )
-from ...python_testing.sdk_python_tests import sdk_python_test_collection
+from ...python_testing.sdk_python_tests import (
+    sdk_mandatory_python_test_collection,
+    sdk_python_test_collection,
+)
 
 
 @pytest.fixture
@@ -40,6 +43,23 @@ def python_test_collection() -> PythonCollectionDeclaration:
     ):
         folder = SDKTestFolder(path=test_sdk_python_path, filename_pattern="TC_*")
         return sdk_python_test_collection(folder, tests_file_path=test_sdk_python_path)
+
+
+def _load_collections_from(
+    tests_file_path: Path,
+) -> tuple[PythonCollectionDeclaration, PythonCollectionDeclaration]:
+    with mock.patch.object(Path, "exists", return_value=True), mock.patch(
+        "test_collections.matter.sdk_tests.support.models.sdk_test_folder.open",
+        new=mock.mock_open(read_data="unit-test-python-version"),
+    ):
+        folder = SDKTestFolder(path=tests_file_path, filename_pattern="TC_*")
+        non_mandatory = sdk_python_test_collection(
+            folder, tests_file_path=tests_file_path
+        )
+        mandatory = sdk_mandatory_python_test_collection(
+            folder, tests_file_path=tests_file_path
+        )
+        return non_mandatory, mandatory
 
 
 def test_sdk_python_test_collection(
@@ -69,3 +89,27 @@ def test_automated_suite(python_test_collection: PythonCollectionDeclaration) ->
         type_count[test_case.test_type] += 1
 
     assert type_count[MatterTestType.AUTOMATED] == expected_automated_test_cases
+
+
+def test_mandatory_test_not_duplicated_across_collections() -> None:
+    """Regression test for issue #1087.
+
+    A mandatory test case (e.g. TC_IDM_10_2) must be present in the
+    "Mandatory SDK Python Tests" collection only, and must not also be
+    duplicated into the "Old script format" (LEGACY) suite of the
+    non-mandatory "SDK Python Tests" collection.
+    """
+    tests_file_path = (
+        Path(__file__).parent / "test_python_script/mandatory_tests_info.json"
+    )
+    non_mandatory_collection, mandatory_collection = _load_collections_from(
+        tests_file_path
+    )
+
+    for suite in non_mandatory_collection.test_suites.values():
+        assert "TC_IDM_10_2" not in suite.test_cases
+
+    mandatory_suite_name = "Python Testing Suite - Mandatories"
+    assert mandatory_suite_name in mandatory_collection.test_suites.keys()
+    mandatory_suite = mandatory_collection.test_suites[mandatory_suite_name]
+    assert "TC_IDM_10_2" in mandatory_suite.test_cases


### PR DESCRIPTION
## Summary

Cherry-picks two commits from `v2.15.1-develop` onto `v2.16-develop`:

1. **#346** — "Allow mandatory tests to be sideloaded" — introduces the `CollectionType` enum (`NON_MANDATORY`/`MANDATORY`/`ALL`) so mandatory tests can be sideloaded via custom test collections.
2. **#358** — "Fix mandatory Python tests duplicated into Old Script Format suite" — fixes a regression introduced by #346 where the LEGACY-suite fallback branch lost its `python_test_type != MANDATORY` guard, causing mandatory tests (e.g. `TC-IDM-10.2`, `TC-IDM-10.3`, `TC-IDM-10.4`, `TC-IDM-10.5`, `TC-IDM-12.1`) to be duplicated into both `Mandatory SDK Python Tests` and `SDK Python Tests` (Old Script Format), and executed twice via the TH CLI.

`v2.16-develop` never had #346 merged, so it was unaffected by the #1087 bug on its own — this PR brings in both the original feature and its fix together so the branch ends up in the same corrected state as `v2.15.1-develop`, without ever passing through the broken intermediate state.

Fixes project-chip/certification-tool#1087 (on this branch)

## Changes

Both commits applied cleanly with no merge conflicts.

- `test_collections/matter/sdk_tests/support/python_testing/sdk_python_tests.py` — `CollectionType` enum + corrected classification guard
- `test_collections/matter/sdk_tests/support/tests/python_tests/test_sdk_python_collection.py` — regression test
- `test_collections/matter/sdk_tests/support/tests/python_tests/test_python_script/mandatory_tests_info.json` — new fixture for the regression test (doesn't touch the shared `python_tests_info.json` fixture used by other tests)

## Testing

flake8, isort, and black all pass on the touched files. Docker isn't available in this environment to run the full pytest suite; please confirm CI passes.
