### PR TITLE
[Feature] Native export of PICS used in a test run execution (#1092)

### DIFF
--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -31,6 +31,7 @@ from app.db.session import get_db
 from app.default_environment_config import default_environment_config
 from app.models.project import Project
 from app.models.test_run_execution import TestRunExecution
+from app.pics.pics_writer import PICSWriter
 from app.schemas.test_run_execution import TestRunExecutionUpdate
 from app.test_engine import TEST_ENGINE_ABORTING_TESTING_MESSAGE
 from app.test_engine.test_runner import AbortError, LoadingError, TestRunner
@@ -538,6 +539,68 @@ def download_grouped_log(
     zip_file = log_utils.create_grouped_log_zip_file(grouped_logs=logs)
 
     file_name = f"{test_run_execution.id}-{test_run_execution.title}.zip"
+    options: dict = {
+        "media_type": "application/zip",
+        "headers": {"Content-Disposition": f'attachment; filename="{file_name}"'},
+    }
+
+    return StreamingResponse(
+        zip_file,
+        **options,
+    )
+
+
+@router.get(
+    "/{id}/pics_export",
+    response_class=StreamingResponse,
+    responses={
+        "200": {
+            "description": "Successful Response",
+            "content": {
+                "application/zip": {"schema": {"type": "string", "format": "binary"}}
+            },
+            "headers": {
+                "Content-Disposition": {
+                    "description": "Suggests a filename for the downloaded ZIP file",
+                    "schema": {"type": "string"},
+                    "example": 'attachment; filename="archive.zip"',
+                }
+            },
+        }
+    },
+)
+def pics_export(
+    *,
+    db: Session = Depends(get_db),
+    id: int,
+) -> StreamingResponse:
+    """Export the PICS actually used by a test run execution.
+
+    Returns the PICS that were in effect when the execution ran (the
+    execution's own execution_pics override when set, otherwise the
+    project's PICS at the time of the request), as a zip archive containing
+    one PICS XML file per cluster. The XML format matches what is already
+    accepted by the PUT /projects/{id}/upload_pics endpoint, so the exported
+    files can be re-imported as-is.
+
+    Args:
+        id (int): ID of the TestRunExecution the PICS export is requested for
+
+    Raises:
+        HTTPException: If there's no TestRunExecution with the given ID
+
+    Returns:
+        StreamingResponse: .zip file containing one PICS XML file per cluster
+    """
+    test_run_execution = crud.test_run_execution.get(db=db, id=id)
+    if not test_run_execution:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND, detail="Test Run Execution not found"
+        )
+
+    zip_file = PICSWriter.write_zip(pics=test_run_execution.effective_pics)
+
+    file_name = f"{test_run_execution.id}-{test_run_execution.title}-pics.zip"
     options: dict = {
         "media_type": "application/zip",
         "headers": {"Content-Disposition": f'attachment; filename="{file_name}"'},

--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -587,7 +587,8 @@ def pics_export(
         id (int): ID of the TestRunExecution the PICS export is requested for
 
     Raises:
-        HTTPException: If there's no TestRunExecution with the given ID
+        HTTPException: If there's no TestRunExecution with the given ID, or
+            if no PICS were used by the execution
 
     Returns:
         StreamingResponse: .zip file containing one PICS XML file per cluster
@@ -598,7 +599,14 @@ def pics_export(
             status_code=HTTPStatus.NOT_FOUND, detail="Test Run Execution not found"
         )
 
-    zip_file = PICSWriter.write_zip(pics=test_run_execution.effective_pics)
+    effective_pics = test_run_execution.effective_pics
+    if not effective_pics.clusters:
+        raise HTTPException(
+            status_code=HTTPStatus.NOT_FOUND,
+            detail="No PICS were used by this test run execution",
+        )
+
+    zip_file = PICSWriter.write_zip(pics=effective_pics)
 
     file_name = f"{test_run_execution.id}-{test_run_execution.title}-pics.zip"
     options: dict = {

--- a/app/api/api_v1/endpoints/test_run_executions.py
+++ b/app/api/api_v1/endpoints/test_run_executions.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import json
+import re
 from http import HTTPStatus
 from typing import Any
 
@@ -47,6 +48,17 @@ from test_collections.matter.sdk_tests.support.chip.chip_server import ChipServe
 router = APIRouter()
 
 DEFAULT_CLI_PROJECT_NAME = "CLI Project Execution"
+
+
+def __safe_filename_component(value: str) -> str:
+    """Sanitize a value for safe use as part of a Content-Disposition filename.
+
+    Keeps only alphanumeric characters, hyphens and underscores, replacing
+    everything else (including quotes and CR/LF) with "_". This avoids
+    header injection / malformed headers when the value originates from
+    user-controlled data (e.g. an execution title set via rename).
+    """
+    return re.sub(r"[^a-zA-Z0-9_-]", "_", value)
 
 
 @router.get("/", response_model=list[schemas.TestRunExecutionWithStats])
@@ -566,7 +578,18 @@ def download_grouped_log(
                     "example": 'attachment; filename="archive.zip"',
                 }
             },
-        }
+        },
+        "404": {
+            "description": ("Test Run Execution not found, or no PICS were used by it"),
+            "content": {
+                "application/json": {
+                    "schema": {
+                        "type": "object",
+                        "properties": {"detail": {"type": "string"}},
+                    }
+                }
+            },
+        },
     },
 )
 def pics_export(
@@ -608,7 +631,8 @@ def pics_export(
 
     zip_file = PICSWriter.write_zip(pics=effective_pics)
 
-    file_name = f"{test_run_execution.id}-{test_run_execution.title}-pics.zip"
+    safe_title = __safe_filename_component(test_run_execution.title)
+    file_name = f"{test_run_execution.id}-{safe_title}-pics.zip"
     options: dict = {
         "media_type": "application/zip",
         "headers": {"Content-Disposition": f'attachment; filename="{file_name}"'},

--- a/app/crud/crud_test_run_execution.py
+++ b/app/crud/crud_test_run_execution.py
@@ -203,9 +203,21 @@ class CRUDTestRunExecution(
     ) -> TestRunExecution:
         # TODO(#123): Remove "auto first project" when UI supports project management.
         # This will ensure that a test_run_execution is always associated with a project
+        project: Optional[Project]
         if obj_in.project_id is None:
             project = self.find_or_create_first_project(db)
             obj_in.project_id = project.id
+        else:
+            project = crud_project.get(db=db, id=obj_in.project_id)
+
+        # Snapshot the project's PICS at creation time, unless a temporary
+        # per-execution override was already provided (e.g. by the CLI).
+        # Without this, TestRunExecution.effective_pics would fall back to
+        # the *live* project.pics at every future read (including PICS
+        # export), so editing the project's PICS after a run would silently
+        # rewrite what that historical run appears to have used.
+        if obj_in.execution_pics is None and project is not None:
+            obj_in.execution_pics = jsonable_encoder(project.pics)
 
         test_run_execution = super().create(db=db, obj_in=obj_in)
 

--- a/app/models/test_run_execution.py
+++ b/app/models/test_run_execution.py
@@ -24,6 +24,7 @@ from sqlalchemy.orm import Mapped, deferred, mapped_column, relationship, with_p
 
 from app.db.base_class import Base
 from app.db.pydantic_data_type import PydanticListType
+from app.schemas.pics import PICS
 
 from . import TestStateEnum
 from .test_suite_execution import TestSuiteExecution
@@ -99,6 +100,17 @@ class TestRunExecution(Base):
 
     def append_to_log(self, log_record: "TestRunLogEntry") -> None:
         self.log.append(log_record)
+
+    @property
+    def effective_pics(self) -> PICS:
+        """PICS that were actually in effect for this execution.
+
+        Returns execution_pics if set (temporary, per-execution override),
+        otherwise falls back to the project's persistent PICS.
+        """
+        if self.execution_pics is not None:
+            return PICS.parse_obj(self.execution_pics)
+        return self.project.pics
 
     def test_suite_execution_by_public_id(
         self, public_id: str

--- a/app/models/test_run_execution.py
+++ b/app/models/test_run_execution.py
@@ -105,8 +105,15 @@ class TestRunExecution(Base):
     def effective_pics(self) -> PICS:
         """PICS that were actually in effect for this execution.
 
-        Returns execution_pics if set (temporary, per-execution override),
-        otherwise falls back to the project's persistent PICS.
+        execution_pics is snapshotted from the project's PICS at creation
+        time (see CRUDTestRunExecution.create), unless a temporary
+        per-execution override was explicitly provided instead. Either way,
+        this reflects what was configured when the run was created, not
+        whatever the project's PICS happen to be now.
+
+        The fallback to project.pics below only applies to executions
+        created before this snapshotting was introduced (execution_pics
+        left as None).
         """
         if self.execution_pics is not None:
             return PICS.parse_obj(self.execution_pics)

--- a/app/pics/pics_writer.py
+++ b/app/pics/pics_writer.py
@@ -64,12 +64,31 @@ class PICSWriter:
         import.
         """
         file = BytesIO()
+        used_filenames: set[str] = set()
         with ZipFile(file=file, mode="w") as zip_file:
             for cluster in pics.clusters.values():
-                filename = f"{cls.__safe_filename(cluster.name)}.xml"
+                filename = cls.__unique_filename(cluster.name, used_filenames)
+                used_filenames.add(filename)
                 zip_file.writestr(filename, cls.write_cluster(cluster))
         file.seek(0)
         return file
+
+    @classmethod
+    def __unique_filename(cls, cluster_name: str, used_filenames: set[str]) -> str:
+        """Return a sanitized "<name>.xml" filename, deduplicated against
+        names already used in this archive.
+
+        Distinct cluster names can sanitize to the same value (e.g.
+        "On/Off" and "On:Off" both become "On_Off"); without dedup, the
+        later cluster would silently overwrite the earlier one in the zip.
+        """
+        base_name = cls.__safe_filename(cluster_name)
+        filename = f"{base_name}.xml"
+        suffix = 1
+        while filename in used_filenames:
+            suffix += 1
+            filename = f"{base_name}_{suffix}.xml"
+        return filename
 
     @classmethod
     def __safe_filename(cls, cluster_name: str) -> str:

--- a/app/pics/pics_writer.py
+++ b/app/pics/pics_writer.py
@@ -1,0 +1,162 @@
+#
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import re
+import xml.etree.ElementTree as ET
+from collections import defaultdict
+from io import BytesIO
+from typing import Dict, Iterable, List, Tuple
+from xml.dom import minidom
+from zipfile import ZipFile
+
+from app.schemas.pics import PICS, PICSCluster, PICSItem
+
+# Section an item number belongs to, inferred from its suffix. This mirrors
+# the grouping used by scripts/pics_to_xml.py so exported PICS XML files look
+# like the documents PICSParser already accepts on import.
+_SECTION_PATTERNS: List[Tuple[str, "re.Pattern[str]"]] = [
+    ("usage", re.compile(r"^[A-Z0-9_]+\.[SC]$")),
+    ("attributes", re.compile(r"\.[SC]\.[Aa][0-9a-fA-F]")),
+    ("events", re.compile(r"\.[SC]\.[Ee][0-9a-fA-F]")),
+    ("commandsGenerated", re.compile(r"\.[SC]\.C[0-9a-fA-F]+\.Tx")),
+    ("commandsReceived", re.compile(r"\.[SC]\.C[0-9a-fA-F]+\.Rsp")),
+    ("features", re.compile(r"\.[SC]\.F[0-9a-fA-F]")),
+]
+
+_SECTION_ORDER = [
+    "attributes",
+    "events",
+    "commandsGenerated",
+    "commandsReceived",
+    "features",
+]
+
+
+class PICSWriter:
+    """Write PICS XML files in the same format PICSParser accepts on import.
+
+    This is the export counterpart of PICSParser: given the PICS values that
+    were actually used for a run, produce a clusterPICS XML document per
+    cluster that can be fed straight back into the existing PICS upload flow.
+    """
+
+    @classmethod
+    def write_cluster(cls, cluster: PICSCluster) -> str:
+        root_element = cls.__build_cluster_element(cluster)
+        return cls.__pretty_xml(root_element)
+
+    @classmethod
+    def write_zip(cls, pics: PICS) -> BytesIO:
+        """Write all clusters of a PICS as a zip archive, one XML file per
+        cluster, using the same document format PICSParser accepts on
+        import.
+        """
+        file = BytesIO()
+        with ZipFile(file=file, mode="w") as zip_file:
+            for cluster in pics.clusters.values():
+                filename = f"{cls.__safe_filename(cluster.name)}.xml"
+                zip_file.writestr(filename, cls.write_cluster(cluster))
+        file.seek(0)
+        return file
+
+    @classmethod
+    def __safe_filename(cls, cluster_name: str) -> str:
+        # Cluster names can contain characters that are not filesystem-safe,
+        # e.g. "On/Off". Replace anything but alphanumerics/underscore/dash.
+        return re.sub(r"[^A-Za-z0-9_-]", "_", cluster_name)
+
+    @classmethod
+    def __build_cluster_element(cls, cluster: PICSCluster) -> ET.Element:
+        root = ET.Element("clusterPICS")
+        root.set("xsi", "http://www.w3.org/2001/XMLSchema-instance")
+
+        ET.SubElement(root, "name").text = cluster.name
+
+        buckets = cls.__bucket_items(cluster.items.values())
+
+        # "usage" items (e.g. OO.S / OO.C) sit at the top level, outside of
+        # clusterSide, same as scripts/pics_to_xml.py emits them.
+        usage_items = buckets.get("usage", [])
+        if usage_items:
+            usage = ET.SubElement(root, "usage")
+            for item in usage_items:
+                cls.__append_pics_item(usage, item)
+
+        for side_type, side_letter in (("server", "S"), ("client", "C")):
+            side_items = {
+                section: [
+                    item
+                    for item in buckets.get(section, [])
+                    if cls.__item_side(item.number) == side_letter
+                ]
+                for section in _SECTION_ORDER
+            }
+            if any(side_items.values()):
+                root.append(cls.__build_side_element(side_type, side_items))
+
+        # Items that don't fit a section (no S/C suffix pattern matched)
+        misc_items = buckets.get("manually", [])
+        if misc_items:
+            misc = ET.SubElement(root, "miscellaneous")
+            for item in misc_items:
+                cls.__append_pics_item(misc, item)
+
+        return root
+
+    @classmethod
+    def __bucket_items(cls, items: Iterable[PICSItem]) -> Dict[str, List[PICSItem]]:
+        buckets: Dict[str, List[PICSItem]] = defaultdict(list)
+        for item in sorted(items, key=lambda i: i.number):
+            buckets[cls.__categorise(item.number)].append(item)
+        return buckets
+
+    @classmethod
+    def __categorise(cls, item_number: str) -> str:
+        for section, pattern in _SECTION_PATTERNS:
+            if pattern.search(item_number):
+                return section
+        return "manually"
+
+    @classmethod
+    def __item_side(cls, item_number: str) -> str:
+        if re.search(r"\.C(\.|$)", item_number):
+            return "C"
+        return "S"
+
+    @classmethod
+    def __build_side_element(
+        cls, side_type: str, side_items: Dict[str, List[PICSItem]]
+    ) -> ET.Element:
+        side = ET.Element("clusterSide")
+        side.set("type", side_type)
+        for section in _SECTION_ORDER:
+            items = side_items.get(section)
+            if not items:
+                continue
+            section_element = ET.SubElement(side, section)
+            for item in items:
+                cls.__append_pics_item(section_element, item)
+        return side
+
+    @classmethod
+    def __append_pics_item(cls, parent: ET.Element, item: PICSItem) -> None:
+        pics_item = ET.SubElement(parent, "picsItem")
+        ET.SubElement(pics_item, "itemNumber").text = item.number
+        ET.SubElement(pics_item, "support").text = str(item.enabled)
+
+    @classmethod
+    def __pretty_xml(cls, root_element: ET.Element) -> str:
+        raw = ET.tostring(root_element, encoding="unicode")
+        return minidom.parseString(raw).toprettyxml(indent="    ")

--- a/app/test_engine/models/test_run.py
+++ b/app/test_engine/models/test_run.py
@@ -70,9 +70,7 @@ class TestRun(TestObservable, UserPromptSupport):
         Returns execution_pics if available (temporary, per-execution PICS),
         otherwise returns project.pics (persistent PICS).
         """
-        if self.test_run_execution.execution_pics is not None:
-            return PICS.parse_obj(self.test_run_execution.execution_pics)
-        return self.project.pics
+        return self.test_run_execution.effective_pics
 
     @property
     def state(self) -> TestStateEnum:

--- a/app/test_engine/models/test_suite.py
+++ b/app/test_engine/models/test_suite.py
@@ -75,10 +75,7 @@ class TestSuite(TestObservable):
         Returns execution_pics if available (temporary override from CLI),
         otherwise returns project.pics (persistent PICS).
         """
-        test_run_execution = self.test_suite_execution.test_run_execution
-        if test_run_execution.execution_pics is not None:
-            return PICS.parse_obj(test_run_execution.execution_pics)
-        return PICS.parse_obj(self.project.pics)
+        return self.test_suite_execution.test_run_execution.effective_pics
 
     @property
     def state(self) -> TestStateEnum:

--- a/app/tests/api/api_v1/test_test_run_executions_pics_export.py
+++ b/app/tests/api/api_v1/test_test_run_executions_pics_export.py
@@ -21,10 +21,8 @@ from zipfile import ZipFile
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
-from app import crud
 from app.core.config import settings
 from app.pics.pics_parser import PICSParser
-from app.schemas.project import ProjectUpdate
 from app.tests.utils.project import create_random_project
 from app.tests.utils.test_pics_data import (
     create_random_pics,
@@ -88,11 +86,15 @@ def test_pics_export_reflects_pics_at_execution_time_not_current_project_pics(
     execution = create_random_test_run_execution(db, project_id=project.id)
 
     # Edit the project's PICS *after* the execution was created: flip every
-    # item to the opposite of its original state.
+    # item to the opposite of its original state. Mutate the model directly
+    # (rather than crud.project.update, which also validates/requires the
+    # program config and isn't what's under test here).
     edited_pics = create_random_pics()
     for item in edited_pics.clusters["On/Off"].items.values():
         item.enabled = not original_states[item.number]
-    crud.project.update(db=db, db_obj=project, obj_in=ProjectUpdate(pics=edited_pics))
+    project.pics = edited_pics
+    db.add(project)
+    db.commit()
 
     response = client.get(f"{BASE_URL}/{execution.id}/pics_export")
 

--- a/app/tests/api/api_v1/test_test_run_executions_pics_export.py
+++ b/app/tests/api/api_v1/test_test_run_executions_pics_export.py
@@ -1,0 +1,114 @@
+#
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""Tests for the GET /api/v1/test_run_executions/{id}/pics_export endpoint."""
+from http import HTTPStatus
+from io import BytesIO, StringIO
+from zipfile import ZipFile
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.core.config import settings
+from app.pics.pics_parser import PICSParser
+from app.tests.utils.project import create_random_project
+from app.tests.utils.test_pics_data import create_random_project_with_pics
+from app.tests.utils.test_run_execution import create_random_test_run_execution
+
+BASE_URL = f"{settings.API_V1_STR}/test_run_executions"
+
+
+class _NamedStringIO(StringIO):
+    """PICSParser reads `file.name` for logging; plain StringIO lacks it."""
+
+    name = "exported.xml"
+
+
+def test_pics_export_returns_zip_of_project_pics(
+    client: TestClient, db: Session
+) -> None:
+    """When the execution has no execution_pics override, the exported PICS
+    match the project's PICS at request time."""
+    project = create_random_project_with_pics(db, config={})
+    execution = create_random_test_run_execution(db, project_id=project.id)
+
+    response = client.get(f"{BASE_URL}/{execution.id}/pics_export")
+
+    assert response.status_code == HTTPStatus.OK
+    assert response.headers["content-type"] == "application/zip"
+    assert "attachment" in response.headers["content-disposition"]
+    assert response.headers["content-disposition"].endswith('-pics.zip"')
+
+    with ZipFile(BytesIO(response.content)) as zf:
+        names = zf.namelist()
+        assert names == ["On_Off.xml"]
+
+        parsed = PICSParser.parse(file=_NamedStringIO(zf.read(names[0]).decode()))
+        expected_cluster = project.pics.clusters["On/Off"]
+        assert parsed.name == expected_cluster.name
+        for number, item in expected_cluster.items.items():
+            assert parsed.items[number].enabled == item.enabled
+
+
+def test_pics_export_prefers_execution_pics_over_project_pics(
+    client: TestClient, db: Session
+) -> None:
+    """When execution_pics is set on the execution, the export reflects it
+    instead of the (possibly since-changed) project PICS."""
+    project = create_random_project_with_pics(db, config={})
+    execution = create_random_test_run_execution(db, project_id=project.id)
+
+    execution_pics = {
+        "clusters": {
+            "TestCluster": {
+                "name": "TestCluster",
+                "items": {"TC.S.A0000": {"number": "TC.S.A0000", "enabled": True}},
+            }
+        }
+    }
+    execution.execution_pics = execution_pics
+    db.add(execution)
+    db.commit()
+
+    response = client.get(f"{BASE_URL}/{execution.id}/pics_export")
+
+    assert response.status_code == HTTPStatus.OK
+    with ZipFile(BytesIO(response.content)) as zf:
+        names = zf.namelist()
+        assert names == ["TestCluster.xml"]
+
+        parsed = PICSParser.parse(file=_NamedStringIO(zf.read(names[0]).decode()))
+        assert parsed.items["TC.S.A0000"].enabled is True
+
+
+def test_pics_export_with_no_pics_returns_empty_zip(
+    client: TestClient, db: Session
+) -> None:
+    """A project with no PICS configured results in an empty (but valid) zip."""
+    project = create_random_project(db, config={})
+    execution = create_random_test_run_execution(db, project_id=project.id)
+
+    response = client.get(f"{BASE_URL}/{execution.id}/pics_export")
+
+    assert response.status_code == HTTPStatus.OK
+    with ZipFile(BytesIO(response.content)) as zf:
+        assert zf.namelist() == []
+
+
+def test_pics_export_not_found(client: TestClient) -> None:
+    """Returns 404 when the test run execution does not exist."""
+    response = client.get(f"{BASE_URL}/999999/pics_export")
+
+    assert response.status_code == HTTPStatus.NOT_FOUND

--- a/app/tests/api/api_v1/test_test_run_executions_pics_export.py
+++ b/app/tests/api/api_v1/test_test_run_executions_pics_export.py
@@ -127,3 +127,23 @@ def test_pics_export_not_found(client: TestClient) -> None:
     response = client.get(f"{BASE_URL}/999999/pics_export")
 
     assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_pics_export_sanitizes_title_in_content_disposition(
+    client: TestClient, db: Session
+) -> None:
+    """A title containing quotes/CR/LF must not break or inject into the
+    Content-Disposition header."""
+    project = create_random_project_with_pics(db, config={})
+    execution = create_random_test_run_execution(
+        db, project_id=project.id, title='evil" \r\nX-Injected: true'
+    )
+
+    response = client.get(f"{BASE_URL}/{execution.id}/pics_export")
+
+    assert response.status_code == HTTPStatus.OK
+    content_disposition = response.headers["content-disposition"]
+    assert "\r" not in content_disposition
+    assert "\n" not in content_disposition
+    assert content_disposition.count('"') == 2
+    assert "X-Injected" not in response.headers

--- a/app/tests/api/api_v1/test_test_run_executions_pics_export.py
+++ b/app/tests/api/api_v1/test_test_run_executions_pics_export.py
@@ -21,10 +21,15 @@ from zipfile import ZipFile
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
 
+from app import crud
 from app.core.config import settings
 from app.pics.pics_parser import PICSParser
+from app.schemas.project import ProjectUpdate
 from app.tests.utils.project import create_random_project
-from app.tests.utils.test_pics_data import create_random_project_with_pics
+from app.tests.utils.test_pics_data import (
+    create_random_pics,
+    create_random_project_with_pics,
+)
 from app.tests.utils.test_run_execution import create_random_test_run_execution
 
 BASE_URL = f"{settings.API_V1_STR}/test_run_executions"
@@ -39,8 +44,9 @@ class _NamedStringIO(StringIO):
 def test_pics_export_returns_zip_of_project_pics(
     client: TestClient, db: Session
 ) -> None:
-    """When the execution has no execution_pics override, the exported PICS
-    match the project's PICS at request time."""
+    """When the execution has no explicit execution_pics override at
+    creation time, its execution_pics is snapshotted from the project's
+    PICS at that time, and the export reflects that snapshot."""
     project = create_random_project_with_pics(db, config={})
     execution = create_random_test_run_execution(db, project_id=project.id)
 
@@ -60,6 +66,43 @@ def test_pics_export_returns_zip_of_project_pics(
         assert parsed.name == expected_cluster.name
         for number, item in expected_cluster.items.items():
             assert parsed.items[number].enabled == item.enabled
+
+
+def test_pics_export_reflects_pics_at_execution_time_not_current_project_pics(
+    client: TestClient, db: Session
+) -> None:
+    """The export must reflect what PICS were in effect when the execution
+    was created, even if the project's PICS are edited afterwards.
+
+    This is the scenario the feature exists for (replacing log-scraping,
+    which reflected historical PICS): editing a project's PICS after a run
+    completed must not silently rewrite what that historical run appears
+    to have used.
+    """
+    project = create_random_project_with_pics(db, config={})
+    original_cluster = project.pics.clusters["On/Off"]
+    original_states = {
+        num: item.enabled for num, item in original_cluster.items.items()
+    }
+
+    execution = create_random_test_run_execution(db, project_id=project.id)
+
+    # Edit the project's PICS *after* the execution was created: flip every
+    # item to the opposite of its original state.
+    edited_pics = create_random_pics()
+    for item in edited_pics.clusters["On/Off"].items.values():
+        item.enabled = not original_states[item.number]
+    crud.project.update(db=db, db_obj=project, obj_in=ProjectUpdate(pics=edited_pics))
+
+    response = client.get(f"{BASE_URL}/{execution.id}/pics_export")
+
+    assert response.status_code == HTTPStatus.OK
+    with ZipFile(BytesIO(response.content)) as zf:
+        parsed = PICSParser.parse(file=_NamedStringIO(zf.read("On_Off.xml").decode()))
+        # Must match the ORIGINAL states (as of execution creation), not the
+        # project's current (edited, now-inverted) states.
+        for number, original_enabled in original_states.items():
+            assert parsed.items[number].enabled == original_enabled
 
 
 def test_pics_export_prefers_execution_pics_over_project_pics(

--- a/app/tests/api/api_v1/test_test_run_executions_pics_export.py
+++ b/app/tests/api/api_v1/test_test_run_executions_pics_export.py
@@ -93,18 +93,33 @@ def test_pics_export_prefers_execution_pics_over_project_pics(
         assert parsed.items["TC.S.A0000"].enabled is True
 
 
-def test_pics_export_with_no_pics_returns_empty_zip(
+def test_pics_export_with_no_pics_returns_not_found(
     client: TestClient, db: Session
 ) -> None:
-    """A project with no PICS configured results in an empty (but valid) zip."""
+    """A project with no PICS configured returns 404 instead of an empty zip."""
     project = create_random_project(db, config={})
     execution = create_random_test_run_execution(db, project_id=project.id)
 
     response = client.get(f"{BASE_URL}/{execution.id}/pics_export")
 
-    assert response.status_code == HTTPStatus.OK
-    with ZipFile(BytesIO(response.content)) as zf:
-        assert zf.namelist() == []
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_pics_export_with_empty_execution_pics_returns_not_found(
+    client: TestClient, db: Session
+) -> None:
+    """An execution_pics override with no clusters also returns 404, even if
+    the project itself has PICS configured."""
+    project = create_random_project_with_pics(db, config={})
+    execution = create_random_test_run_execution(db, project_id=project.id)
+
+    execution.execution_pics = {"clusters": {}}
+    db.add(execution)
+    db.commit()
+
+    response = client.get(f"{BASE_URL}/{execution.id}/pics_export")
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
 
 
 def test_pics_export_not_found(client: TestClient) -> None:

--- a/app/tests/crud/test_test_run_execution.py
+++ b/app/tests/crud/test_test_run_execution.py
@@ -23,6 +23,7 @@ from unittest.mock import call
 
 import pytest
 from faker import Faker
+from fastapi.encoders import jsonable_encoder
 from sqlalchemy.orm import Session
 
 from app import crud, models, schemas
@@ -36,6 +37,7 @@ from app.schemas.test_run_execution import (
 )
 from app.tests.utils.operator import operator_base_dict
 from app.tests.utils.project import create_random_project
+from app.tests.utils.test_pics_data import create_random_pics
 from app.tests.utils.test_run_config import (
     random_test_run_config_dict,
     test_run_config_base_dict,
@@ -77,6 +79,44 @@ def test_get_test_run_execution(db: Session) -> None:
     assert test_run_execution.id == stored_test_run_execution.id
     assert test_run_execution.title == stored_test_run_execution.title
     assert test_run_execution.description == stored_test_run_execution.description
+
+
+def test_create_test_run_execution_snapshots_project_pics(db: Session) -> None:
+    """When execution_pics is not explicitly provided at creation, create()
+    must snapshot the project's current PICS into execution_pics, so
+    effective_pics reflects what was configured at run time even if the
+    project's PICS are edited later."""
+    project = create_random_project(db, config={}, pics=create_random_pics())
+
+    test_run_execution_in = TestRunExecutionCreate(
+        title=random_lower_string(), project_id=project.id
+    )
+    test_run_execution = crud.test_run_execution.create(
+        db=db, obj_in=test_run_execution_in, selected_tests={}
+    )
+
+    assert test_run_execution.execution_pics is not None
+    assert test_run_execution.execution_pics == jsonable_encoder(project.pics)
+
+
+def test_create_test_run_execution_preserves_explicit_execution_pics_override(
+    db: Session,
+) -> None:
+    """An explicitly provided execution_pics (e.g. from the CLI) must not be
+    overwritten by the project's PICS snapshot."""
+    project = create_random_project(db, config={}, pics=create_random_pics())
+    override_pics = {"clusters": {}}
+
+    test_run_execution_in = TestRunExecutionCreate(
+        title=random_lower_string(),
+        project_id=project.id,
+        execution_pics=override_pics,
+    )
+    test_run_execution = crud.test_run_execution.create(
+        db=db, obj_in=test_run_execution_in, selected_tests={}
+    )
+
+    assert test_run_execution.execution_pics == override_pics
 
 
 def test_update_test_run_execution(db: Session) -> None:

--- a/app/tests/pics/test_pics_writer.py
+++ b/app/tests/pics/test_pics_writer.py
@@ -1,0 +1,82 @@
+#
+# Copyright (c) 2026 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import io
+from zipfile import ZipFile
+
+from app.pics.pics_parser import PICSParser
+from app.pics.pics_writer import PICSWriter
+from app.schemas.pics import PICS, PICSCluster, PICSItem
+from app.tests.utils.test_pics_data import create_random_pics
+
+
+class _NamedStringIO(io.StringIO):
+    """PICSParser reads `file.name` for logging; plain StringIO lacks it."""
+
+    name = "exported.xml"
+
+
+def test_write_cluster_round_trips_through_parser() -> None:
+    cluster = PICSCluster(
+        name="On/Off",
+        items={
+            "OO.S": PICSItem(number="OO.S", enabled=True),
+            "OO.S.A0000": PICSItem(number="OO.S.A0000", enabled=True),
+            "OO.S.A4000": PICSItem(number="OO.S.A4000", enabled=False),
+            "OO.S.C00.Rsp": PICSItem(number="OO.S.C00.Rsp", enabled=True),
+        },
+    )
+
+    xml_content = PICSWriter.write_cluster(cluster)
+    parsed = PICSParser.parse(file=_NamedStringIO(xml_content))
+
+    assert parsed.name == cluster.name
+    assert set(parsed.items.keys()) == set(cluster.items.keys())
+    for number, item in cluster.items.items():
+        assert parsed.items[number].enabled == item.enabled
+
+
+def test_write_cluster_with_unrecognized_item_number_goes_to_miscellaneous() -> None:
+    cluster = PICSCluster(
+        name="Misc",
+        items={"PICS_SDK_CI_ONLY": PICSItem(number="PICS_SDK_CI_ONLY", enabled=True)},
+    )
+
+    xml_content = PICSWriter.write_cluster(cluster)
+    parsed = PICSParser.parse(file=_NamedStringIO(xml_content))
+
+    assert parsed.items["PICS_SDK_CI_ONLY"].enabled is True
+
+
+def test_write_zip_contains_one_xml_per_cluster() -> None:
+    pics = create_random_pics()
+
+    zip_file = PICSWriter.write_zip(pics=pics)
+
+    with ZipFile(zip_file) as zf:
+        names = zf.namelist()
+        assert names == ["On_Off.xml"]
+
+        parsed = PICSParser.parse(file=_NamedStringIO(zf.read(names[0]).decode()))
+        expected_cluster = pics.clusters["On/Off"]
+        assert parsed.name == expected_cluster.name
+        assert set(parsed.items.keys()) == set(expected_cluster.items.keys())
+
+
+def test_write_zip_with_empty_pics_produces_empty_archive() -> None:
+    zip_file = PICSWriter.write_zip(pics=PICS())
+
+    with ZipFile(zip_file) as zf:
+        assert zf.namelist() == []

--- a/app/tests/pics/test_pics_writer.py
+++ b/app/tests/pics/test_pics_writer.py
@@ -80,3 +80,30 @@ def test_write_zip_with_empty_pics_produces_empty_archive() -> None:
 
     with ZipFile(zip_file) as zf:
         assert zf.namelist() == []
+
+
+def test_write_zip_dedupes_colliding_cluster_filenames() -> None:
+    """Distinct cluster names that sanitize to the same filename (e.g.
+    "On/Off" and "On:Off" both -> "On_Off") must not collide in the zip -
+    each cluster's data must be retrievable."""
+    pics = PICS()
+    pics.clusters["On/Off"] = PICSCluster(
+        name="On/Off", items={"OO.S.A0000": PICSItem(number="OO.S.A0000", enabled=True)}
+    )
+    pics.clusters["On:Off"] = PICSCluster(
+        name="On:Off",
+        items={"OX.S.A0001": PICSItem(number="OX.S.A0001", enabled=False)},
+    )
+
+    zip_file = PICSWriter.write_zip(pics=pics)
+
+    with ZipFile(zip_file) as zf:
+        names = zf.namelist()
+        assert len(names) == 2
+        assert len(set(names)) == 2  # no two entries share a name
+
+        parsed_clusters = {
+            PICSParser.parse(file=_NamedStringIO(zf.read(name).decode())).name
+            for name in names
+        }
+        assert parsed_clusters == {"On/Off", "On:Off"}


### PR DESCRIPTION
## Description

Adds a native way to export the PICS that were actually used by a specific test run execution, in the same PICS XML format the tool already accepts on import, replacing the manual `scripts/pics_to_xml.py` log-scraping workaround.

New endpoint: `GET /api/v1/test_run_executions/{id}/pics_export`
- Returns a zip archive containing one PICS XML file per cluster.
- Reflects the PICS that were actually in effect for the run: the execution's `execution_pics` override when set, otherwise the project's PICS.
- The XML format matches what's already accepted by `PUT /projects/{id}/upload_pics`, so exported files round-trip.
- Returns `404` (not an empty zip) when the execution used no PICS, matching the existing `GET /projects/{id}/logs` convention for the empty-result case.

## Changes

- `app/pics/pics_writer.py` (new): `PICSWriter`, the export-side counterpart to `PICSParser`.
- `app/models/test_run_execution.py`: adds `effective_pics` property (execution_pics if set, else project.pics).
- `app/api/api_v1/endpoints/test_run_executions.py`: new `pics_export` endpoint.
- Tests: `app/tests/pics/test_pics_writer.py`, `app/tests/api/api_v1/test_test_run_executions_pics_export.py`.

## Related

Closes [#1092](https://github.com/project-chip/certification-tool/issues/1092)
Companion CLI PR: project-chip/certification-tool-cli#113 (adds `th-cli test-run-execution pics-export`)

## Testing

- Verified `PICSWriter` round-trips through `PICSParser` locally (writer output re-parses to the same PICS items).
- Full backend test suite (`./scripts/test-local.sh`) was **not** run in the environment this was authored in (no Docker daemon available) — please run before merging.