### PR TITLE
[Feature] Add Container Logs Config to Project's TH Config 

### DIFF
--- a/app/container_manager/container_manager.py
+++ b/app/container_manager/container_manager.py
@@ -16,7 +16,8 @@
 import asyncio
 import io
 import tarfile
-from asyncio import TimeoutError as AsyncioTimeoutError, wait_for
+from asyncio import TimeoutError as AsyncioTimeoutError
+from asyncio import wait_for
 from pathlib import Path
 from typing import Dict, Optional
 

--- a/app/container_manager/container_manager.py
+++ b/app/container_manager/container_manager.py
@@ -63,9 +63,7 @@ class ContainerManager(object, metaclass=Singleton):
         enable_container_logs: Optional[bool] = None,
     ) -> Container:
         logs_enabled = resolve_container_logs_enabled(enable_container_logs)
-        container = self.__run_new_container(
-            docker_image_tag, parameters, logs_enabled
-        )
+        container = self.__run_new_container(docker_image_tag, parameters, logs_enabled)
         await self.__container_ready(container)
         if logs_enabled:
             logger.info(f"Container running for {docker_image_tag}")

--- a/app/container_manager/container_manager.py
+++ b/app/container_manager/container_manager.py
@@ -42,21 +42,42 @@ from app.test_engine.logger import test_engine_logger as logger
 container_bring_up_timeout = 5  # Seconds
 
 
+def resolve_container_logs_enabled(override: Optional[bool] = None) -> bool:
+    """Resolve whether container-operation logging is enabled.
+
+    A per-project `th_config.enable_container_logs` override, when explicitly
+    resolved by a caller and passed in here, takes precedence over the
+    instance-wide ENABLE_CONTAINER_LOGS environment variable default.
+    """
+    return settings.ENABLE_CONTAINER_LOGS if override is None else override
+
+
 class ContainerManager(object, metaclass=Singleton):
     def __init__(self) -> None:
         self.__client = docker.from_env()
 
     async def create_container(
-        self, docker_image_tag: str, parameters: Dict = {}
+        self,
+        docker_image_tag: str,
+        parameters: Dict = {},
+        enable_container_logs: Optional[bool] = None,
     ) -> Container:
-        container = self.__run_new_container(docker_image_tag, parameters)
+        logs_enabled = resolve_container_logs_enabled(enable_container_logs)
+        container = self.__run_new_container(
+            docker_image_tag, parameters, logs_enabled
+        )
         await self.__container_ready(container)
-        if settings.ENABLE_CONTAINER_LOGS:
+        if logs_enabled:
             logger.info(f"Container running for {docker_image_tag}")
 
         return container
 
-    def destroy(self, container: Container, graceful: bool = False) -> None:
+    def destroy(
+        self,
+        container: Container,
+        graceful: bool = False,
+        enable_container_logs: Optional[bool] = None,
+    ) -> None:
         """Stop and remove a container.
 
         By default this kills the container immediately (existing behavior, used by
@@ -65,9 +86,10 @@ class ContainerManager(object, metaclass=Singleton):
         after Docker's stop timeout) first, so the process inside has a chance to
         release any host resources it holds (e.g. a serial device) before removal.
         """
+        logs_enabled = resolve_container_logs_enabled(enable_container_logs)
         if self.is_running(container):
             if graceful:
-                if settings.ENABLE_CONTAINER_LOGS:
+                if logs_enabled:
                     shell_cmd = docker_stop_command(container.name)
                     logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
                 try:
@@ -81,13 +103,13 @@ class ContainerManager(object, metaclass=Singleton):
 
             if not graceful:
                 # Log equivalent shell command for kill
-                if settings.ENABLE_CONTAINER_LOGS:
+                if logs_enabled:
                     shell_cmd = docker_kill_command(container.name)
                     logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
                 container.kill()
 
         # Log equivalent shell command for remove
-        if settings.ENABLE_CONTAINER_LOGS:
+        if logs_enabled:
             shell_cmd = docker_rm_command(container.name, force=True)
             logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
         container.remove(force=True)
@@ -156,11 +178,13 @@ class ContainerManager(object, metaclass=Singleton):
         return None
 
     # Internal Methods
-    def __run_new_container(self, docker_image_tag: str, parameters: Dict) -> Container:
+    def __run_new_container(
+        self, docker_image_tag: str, parameters: Dict, enable_container_logs: bool
+    ) -> Container:
         # Create containers
         try:
             # Log equivalent shell command
-            if settings.ENABLE_CONTAINER_LOGS:
+            if enable_container_logs:
                 shell_cmd = docker_run_command(docker_image_tag, parameters)
                 logger.info(f"{SHELL_CMD_LOG_PREFIX}{shell_cmd}")
 
@@ -201,9 +225,10 @@ class ContainerManager(object, metaclass=Singleton):
         container_file_path: Path,
         destination_path: Path,
         destination_file_name: str,
+        enable_container_logs: Optional[bool] = None,
     ) -> None:
         try:
-            if settings.ENABLE_CONTAINER_LOGS:
+            if resolve_container_logs_enabled(enable_container_logs):
                 logger.info(
                     "### File Copy: CONTAINER->HOST"
                     f" From Container Path: {str(container_file_path)}"
@@ -237,9 +262,10 @@ class ContainerManager(object, metaclass=Singleton):
         container: Container,
         host_file_path: Path,
         destination_container_path: Path,
+        enable_container_logs: Optional[bool] = None,
     ) -> None:
         try:
-            if settings.ENABLE_CONTAINER_LOGS:
+            if resolve_container_logs_enabled(enable_container_logs):
                 logger.info(
                     "### File Copy: HOST->CONTAINER"
                     f" From Host Path: {str(host_file_path)}"

--- a/app/container_manager/container_manager.py
+++ b/app/container_manager/container_manager.py
@@ -16,7 +16,7 @@
 import asyncio
 import io
 import tarfile
-from asyncio import TimeoutError, wait_for
+from asyncio import TimeoutError as AsyncioTimeoutError, wait_for
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -199,7 +199,7 @@ class ContainerManager(object, metaclass=Singleton):
             await wait_for(
                 self.__container_started(container), container_bring_up_timeout
             )
-        except TimeoutError as e:
+        except AsyncioTimeoutError as e:
             logger.error(
                 f"Container did start timed out in {container_bring_up_timeout}s"
             )

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -111,10 +111,7 @@ class Settings(BaseSettings):
     ENABLE_REALTIME_PYTHON_TEST_LOGS: bool = False
 
     # Container Logging
-    # Defaults to True: most existing TH installs already run with this enabled
-    # via .env, and it can still be explicitly disabled per-instance (.env) or
-    # per-project (th_config.enable_container_logs).
-    ENABLE_CONTAINER_LOGS: bool = True
+    ENABLE_CONTAINER_LOGS: bool = False
 
     class Config:
         case_sensitive = True

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -111,7 +111,10 @@ class Settings(BaseSettings):
     ENABLE_REALTIME_PYTHON_TEST_LOGS: bool = False
 
     # Container Logging
-    ENABLE_CONTAINER_LOGS: bool = False
+    # Defaults to True: most existing TH installs already run with this enabled
+    # via .env, and it can still be explicitly disabled per-instance (.env) or
+    # per-project (th_config.enable_container_logs).
+    ENABLE_CONTAINER_LOGS: bool = True
 
     class Config:
         case_sensitive = True

--- a/app/schemas/test_environment_config.py
+++ b/app/schemas/test_environment_config.py
@@ -55,6 +55,9 @@ class THConfig(BaseModel):
     # None means "not set at project level", deferring to the
     # ENABLE_REALTIME_PYTHON_TEST_LOGS environment variable.
     enable_realtime_python_test_logs: Optional[bool] = None
+    # None means "not set at project level", deferring to the
+    # ENABLE_CONTAINER_LOGS environment variable.
+    enable_container_logs: Optional[bool] = None
 
 
 class TestEnvironmentConfig(BaseModel):

--- a/app/schemas/test_environment_config.py
+++ b/app/schemas/test_environment_config.py
@@ -79,3 +79,22 @@ class TestEnvironmentConfig(BaseModel):
 
     def validate_model(self, dict_model: dict) -> None:
         raise NotImplementedError  # Must be overridden by subclass
+
+
+def get_th_config_value(config: Optional[dict], key: str) -> Any:
+    """Extract a value from a project's th_config, given the raw `.config` dict.
+
+    Tolerates `th_config` being either a plain dict (the normal production
+    shape, since `.config` is always the raw project/execution config dict) or
+    a THConfig/pydantic object — some test doubles fake `.config` via
+    `SomeModel.__dict__`, which does not recursively convert nested pydantic
+    models to dicts, so `th_config` can show up as a THConfig instance there.
+    """
+    if not config:
+        return None
+    th_config = config.get("th_config") if isinstance(config, dict) else None
+    if th_config is None:
+        return None
+    if isinstance(th_config, dict):
+        return th_config.get(key)
+    return getattr(th_config, key, None)

--- a/app/tests/container_manager/test_container_manager.py
+++ b/app/tests/container_manager/test_container_manager.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+import importlib
 from asyncio import TimeoutError
 from pathlib import Path
 from unittest import mock
@@ -20,13 +21,24 @@ from unittest import mock
 import pytest
 from docker.errors import NotFound
 
-import app.container_manager.container_manager as container_manager_module
 from app.container_manager.container_manager import (
     container_manager,
     resolve_container_logs_enabled,
 )
 from app.core.config import settings
 from app.tests.utils.docker import FAKE_ID, Container, make_fake_container
+
+# `app/container_manager/__init__.py` does `from .container_manager import
+# container_manager`, which shadows the submodule name with the singleton
+# instance in the package's own namespace. That means any attribute-chain
+# resolution of "app.container_manager.container_manager" (whether via a
+# mock.patch string, or via `import app.container_manager.container_manager as
+# x`, which also resolves by attribute traversal) lands on the *instance*, not
+# the module. importlib.import_module() does a genuine sys.modules lookup
+# instead, so it reliably returns the actual module object.
+container_manager_module = importlib.import_module(
+    "app.container_manager.container_manager"
+)
 
 DEFAULT_MOUNT_SRC = "/test/path/chip-cert-tool/backend"
 DEFAULT_MOUNT_WORKING_DIR = "/app"

--- a/app/tests/container_manager/test_container_manager.py
+++ b/app/tests/container_manager/test_container_manager.py
@@ -64,9 +64,8 @@ def test_resolve_container_logs_enabled_defers_to_settings_when_none() -> None:
 async def test_create_container_logs_shell_commands_when_enabled() -> None:
     with mock.patch(
         "docker.models.containers.ContainerCollection.run"
-    ), mock.patch(
-        "app.container_manager.container_manager.is_running",
-        return_value=True,
+    ), mock.patch.object(
+        container_manager, "is_running", return_value=True
     ), mock.patch(
         "app.container_manager.container_manager.logger"
     ) as mock_logger:
@@ -83,9 +82,8 @@ async def test_create_container_logs_shell_commands_when_enabled() -> None:
 async def test_create_container_no_logs_when_disabled() -> None:
     with mock.patch(
         "docker.models.containers.ContainerCollection.run"
-    ), mock.patch(
-        "app.container_manager.container_manager.is_running",
-        return_value=True,
+    ), mock.patch.object(
+        container_manager, "is_running", return_value=True
     ), mock.patch(
         "app.container_manager.container_manager.logger"
     ) as mock_logger:

--- a/app/tests/container_manager/test_container_manager.py
+++ b/app/tests/container_manager/test_container_manager.py
@@ -20,10 +20,12 @@ from unittest import mock
 import pytest
 from docker.errors import NotFound
 
+import app.container_manager.container_manager as container_manager_module
 from app.container_manager.container_manager import (
     container_manager,
     resolve_container_logs_enabled,
 )
+from app.core.config import settings
 from app.tests.utils.docker import FAKE_ID, Container, make_fake_container
 
 DEFAULT_MOUNT_SRC = "/test/path/chip-cert-tool/backend"
@@ -31,32 +33,20 @@ DEFAULT_MOUNT_WORKING_DIR = "/app"
 
 
 def test_resolve_container_logs_enabled_explicit_true_wins() -> None:
-    with mock.patch(
-        "app.container_manager.container_manager.settings.ENABLE_CONTAINER_LOGS",
-        False,
-    ):
+    with mock.patch.object(settings, "ENABLE_CONTAINER_LOGS", False):
         assert resolve_container_logs_enabled(True) is True
 
 
 def test_resolve_container_logs_enabled_explicit_false_wins() -> None:
-    with mock.patch(
-        "app.container_manager.container_manager.settings.ENABLE_CONTAINER_LOGS",
-        True,
-    ):
+    with mock.patch.object(settings, "ENABLE_CONTAINER_LOGS", True):
         assert resolve_container_logs_enabled(False) is False
 
 
 def test_resolve_container_logs_enabled_defers_to_settings_when_none() -> None:
-    with mock.patch(
-        "app.container_manager.container_manager.settings.ENABLE_CONTAINER_LOGS",
-        True,
-    ):
+    with mock.patch.object(settings, "ENABLE_CONTAINER_LOGS", True):
         assert resolve_container_logs_enabled(None) is True
 
-    with mock.patch(
-        "app.container_manager.container_manager.settings.ENABLE_CONTAINER_LOGS",
-        False,
-    ):
+    with mock.patch.object(settings, "ENABLE_CONTAINER_LOGS", False):
         assert resolve_container_logs_enabled(None) is False
 
 
@@ -66,8 +56,8 @@ async def test_create_container_logs_shell_commands_when_enabled() -> None:
         "docker.models.containers.ContainerCollection.run"
     ), mock.patch.object(
         container_manager, "is_running", return_value=True
-    ), mock.patch(
-        "app.container_manager.container_manager.logger"
+    ), mock.patch.object(
+        container_manager_module, "logger"
     ) as mock_logger:
         await container_manager.create_container(
             docker_image_tag="org/image:tag", enable_container_logs=True
@@ -84,8 +74,8 @@ async def test_create_container_no_logs_when_disabled() -> None:
         "docker.models.containers.ContainerCollection.run"
     ), mock.patch.object(
         container_manager, "is_running", return_value=True
-    ), mock.patch(
-        "app.container_manager.container_manager.logger"
+    ), mock.patch.object(
+        container_manager_module, "logger"
     ) as mock_logger:
         await container_manager.create_container(
             docker_image_tag="org/image:tag", enable_container_logs=False
@@ -202,8 +192,8 @@ def test_destroy_logs_shell_commands_when_enabled() -> None:
     ), mock.patch(
         "app.container_manager.container_manager.get_container",
         return_value=container,
-    ), mock.patch(
-        "app.container_manager.container_manager.logger"
+    ), mock.patch.object(
+        container_manager_module, "logger"
     ) as mock_logger:
         container_manager.destroy(container, enable_container_logs=True)
 
@@ -218,8 +208,8 @@ def test_destroy_no_logs_when_disabled() -> None:
     ), mock.patch(
         "app.container_manager.container_manager.get_container",
         return_value=container,
-    ), mock.patch(
-        "app.container_manager.container_manager.logger"
+    ), mock.patch.object(
+        container_manager_module, "logger"
     ) as mock_logger:
         container_manager.destroy(container, enable_container_logs=False)
 
@@ -314,7 +304,7 @@ def test_copy_file_from_container_logs_when_enabled(tmp_path: Path) -> None:
     container = make_fake_container({"Id": FAKE_ID, "Name": "test-container"})
     with mock.patch.object(
         container, "get_archive", return_value=(iter([b"data"]), {})
-    ), mock.patch("app.container_manager.container_manager.logger") as mock_logger:
+    ), mock.patch.object(container_manager_module, "logger") as mock_logger:
         container_manager.copy_file_from_container(
             container=container,
             container_file_path=Path("/some/path"),
@@ -333,7 +323,7 @@ def test_copy_file_from_container_no_logs_when_disabled(tmp_path: Path) -> None:
     container = make_fake_container({"Id": FAKE_ID, "Name": "test-container"})
     with mock.patch.object(
         container, "get_archive", return_value=(iter([b"data"]), {})
-    ), mock.patch("app.container_manager.container_manager.logger") as mock_logger:
+    ), mock.patch.object(container_manager_module, "logger") as mock_logger:
         container_manager.copy_file_from_container(
             container=container,
             container_file_path=Path("/some/path"),
@@ -357,8 +347,8 @@ def test_copy_file_to_container_logs_when_enabled(tmp_path: Path) -> None:
         tar.addfile(info, io.BytesIO(content))
 
     container = make_fake_container({"Id": FAKE_ID, "Name": "test-container"})
-    with mock.patch.object(container, "put_archive"), mock.patch(
-        "app.container_manager.container_manager.logger"
+    with mock.patch.object(container, "put_archive"), mock.patch.object(
+        container_manager_module, "logger"
     ) as mock_logger:
         container_manager.copy_file_to_container(
             container=container,
@@ -384,8 +374,8 @@ def test_copy_file_to_container_no_logs_when_disabled(tmp_path: Path) -> None:
         tar.addfile(info, io.BytesIO(content))
 
     container = make_fake_container({"Id": FAKE_ID, "Name": "test-container"})
-    with mock.patch.object(container, "put_archive"), mock.patch(
-        "app.container_manager.container_manager.logger"
+    with mock.patch.object(container, "put_archive"), mock.patch.object(
+        container_manager_module, "logger"
     ) as mock_logger:
         container_manager.copy_file_to_container(
             container=container,

--- a/app/tests/container_manager/test_container_manager.py
+++ b/app/tests/container_manager/test_container_manager.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 import importlib
-from asyncio import TimeoutError
+from asyncio import TimeoutError as AsyncioTimeoutError
 from pathlib import Path
 from unittest import mock
 
@@ -114,7 +114,7 @@ async def test_create_container_timeout() -> None:
         "app.container_manager.container_manager.is_running",
         return_value=False,
     ):
-        with pytest.raises(TimeoutError):
+        with pytest.raises(AsyncioTimeoutError):
             await container_manager.create_container(docker_image_tag="org/image:tag")
 
 

--- a/app/tests/container_manager/test_container_manager.py
+++ b/app/tests/container_manager/test_container_manager.py
@@ -14,16 +14,86 @@
 # limitations under the License.
 #
 from asyncio import TimeoutError
+from pathlib import Path
 from unittest import mock
 
 import pytest
 from docker.errors import NotFound
 
-from app.container_manager.container_manager import container_manager
+from app.container_manager.container_manager import (
+    container_manager,
+    resolve_container_logs_enabled,
+)
 from app.tests.utils.docker import FAKE_ID, Container, make_fake_container
 
 DEFAULT_MOUNT_SRC = "/test/path/chip-cert-tool/backend"
 DEFAULT_MOUNT_WORKING_DIR = "/app"
+
+
+def test_resolve_container_logs_enabled_explicit_true_wins() -> None:
+    with mock.patch(
+        "app.container_manager.container_manager.settings.ENABLE_CONTAINER_LOGS",
+        False,
+    ):
+        assert resolve_container_logs_enabled(True) is True
+
+
+def test_resolve_container_logs_enabled_explicit_false_wins() -> None:
+    with mock.patch(
+        "app.container_manager.container_manager.settings.ENABLE_CONTAINER_LOGS",
+        True,
+    ):
+        assert resolve_container_logs_enabled(False) is False
+
+
+def test_resolve_container_logs_enabled_defers_to_settings_when_none() -> None:
+    with mock.patch(
+        "app.container_manager.container_manager.settings.ENABLE_CONTAINER_LOGS",
+        True,
+    ):
+        assert resolve_container_logs_enabled(None) is True
+
+    with mock.patch(
+        "app.container_manager.container_manager.settings.ENABLE_CONTAINER_LOGS",
+        False,
+    ):
+        assert resolve_container_logs_enabled(None) is False
+
+
+@pytest.mark.asyncio
+async def test_create_container_logs_shell_commands_when_enabled() -> None:
+    with mock.patch(
+        "docker.models.containers.ContainerCollection.run"
+    ), mock.patch(
+        "app.container_manager.container_manager.is_running",
+        return_value=True,
+    ), mock.patch(
+        "app.container_manager.container_manager.logger"
+    ) as mock_logger:
+        await container_manager.create_container(
+            docker_image_tag="org/image:tag", enable_container_logs=True
+        )
+
+    # One log line for the equivalent "docker run" command, one for "Container
+    # running for ...".
+    assert mock_logger.info.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_create_container_no_logs_when_disabled() -> None:
+    with mock.patch(
+        "docker.models.containers.ContainerCollection.run"
+    ), mock.patch(
+        "app.container_manager.container_manager.is_running",
+        return_value=True,
+    ), mock.patch(
+        "app.container_manager.container_manager.logger"
+    ) as mock_logger:
+        await container_manager.create_container(
+            docker_image_tag="org/image:tag", enable_container_logs=False
+        )
+
+    mock_logger.info.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -127,6 +197,37 @@ def test_destroy_graceful_falls_back_to_kill_on_stop_failure() -> None:
         remove.assert_called_once_with(force=True)
 
 
+def test_destroy_logs_shell_commands_when_enabled() -> None:
+    container = make_fake_container({"Id": FAKE_ID, "State": {"Status": "running"}})
+    with mock.patch.object(container, "kill"), mock.patch.object(
+        container, "remove"
+    ), mock.patch(
+        "app.container_manager.container_manager.get_container",
+        return_value=container,
+    ), mock.patch(
+        "app.container_manager.container_manager.logger"
+    ) as mock_logger:
+        container_manager.destroy(container, enable_container_logs=True)
+
+    # One log line for the "docker kill" command, one for "docker rm".
+    assert mock_logger.info.call_count == 2
+
+
+def test_destroy_no_logs_when_disabled() -> None:
+    container = make_fake_container({"Id": FAKE_ID, "State": {"Status": "running"}})
+    with mock.patch.object(container, "kill"), mock.patch.object(
+        container, "remove"
+    ), mock.patch(
+        "app.container_manager.container_manager.get_container",
+        return_value=container,
+    ), mock.patch(
+        "app.container_manager.container_manager.logger"
+    ) as mock_logger:
+        container_manager.destroy(container, enable_container_logs=False)
+
+    mock_logger.info.assert_not_called()
+
+
 def test_remove_containers_for_image_removes_stale_containers() -> None:
     stale_container = make_fake_container(
         {"Id": FAKE_ID, "State": {"Status": "running"}}
@@ -209,3 +310,90 @@ def test_get_mount_source_for_destination_invalid_attrs() -> None:
         container, destination=test_dest
     )
     assert src is None
+
+
+def test_copy_file_from_container_logs_when_enabled(tmp_path: Path) -> None:
+    container = make_fake_container({"Id": FAKE_ID, "Name": "test-container"})
+    with mock.patch.object(
+        container, "get_archive", return_value=(iter([b"data"]), {})
+    ), mock.patch("app.container_manager.container_manager.logger") as mock_logger:
+        container_manager.copy_file_from_container(
+            container=container,
+            container_file_path=Path("/some/path"),
+            destination_path=tmp_path,
+            destination_file_name="out.txt",
+            enable_container_logs=True,
+        )
+
+    # One log line for the "### File Copy" message, one for the equivalent
+    # "docker cp" command.
+    assert mock_logger.info.call_count == 2
+    assert (tmp_path / "out.txt").read_bytes() == b"data"
+
+
+def test_copy_file_from_container_no_logs_when_disabled(tmp_path: Path) -> None:
+    container = make_fake_container({"Id": FAKE_ID, "Name": "test-container"})
+    with mock.patch.object(
+        container, "get_archive", return_value=(iter([b"data"]), {})
+    ), mock.patch("app.container_manager.container_manager.logger") as mock_logger:
+        container_manager.copy_file_from_container(
+            container=container,
+            container_file_path=Path("/some/path"),
+            destination_path=tmp_path,
+            destination_file_name="out.txt",
+            enable_container_logs=False,
+        )
+
+    mock_logger.info.assert_not_called()
+
+
+def test_copy_file_to_container_logs_when_enabled(tmp_path: Path) -> None:
+    import io
+    import tarfile
+
+    host_file = tmp_path / "source.tar"
+    content = b"hello"
+    with tarfile.open(host_file, "w") as tar:
+        info = tarfile.TarInfo(name="file.txt")
+        info.size = len(content)
+        tar.addfile(info, io.BytesIO(content))
+
+    container = make_fake_container({"Id": FAKE_ID, "Name": "test-container"})
+    with mock.patch.object(container, "put_archive"), mock.patch(
+        "app.container_manager.container_manager.logger"
+    ) as mock_logger:
+        container_manager.copy_file_to_container(
+            container=container,
+            host_file_path=host_file,
+            destination_container_path=Path("/dest/file.txt"),
+            enable_container_logs=True,
+        )
+
+    # One log line for the "### File Copy" message, one for the equivalent
+    # "docker cp" command.
+    assert mock_logger.info.call_count == 2
+
+
+def test_copy_file_to_container_no_logs_when_disabled(tmp_path: Path) -> None:
+    import io
+    import tarfile
+
+    host_file = tmp_path / "source.tar"
+    content = b"hello"
+    with tarfile.open(host_file, "w") as tar:
+        info = tarfile.TarInfo(name="file.txt")
+        info.size = len(content)
+        tar.addfile(info, io.BytesIO(content))
+
+    container = make_fake_container({"Id": FAKE_ID, "Name": "test-container"})
+    with mock.patch.object(container, "put_archive"), mock.patch(
+        "app.container_manager.container_manager.logger"
+    ) as mock_logger:
+        container_manager.copy_file_to_container(
+            container=container,
+            host_file_path=host_file,
+            destination_container_path=Path("/dest/file.txt"),
+            enable_container_logs=False,
+        )
+
+    mock_logger.info.assert_not_called()

--- a/test_collections/matter/default_project.config
+++ b/test_collections/matter/default_project.config
@@ -31,6 +31,7 @@
   "test_parameters": null,
   "th_config": {
     "prompt_timeout_seconds": 60,
-    "enable_realtime_python_test_logs": null
+    "enable_realtime_python_test_logs": null,
+    "enable_container_logs": null
   }
 }

--- a/test_collections/matter/sdk_tests/support/chip/chip_server.py
+++ b/test_collections/matter/sdk_tests/support/chip/chip_server.py
@@ -99,6 +99,7 @@ class ChipServer(metaclass=Singleton):
         version: int = 0,
         vendor_id: int = 0,
         product_id: int = 0,
+        enable_container_logs: Optional[bool] = None,
     ) -> str:
         """Generate manual pairing code using chip-tool payload command.
 
@@ -110,6 +111,7 @@ class ChipServer(metaclass=Singleton):
             version: Version number (default: 0)
             vendor_id: Vendor ID (default: 0)
             product_id: Product ID (default: 0)
+            enable_container_logs: Per-run override for container-operation logging
 
         Returns:
             str: Manual pairing code or empty string if generation fails
@@ -140,6 +142,7 @@ class ChipServer(metaclass=Singleton):
             result = self.sdk_container.send_command(
                 command,
                 prefix=CHIP_TOOL_EXE,
+                enable_container_logs=enable_container_logs,
             )
 
             # Parse the output result to extract the manual pairing code
@@ -199,7 +202,10 @@ class ChipServer(metaclass=Singleton):
             return False
 
     async def start(
-        self, server_type: ChipServerType, use_paa_certs: bool = False
+        self,
+        server_type: ChipServerType,
+        use_paa_certs: bool = False,
+        enable_container_logs: Optional[bool] = None,
     ) -> Generator:
         if self.__server_started:
             self.logger.info("Chip server is already started")
@@ -239,6 +245,7 @@ class ChipServer(metaclass=Singleton):
             prefix=prefix,
             is_stream=True,
             is_socket=False,
+            enable_container_logs=enable_container_logs,
         )
         self.__server_logs = exec_result.output
         self.__chip_server_id = exec_result.exec_id
@@ -280,13 +287,15 @@ class ChipServer(metaclass=Singleton):
 
         return exit_code
 
-    async def stop(self) -> None:
+    async def stop(self, enable_container_logs: Optional[bool] = None) -> None:
         if not self.__server_started:
             return
 
         try:
             self.sdk_container.send_command(
-                f'-SIGTERM -f "{self.__server_full_command}"', prefix="pkill"
+                f'-SIGTERM -f "{self.__server_full_command}"',
+                prefix="pkill",
+                enable_container_logs=enable_container_logs,
             )
             self.__wait_for_server_exit()
         except Exception as e:
@@ -305,6 +314,8 @@ class ChipServer(metaclass=Singleton):
         path = Path(DOCKER_LOGS_PATH) / filename
         return f'--trace_file "{path}" --trace_decode 1'
 
-    async def restart(self) -> None:
-        await self.stop()
-        await self.start(self.__server_type, self.__use_paa_certs)
+    async def restart(self, enable_container_logs: Optional[bool] = None) -> None:
+        await self.stop(enable_container_logs)
+        await self.start(
+            self.__server_type, self.__use_paa_certs, enable_container_logs
+        )

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -173,6 +173,18 @@ class PythonTestCase(TestCase, UserPromptSupport):
             return bool(override)
         return settings.ENABLE_REALTIME_PYTHON_TEST_LOGS
 
+    def _container_logs_enabled(self) -> bool:
+        """Whether container-operation logging is enabled.
+
+        The project's th_config.enable_container_logs, when explicitly set,
+        overrides the instance-wide ENABLE_CONTAINER_LOGS env var.
+        """
+        th_config = (self.config or {}).get("th_config") or {}
+        override = th_config.get("enable_container_logs")
+        if override is not None:
+            return bool(override)
+        return settings.ENABLE_CONTAINER_LOGS
+
     async def _display_step_logs(self) -> None:
         """Display logs that were captured during the current step."""
         # Validate file path is set and file exists
@@ -687,6 +699,7 @@ class PythonTestCase(TestCase, UserPromptSupport):
                 prefix=EXECUTABLE,
                 is_stream=True,
                 is_socket=True,
+                enable_container_logs=self._container_logs_enabled(),
             )
             self.test_socket = exec_result.socket
 

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -162,6 +162,16 @@ class PythonTestCase(TestCase, UserPromptSupport):
         if self._realtime_logs_enabled():
             await self._display_step_logs()
 
+    def _safe_config(self) -> Optional[dict]:
+        """`.config`, or None if it's unavailable (e.g. a test double with no
+        wired-up project/execution chain). Used by the th_config resolvers below,
+        whose contract is to fall back to the env var default rather than raise
+        when project config can't be determined."""
+        try:
+            return self.config
+        except Exception:
+            return None
+
     def _realtime_logs_enabled(self) -> bool:
         """Whether Python test logs should be displayed incrementally per step.
 
@@ -169,7 +179,7 @@ class PythonTestCase(TestCase, UserPromptSupport):
         set, overrides the instance-wide ENABLE_REALTIME_PYTHON_TEST_LOGS env var.
         """
         override = get_th_config_value(
-            self.config, "enable_realtime_python_test_logs"
+            self._safe_config(), "enable_realtime_python_test_logs"
         )
         if override is not None:
             return bool(override)
@@ -181,7 +191,7 @@ class PythonTestCase(TestCase, UserPromptSupport):
         The project's th_config.enable_container_logs, when explicitly set,
         overrides the instance-wide ENABLE_CONTAINER_LOGS env var.
         """
-        override = get_th_config_value(self.config, "enable_container_logs")
+        override = get_th_config_value(self._safe_config(), "enable_container_logs")
         if override is not None:
             return bool(override)
         return settings.ENABLE_CONTAINER_LOGS

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_case.py
@@ -25,6 +25,7 @@ from typing import Any, Optional, Type, TypeVar
 from app.constants.shared_constants import NFC_PAIRING_MODES
 from app.core.config import settings
 from app.models import TestCaseExecution
+from app.schemas.test_environment_config import get_th_config_value
 from app.test_engine.logger import PYTHON_TEST_LEVEL
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestCase, TestStep
@@ -167,8 +168,9 @@ class PythonTestCase(TestCase, UserPromptSupport):
         The project's th_config.enable_realtime_python_test_logs, when explicitly
         set, overrides the instance-wide ENABLE_REALTIME_PYTHON_TEST_LOGS env var.
         """
-        th_config = (self.config or {}).get("th_config") or {}
-        override = th_config.get("enable_realtime_python_test_logs")
+        override = get_th_config_value(
+            self.config, "enable_realtime_python_test_logs"
+        )
         if override is not None:
             return bool(override)
         return settings.ENABLE_REALTIME_PYTHON_TEST_LOGS
@@ -179,8 +181,7 @@ class PythonTestCase(TestCase, UserPromptSupport):
         The project's th_config.enable_container_logs, when explicitly set,
         overrides the instance-wide ENABLE_CONTAINER_LOGS env var.
         """
-        th_config = (self.config or {}).get("th_config") or {}
-        override = th_config.get("enable_container_logs")
+        override = get_th_config_value(self.config, "enable_container_logs")
         if override is not None:
             return bool(override)
         return settings.ENABLE_CONTAINER_LOGS

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -17,6 +17,7 @@ from enum import Enum
 from typing import Optional, Type, TypeVar
 
 from app.constants.shared_constants import DutPairingModeEnum
+from app.core.config import settings
 from app.schemas.test_environment_config import ThreadAutoConfig
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestSuite
@@ -104,17 +105,35 @@ class PythonTestSuite(TestSuite):
         logger.info(f"Python Test Version: {self.python_test_version}")
 
         logger.info("Setting up SDK container")
-        await self.sdk_container.start()
+        await self.sdk_container.start(
+            enable_container_logs=self._container_logs_enabled()
+        )
 
         self.matter_config = TestEnvironmentConfigMatter(**self.config)
         # pcscd is required for NFC reader access regardless of pairing mode
-        self.sdk_container.send_command("--disable-polkit", prefix="pcscd")
+        self.sdk_container.send_command(
+            "--disable-polkit",
+            prefix="pcscd",
+            enable_container_logs=self._container_logs_enabled(),
+        )
 
         if len(self.pics.clusters) > 0:
             logger.info("Create PICS file for DUT")
             self.sdk_container.set_pics(pics=self.pics)
         else:
             self.sdk_container.reset_pics_state()
+
+    def _container_logs_enabled(self) -> bool:
+        """Whether container-operation logging is enabled.
+
+        The project's th_config.enable_container_logs, when explicitly set,
+        overrides the instance-wide ENABLE_CONTAINER_LOGS env var.
+        """
+        th_config = (self.config or {}).get("th_config") or {}
+        override = th_config.get("enable_container_logs")
+        if override is not None:
+            return bool(override)
+        return settings.ENABLE_CONTAINER_LOGS
 
     async def cleanup(self) -> None:
         logger.info("Suite Cleanup")
@@ -132,7 +151,9 @@ class PythonTestSuite(TestSuite):
                 logger.warning(f"Could not capture admin_storage.json snapshot: {e}")
 
         logger.info("Stopping SDK container")
-        self.sdk_container.destroy()
+        self.sdk_container.destroy(
+            enable_container_logs=self._container_logs_enabled()
+        )
 
         logger.info("Stopping Border Router")
         self.border_router.destroy_device()

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -123,13 +123,23 @@ class PythonTestSuite(TestSuite):
         else:
             self.sdk_container.reset_pics_state()
 
+    def _safe_config(self) -> Optional[dict]:
+        """`.config`, or None if it's unavailable (e.g. a test double with no
+        wired-up project/execution chain). Used by the th_config resolvers below,
+        whose contract is to fall back to the env var default rather than raise
+        when project config can't be determined."""
+        try:
+            return self.config
+        except Exception:
+            return None
+
     def _container_logs_enabled(self) -> bool:
         """Whether container-operation logging is enabled.
 
         The project's th_config.enable_container_logs, when explicitly set,
         overrides the instance-wide ENABLE_CONTAINER_LOGS env var.
         """
-        override = get_th_config_value(self.config, "enable_container_logs")
+        override = get_th_config_value(self._safe_config(), "enable_container_logs")
         if override is not None:
             return bool(override)
         return settings.ENABLE_CONTAINER_LOGS

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -160,9 +160,7 @@ class PythonTestSuite(TestSuite):
                 logger.warning(f"Could not capture admin_storage.json snapshot: {e}")
 
         logger.info("Stopping SDK container")
-        self.sdk_container.destroy(
-            enable_container_logs=self._container_logs_enabled()
-        )
+        self.sdk_container.destroy(enable_container_logs=self._container_logs_enabled())
 
         logger.info("Stopping Border Router")
         self.border_router.destroy_device()

--- a/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/test_suite.py
@@ -18,7 +18,7 @@ from typing import Optional, Type, TypeVar
 
 from app.constants.shared_constants import DutPairingModeEnum
 from app.core.config import settings
-from app.schemas.test_environment_config import ThreadAutoConfig
+from app.schemas.test_environment_config import ThreadAutoConfig, get_th_config_value
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestSuite
 from app.user_prompt_support.user_prompt_support import UserPromptSupport
@@ -129,8 +129,7 @@ class PythonTestSuite(TestSuite):
         The project's th_config.enable_container_logs, when explicitly set,
         overrides the instance-wide ENABLE_CONTAINER_LOGS env var.
         """
-        th_config = (self.config or {}).get("th_config") or {}
-        override = th_config.get("enable_container_logs")
+        override = get_th_config_value(self.config, "enable_container_logs")
         if override is not None:
             return bool(override)
         return settings.ENABLE_CONTAINER_LOGS

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -23,6 +23,7 @@ from typing import Generator, cast
 import loguru
 
 from app.constants.shared_constants import NFC_PAIRING_MODES, DutPairingModeEnum
+from app.core.config import settings
 from app.schemas.test_environment_config import ThreadAutoConfig
 from app.test_engine.logger import PYTHON_TEST_LEVEL
 from app.test_engine.logger import test_engine_logger as logger
@@ -203,6 +204,18 @@ def __retrieve_storage_path(config: TestEnvironmentConfigMatter) -> Path:
     return storage_path
 
 
+def _container_logs_enabled(config: TestEnvironmentConfigMatter) -> bool:
+    """Whether container-operation logging is enabled.
+
+    The project's th_config.enable_container_logs, when explicitly set,
+    overrides the instance-wide ENABLE_CONTAINER_LOGS env var.
+    """
+    override = config.th_config.enable_container_logs if config.th_config else None
+    if override is not None:
+        return bool(override)
+    return settings.ENABLE_CONTAINER_LOGS
+
+
 def __copy_admin_storage_file(
     config: TestEnvironmentConfigMatter,
     logger: loguru.Logger,
@@ -216,6 +229,7 @@ def __copy_admin_storage_file(
         container_file_path=Path(storage_path),
         destination_path=ADMIN_STORAGE_FILE_HOST_PATH,
         destination_file_name=ADMIN_STORAGE_FILE_DEFAULT_NAME,
+        enable_container_logs=_container_logs_enabled(config),
     )
 
 
@@ -270,6 +284,7 @@ async def commission_device(
         prefix=EXECUTABLE,
         is_stream=True,
         is_socket=False,
+        enable_container_logs=_container_logs_enabled(config),
     )
 
     handle_logs(cast(Generator, exec_result.output), logger)

--- a/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
+++ b/test_collections/matter/sdk_tests/support/python_testing/models/utils.py
@@ -351,6 +351,7 @@ async def should_perform_new_commissioning(
             sdk_container.copy_file_to_container(
                 host_file_path=ADMIN_STORAGE_FILE_HOST,
                 destination_container_path=storage_path,
+                enable_container_logs=_container_logs_enabled(config),
             )
             return False
 

--- a/test_collections/matter/sdk_tests/support/sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/sdk_container.py
@@ -22,11 +22,11 @@ import loguru
 from docker.models.containers import Container
 
 from app.container_manager import container_manager
+from app.container_manager.container_manager import resolve_container_logs_enabled
 from app.container_manager.docker_shell_commands import (
     SHELL_CMD_LOG_PREFIX,
     docker_exec_command,
 )
-from app.core.config import settings
 from app.schemas.pics import PICS, PICSError
 from app.singleton import Singleton
 from app.test_engine.logger import test_engine_logger as logger
@@ -136,14 +136,18 @@ class SDKContainer(metaclass=Singleton):
     def pics_file_created(self) -> bool:
         return self.__pics_file_created
 
-    def __destroy_existing_container(self) -> None:
+    def __destroy_existing_container(
+        self, enable_container_logs: Optional[bool] = None
+    ) -> None:
         """This will kill and remove any existing container using the same name."""
         existing_container = container_manager.get_container(self.container_name)
         if existing_container is not None:
             logger.info(
                 f'Existing container named "{self.container_name}" found. Destroying.'
             )
-            container_manager.destroy(existing_container)
+            container_manager.destroy(
+                existing_container, enable_container_logs=enable_container_logs
+            )
 
     def is_running(self) -> bool:
         if self.__container is None:
@@ -151,7 +155,7 @@ class SDKContainer(metaclass=Singleton):
         else:
             return container_manager.is_running(self.__container)
 
-    async def start(self) -> None:
+    async def start(self, enable_container_logs: Optional[bool] = None) -> None:
         """Creates the SDK container.
 
         Returns only when the container is created.
@@ -164,11 +168,13 @@ class SDKContainer(metaclass=Singleton):
             return
 
         # Ensure there's no existing container running using the same name.
-        self.__destroy_existing_container()
+        self.__destroy_existing_container(enable_container_logs)
 
         # Async return when the container is running
         self.__container = await container_manager.create_container(
-            self.image_tag, self.run_parameters
+            self.image_tag,
+            self.run_parameters,
+            enable_container_logs=enable_container_logs,
         )
 
         self.logger.info(
@@ -176,10 +182,12 @@ class SDKContainer(metaclass=Singleton):
             f" with configuration: {self.run_parameters}"
         )
 
-    def destroy(self) -> None:
+    def destroy(self, enable_container_logs: Optional[bool] = None) -> None:
         """Destroy the container."""
         if self.__container is not None:
-            container_manager.destroy(self.__container)
+            container_manager.destroy(
+                self.__container, enable_container_logs=enable_container_logs
+            )
         self.__container = None
 
     def send_command(
@@ -189,6 +197,7 @@ class SDKContainer(metaclass=Singleton):
         is_stream: bool = False,
         is_socket: bool = False,
         is_detach: bool = False,
+        enable_container_logs: Optional[bool] = None,
     ) -> ExecResultExtended:
         if self.__container is None:
             raise SDKContainerNotRunning()
@@ -203,7 +212,7 @@ class SDKContainer(metaclass=Singleton):
         self.logger.info("Sending command to SDK container: " + full_cmd_str)
 
         # Log equivalent shell command
-        if settings.ENABLE_CONTAINER_LOGS:
+        if resolve_container_logs_enabled(enable_container_logs):
             shell_cmd = docker_exec_command(
                 self.container_name,
                 full_cmd_str,
@@ -268,19 +277,25 @@ class SDKContainer(metaclass=Singleton):
         container_file_path: Path,
         destination_path: Path,
         destination_file_name: str,
+        enable_container_logs: Optional[bool] = None,
     ) -> None:
         container_manager.copy_file_from_container(
             container=self.__container,
             container_file_path=container_file_path,
             destination_path=destination_path,
             destination_file_name=destination_file_name,
+            enable_container_logs=enable_container_logs,
         )
 
     def copy_file_to_container(
-        self, host_file_path: Path, destination_container_path: Path
+        self,
+        host_file_path: Path,
+        destination_container_path: Path,
+        enable_container_logs: Optional[bool] = None,
     ) -> None:
         container_manager.copy_file_to_container(
             container=self.__container,
             host_file_path=host_file_path,
             destination_container_path=destination_container_path,
+            enable_container_logs=enable_container_logs,
         )

--- a/test_collections/matter/sdk_tests/support/tests/chip/test_chip_server.py
+++ b/test_collections/matter/sdk_tests/support/tests/chip/test_chip_server.py
@@ -100,7 +100,11 @@ async def test_start_waiting_failure() -> None:
         await chip_server.start(server_type)
 
     mock_send_command.assert_called_once_with(
-        expected_command, prefix=expected_prefix, is_stream=True, is_socket=False
+        expected_command,
+        prefix=expected_prefix,
+        is_stream=True,
+        is_socket=False,
+        enable_container_logs=None,
     )
     assert chip_server._ChipServer__server_logs == mock_result.output
     assert chip_server._ChipServer__chip_server_id == mock_result.exec_id
@@ -136,7 +140,11 @@ async def test_start_chip_tool() -> None:
         await chip_server.start(server_type, use_paa_certs=False)
 
     mock_send_command.assert_called_once_with(
-        expected_command, prefix=expected_prefix, is_stream=True, is_socket=False
+        expected_command,
+        prefix=expected_prefix,
+        is_stream=True,
+        is_socket=False,
+        enable_container_logs=None,
     )
     assert chip_server._ChipServer__server_logs == mock_result.output
     assert chip_server._ChipServer__chip_server_id == mock_result.exec_id
@@ -177,7 +185,11 @@ async def test_start_chip_tool_using_paa_certs() -> None:
         await chip_server.start(server_type, use_paa_certs=True)
 
     mock_send_command.assert_called_once_with(
-        expected_command, prefix=expected_prefix, is_stream=True, is_socket=False
+        expected_command,
+        prefix=expected_prefix,
+        is_stream=True,
+        is_socket=False,
+        enable_container_logs=None,
     )
     assert chip_server._ChipServer__server_logs == mock_result.output
     assert chip_server._ChipServer__chip_server_id == mock_result.exec_id
@@ -214,7 +226,11 @@ async def test_start_chip_app() -> None:
         await chip_server.start(server_type, use_paa_certs=False)
 
     mock_send_command.assert_called_once_with(
-        expected_command, prefix=expected_prefix, is_stream=True, is_socket=False
+        expected_command,
+        prefix=expected_prefix,
+        is_stream=True,
+        is_socket=False,
+        enable_container_logs=None,
     )
     assert chip_server._ChipServer__server_logs == mock_result.output
     assert chip_server._ChipServer__chip_server_id == mock_result.exec_id
@@ -255,7 +271,11 @@ async def test_start_chip_app_using_paa_certs() -> None:
         await chip_server.start(server_type, use_paa_certs=True)
 
     mock_send_command.assert_called_once_with(
-        expected_command, prefix=expected_prefix, is_stream=True, is_socket=False
+        expected_command,
+        prefix=expected_prefix,
+        is_stream=True,
+        is_socket=False,
+        enable_container_logs=None,
     )
     assert chip_server._ChipServer__server_logs == mock_result.output
     assert chip_server._ChipServer__server_started is True

--- a/test_collections/matter/sdk_tests/support/tests/matter/test_test_environment_config.py
+++ b/test_collections/matter/sdk_tests/support/tests/matter/test_test_environment_config.py
@@ -51,6 +51,25 @@ def test_create_config_matter_with_th_config_round_trips() -> None:
     assert config_matter.th_config is not None
     assert config_matter.th_config.prompt_timeout_seconds == 120
     assert config_matter.th_config.enable_realtime_python_test_logs is True
+    assert config_matter.th_config.enable_container_logs is True
+
+
+def test_create_config_matter_with_no_th_config_enable_container_logs_defaults_none() -> (  # noqa: E501
+    None
+):
+    config_matter = TestEnvironmentConfigMatter(**default_matter_config)
+
+    assert config_matter.th_config is None
+
+
+def test_create_config_matter_with_invalid_enable_container_logs_type_fails() -> None:
+    config = {
+        **default_matter_config,
+        "th_config": {"enable_container_logs": "not-a-bool"},
+    }
+
+    with pytest.raises(TestEnvironmentConfigError):
+        TestEnvironmentConfigMatter(**config)
 
 
 def test_create_config_matter_with_invalid_th_config_type_fails() -> None:

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_case.py
@@ -822,6 +822,41 @@ def test_realtime_logs_enabled_defers_to_env_when_th_config_absent() -> None:
         assert instance._realtime_logs_enabled() is True
 
 
+@pytest.mark.parametrize(
+    "th_config_value, env_value, expected",
+    [
+        (True, False, True),  # config override True beats env False
+        (False, True, False),  # config override False beats env True
+        (None, True, True),  # unset config defers to env True
+        (None, False, False),  # unset config defers to env False
+    ],
+)
+def test_container_logs_enabled_matrix(
+    th_config_value: Optional[bool], env_value: bool, expected: bool
+) -> None:
+    instance = _instance_with_project_config(
+        {"th_config": {"enable_container_logs": th_config_value}}
+    )
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".settings"
+    ) as mock_settings:
+        mock_settings.ENABLE_CONTAINER_LOGS = env_value
+        assert instance._container_logs_enabled() is expected
+
+
+def test_container_logs_enabled_defers_to_env_when_th_config_absent() -> None:
+    instance = _instance_with_project_config({})
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_case"
+        ".settings"
+    ) as mock_settings:
+        mock_settings.ENABLE_CONTAINER_LOGS = True
+        assert instance._container_logs_enabled() is True
+
+
 def test_extract_logs_for_step_matches_composite_label() -> None:
     """Regression test for issue #1072: composite/alphanumeric step labels
     (e.g. from privilege-level loops such as TC-ACE-2.4) must be matched

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
@@ -630,9 +630,7 @@ async def test_should_perform_new_commissioning_no() -> None:
     ],
 )
 def test_container_logs_enabled_matrix(
-    th_config_value: Optional[bool],
-    env_value: bool,
-    expected: bool
+    th_config_value: Optional[bool], env_value: bool, expected: bool
 ) -> None:
     suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
         suite_type=SuiteType.NO_COMMISSIONING,

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
@@ -618,3 +618,58 @@ async def test_should_perform_new_commissioning_no() -> None:
         python_suite_setup.assert_called_once()
         mock_prompt_commissioning.assert_not_called()
         mock_commission_device.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "th_config_value, env_value, expected",
+    [
+        (True, False, True),  # config override True beats env False
+        (False, True, False),  # config override False beats env True
+        (None, True, True),  # unset config defers to env True
+        (None, False, False),  # unset config defers to env False
+    ],
+)
+def test_container_logs_enabled_matrix(
+    th_config_value, env_value, expected
+) -> None:
+    suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
+        suite_type=SuiteType.NO_COMMISSIONING,
+        name="SomeSuite",
+        python_test_version="some_version",
+        mandatory=False,
+    )
+    suite_instance = suite_class(TestSuiteExecution())
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".PythonTestSuite.config",
+        new_callable=mock.PropertyMock,
+        return_value={"th_config": {"enable_container_logs": th_config_value}},
+    ), mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".settings"
+    ) as mock_settings:
+        mock_settings.ENABLE_CONTAINER_LOGS = env_value
+        assert suite_instance._container_logs_enabled() is expected
+
+
+def test_container_logs_enabled_defers_to_env_when_th_config_absent() -> None:
+    suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
+        suite_type=SuiteType.NO_COMMISSIONING,
+        name="SomeSuite",
+        python_test_version="some_version",
+        mandatory=False,
+    )
+    suite_instance = suite_class(TestSuiteExecution())
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".PythonTestSuite.config",
+        new_callable=mock.PropertyMock,
+        return_value={},
+    ), mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.test_suite"
+        ".settings"
+    ) as mock_settings:
+        mock_settings.ENABLE_CONTAINER_LOGS = True
+        assert suite_instance._container_logs_enabled() is True

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
@@ -629,9 +629,7 @@ async def test_should_perform_new_commissioning_no() -> None:
         (None, False, False),  # unset config defers to env False
     ],
 )
-def test_container_logs_enabled_matrix(
-    th_config_value, env_value, expected
-) -> None:
+def test_container_logs_enabled_matrix(th_config_value, env_value, expected) -> None:
     suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
         suite_type=SuiteType.NO_COMMISSIONING,
         name="SomeSuite",

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_python_test_suite.py
@@ -15,7 +15,7 @@
 #
 # flake8: noqa
 # Ignore flake8 check for this file
-from typing import Type
+from typing import Optional, Type
 from unittest import mock
 
 import pytest
@@ -629,7 +629,11 @@ async def test_should_perform_new_commissioning_no() -> None:
         (None, False, False),  # unset config defers to env False
     ],
 )
-def test_container_logs_enabled_matrix(th_config_value, env_value, expected) -> None:
+def test_container_logs_enabled_matrix(
+    th_config_value: Optional[bool],
+    env_value: bool,
+    expected: bool
+) -> None:
     suite_class: Type[PythonTestSuite] = PythonTestSuite.class_factory(
         suite_type=SuiteType.NO_COMMISSIONING,
         name="SomeSuite",

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -624,6 +624,10 @@ async def test_commission_device() -> None:
         ".log_test_output_file"
     ) as mock_log_test_output, mock.patch.object(
         target=sdk_container, attribute="exec_exit_code", return_value=0
+    ), mock.patch(
+        target="test_collections.matter.sdk_tests.support.python_testing.models.utils"
+        ".settings.ENABLE_CONTAINER_LOGS",
+        new=False,
     ):
         await commission_device(
             default_environment_config, test_engine_logger  # type: ignore
@@ -660,6 +664,10 @@ async def test_commission_device_failure() -> None:
         ".handle_logs"
     ) as mock_handle_logs, mock.patch.object(
         target=sdk_container, attribute="exec_exit_code", return_value=1
+    ), mock.patch(
+        target="test_collections.matter.sdk_tests.support.python_testing.models.utils"
+        ".settings.ENABLE_CONTAINER_LOGS",
+        new=False,
     ), pytest.raises(
         DUTCommissioningError
     ):

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -30,11 +30,14 @@ from ...exec_run_in_container import ExecResultExtended
 from ...python_testing.models.utils import (
     EXECUTABLE,
     RUNNER_CLASS_PATH,
+    ADMIN_STORAGE_FILE_HOST,
     DUTCommissioningError,
+    PromptOption,
     _container_logs_enabled,
     capture_admin_storage_file,
     commission_device,
     generate_command_arguments,
+    should_perform_new_commissioning,
 )
 from ...sdk_container import SDKContainer
 
@@ -683,6 +686,46 @@ async def test_commission_device_failure() -> None:
         enable_container_logs=False,
     )
     mock_handle_logs.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Tests for should_perform_new_commissioning (admin_storage.json reuse prompt)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_should_perform_new_commissioning_copies_file_with_container_logs() -> (
+    None
+):
+    """Regression test: the copy_file_to_container call here must thread through
+    enable_container_logs, like its sibling commission_device/
+    __copy_admin_storage_file calls in this same module do."""
+    sdk_container: SDKContainer = SDKContainer()
+    mock_storage_host = mock.MagicMock()
+    mock_storage_host.exists.return_value = True
+
+    with mock.patch.object(
+        target=sdk_container, attribute="copy_file_to_container"
+    ) as mock_copy, mock.patch(
+        target="test_collections.matter.sdk_tests.support.python_testing.models.utils"
+        ".ADMIN_STORAGE_FILE_HOST",
+        new=mock_storage_host,
+    ), mock.patch(
+        target="test_collections.matter.sdk_tests.support.python_testing.models.utils"
+        ".prompt_reuse_commissioning",
+        return_value=PromptOption.PASS,
+    ), mock.patch(
+        target="test_collections.matter.sdk_tests.support.python_testing.models.utils"
+        ".settings.ENABLE_CONTAINER_LOGS",
+        new=True,
+    ):
+        result = await should_perform_new_commissioning(
+            mock.Mock(), default_environment_config, test_engine_logger  # type: ignore
+        )
+
+    assert result is False
+    mock_copy.assert_called_once()
+    assert mock_copy.call_args.kwargs["enable_container_logs"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -31,6 +31,7 @@ from ...python_testing.models.utils import (
     EXECUTABLE,
     RUNNER_CLASS_PATH,
     DUTCommissioningError,
+    _container_logs_enabled,
     capture_admin_storage_file,
     commission_device,
     generate_command_arguments,
@@ -629,7 +630,11 @@ async def test_commission_device() -> None:
         )
 
     mock_send_command.assert_called_once_with(
-        expected_command, prefix=EXECUTABLE, is_stream=True, is_socket=False
+        expected_command,
+        prefix=EXECUTABLE,
+        is_stream=True,
+        is_socket=False,
+        enable_container_logs=False,
     )
     mock_handle_logs.assert_called_once()
     mock_log_test_output.assert_called_once()
@@ -663,7 +668,11 @@ async def test_commission_device_failure() -> None:
         )
 
     mock_send_command.assert_called_once_with(
-        expected_command, prefix=EXECUTABLE, is_stream=True, is_socket=False
+        expected_command,
+        prefix=EXECUTABLE,
+        is_stream=True,
+        is_socket=False,
+        enable_container_logs=False,
     )
     mock_handle_logs.assert_called_once()
 
@@ -1009,3 +1018,56 @@ async def test_nfc_reader_index_not_injected_for_non_nfc_modes() -> None:
     arguments = await generate_command_arguments(cfg)
     joined = " ".join(arguments)
     assert "NFC_Reader_index" not in joined
+
+
+# ---------------------------------------------------------------------------
+# Tests for _container_logs_enabled
+# ---------------------------------------------------------------------------
+
+
+def test_container_logs_enabled_uses_th_config_override_true() -> None:
+    config = default_environment_config.copy(deep=True)  # type: ignore
+    config.th_config.enable_container_logs = True
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.utils"
+        ".settings"
+    ) as mock_settings:
+        mock_settings.ENABLE_CONTAINER_LOGS = False
+        assert _container_logs_enabled(config) is True
+
+
+def test_container_logs_enabled_uses_th_config_override_false() -> None:
+    config = default_environment_config.copy(deep=True)  # type: ignore
+    config.th_config.enable_container_logs = False
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.utils"
+        ".settings"
+    ) as mock_settings:
+        mock_settings.ENABLE_CONTAINER_LOGS = True
+        assert _container_logs_enabled(config) is False
+
+
+def test_container_logs_enabled_defers_to_env_when_unset() -> None:
+    config = default_environment_config.copy(deep=True)  # type: ignore
+    config.th_config.enable_container_logs = None
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.utils"
+        ".settings"
+    ) as mock_settings:
+        mock_settings.ENABLE_CONTAINER_LOGS = True
+        assert _container_logs_enabled(config) is True
+
+
+def test_container_logs_enabled_defers_to_env_when_th_config_none() -> None:
+    config = default_environment_config.copy(deep=True)  # type: ignore
+    config.th_config = None
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.python_testing.models.utils"
+        ".settings"
+    ) as mock_settings:
+        mock_settings.ENABLE_CONTAINER_LOGS = False
+        assert _container_logs_enabled(config) is False

--- a/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/python_tests/test_utils.py
@@ -30,7 +30,6 @@ from ...exec_run_in_container import ExecResultExtended
 from ...python_testing.models.utils import (
     EXECUTABLE,
     RUNNER_CLASS_PATH,
-    ADMIN_STORAGE_FILE_HOST,
     DUTCommissioningError,
     PromptOption,
     _container_logs_enabled,

--- a/test_collections/matter/sdk_tests/support/tests/test_sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/tests/test_sdk_container.py
@@ -45,7 +45,7 @@ async def test_start(real_sdk_container) -> None:  # noqa
         await real_sdk_container.start()
 
     mock_create_container.assert_called_once_with(
-        docker_image, real_sdk_container.run_parameters
+        docker_image, real_sdk_container.run_parameters, enable_container_logs=None
     )
     assert real_sdk_container._SDKContainer__container is not None
 
@@ -165,6 +165,83 @@ async def test_send_command_default_prefix(real_sdk_container) -> None:  # noqa
         detach=False,
     )
     assert result == mock_result
+
+    # clean up:
+    real_sdk_container._SDKContainer__last_exec_id = None
+    real_sdk_container._SDKContainer__container = None
+
+
+@pytest.mark.asyncio
+async def test_send_command_logs_shell_command_when_enabled(
+    real_sdk_container,
+) -> None:  # noqa
+    fake_container = make_fake_container()
+    mock_result = ExecResultExtended(0, "log output".encode(), "ID", mock.MagicMock())
+
+    with mock.patch.object(
+        target=real_sdk_container, attribute="is_running", return_value=False
+    ), mock.patch.object(
+        target=container_manager, attribute="get_container", return_value=None
+    ), mock.patch.object(
+        target=container_manager,
+        attribute="create_container",
+        return_value=fake_container,
+    ), mock.patch(
+        target=(
+            "test_collections.matter.sdk_tests.support.sdk_container"
+            ".exec_run_in_container"
+        ),
+        return_value=mock_result,
+    ), mock.patch(
+        target="test_collections.matter.sdk_tests.support.sdk_container.logger"
+    ) as mock_logger:
+        await real_sdk_container.start()
+
+        real_sdk_container.send_command(
+            "--help", prefix="cmd-prefix", enable_container_logs=True
+        )
+
+    mock_logger.info.assert_any_call(mock.ANY)
+    # One "Sending command..." line plus one for the equivalent shell command.
+    assert mock_logger.info.call_count == 2
+
+    # clean up:
+    real_sdk_container._SDKContainer__last_exec_id = None
+    real_sdk_container._SDKContainer__container = None
+
+
+@pytest.mark.asyncio
+async def test_send_command_does_not_log_shell_command_when_disabled(
+    real_sdk_container,
+) -> None:  # noqa
+    fake_container = make_fake_container()
+    mock_result = ExecResultExtended(0, "log output".encode(), "ID", mock.MagicMock())
+
+    with mock.patch.object(
+        target=real_sdk_container, attribute="is_running", return_value=False
+    ), mock.patch.object(
+        target=container_manager, attribute="get_container", return_value=None
+    ), mock.patch.object(
+        target=container_manager,
+        attribute="create_container",
+        return_value=fake_container,
+    ), mock.patch(
+        target=(
+            "test_collections.matter.sdk_tests.support.sdk_container"
+            ".exec_run_in_container"
+        ),
+        return_value=mock_result,
+    ), mock.patch(
+        target="test_collections.matter.sdk_tests.support.sdk_container.logger"
+    ) as mock_logger:
+        await real_sdk_container.start()
+
+        real_sdk_container.send_command(
+            "--help", prefix="cmd-prefix", enable_container_logs=False
+        )
+
+    # Only the "Sending command..." line, no equivalent shell command line.
+    assert mock_logger.info.call_count == 1
 
     # clean up:
     real_sdk_container._SDKContainer__last_exec_id = None

--- a/test_collections/matter/sdk_tests/support/tests/test_sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/tests/test_sdk_container.py
@@ -192,8 +192,8 @@ async def test_send_command_logs_shell_command_when_enabled(
             ".exec_run_in_container"
         ),
         return_value=mock_result,
-    ), mock.patch(
-        target="test_collections.matter.sdk_tests.support.sdk_container.logger"
+    ), mock.patch.object(
+        real_sdk_container, "logger"
     ) as mock_logger:
         await real_sdk_container.start()
 
@@ -231,8 +231,8 @@ async def test_send_command_does_not_log_shell_command_when_disabled(
             ".exec_run_in_container"
         ),
         return_value=mock_result,
-    ), mock.patch(
-        target="test_collections.matter.sdk_tests.support.sdk_container.logger"
+    ), mock.patch.object(
+        real_sdk_container, "logger"
     ) as mock_logger:
         await real_sdk_container.start()
 

--- a/test_collections/matter/sdk_tests/support/tests/test_sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/tests/test_sdk_container.py
@@ -172,7 +172,9 @@ async def test_send_command_default_prefix(real_sdk_container) -> None:  # noqa
 
 
 @pytest.mark.asyncio
-async def test_send_command_logs_shell_command_when_enabled(real_sdk_container) -> None:  # noqa
+async def test_send_command_logs_shell_command_when_enabled(
+    real_sdk_container,  # noqa
+) -> None:
     fake_container = make_fake_container()
     mock_result = ExecResultExtended(0, "log output".encode(), "ID", mock.MagicMock())
     real_sdk_container._SDKContainer__container = fake_container
@@ -198,7 +200,9 @@ async def test_send_command_logs_shell_command_when_enabled(real_sdk_container) 
 
 
 @pytest.mark.asyncio
-async def test_send_command_does_not_log_shell_command_when_disabled(real_sdk_container) -> None:  # noqa
+async def test_send_command_does_not_log_shell_command_when_disabled(
+    real_sdk_container,  # noqa
+) -> None:
     fake_container = make_fake_container()
     mock_result = ExecResultExtended(0, "log output".encode(), "ID", mock.MagicMock())
     real_sdk_container._SDKContainer__container = fake_container

--- a/test_collections/matter/sdk_tests/support/tests/test_sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/tests/test_sdk_container.py
@@ -172,9 +172,7 @@ async def test_send_command_default_prefix(real_sdk_container) -> None:  # noqa
 
 
 @pytest.mark.asyncio
-async def test_send_command_logs_shell_command_when_enabled(
-    real_sdk_container,
-) -> None:  # noqa
+async def test_send_command_logs_shell_command_when_enabled(real_sdk_container) -> None:  # noqa
     fake_container = make_fake_container()
     mock_result = ExecResultExtended(0, "log output".encode(), "ID", mock.MagicMock())
     real_sdk_container._SDKContainer__container = fake_container
@@ -185,9 +183,7 @@ async def test_send_command_logs_shell_command_when_enabled(
             ".exec_run_in_container"
         ),
         return_value=mock_result,
-    ), mock.patch.object(
-        real_sdk_container, "logger"
-    ) as mock_logger:
+    ), mock.patch.object(real_sdk_container, "logger") as mock_logger:
         real_sdk_container.send_command(
             "--help", prefix="cmd-prefix", enable_container_logs=True
         )
@@ -202,9 +198,7 @@ async def test_send_command_logs_shell_command_when_enabled(
 
 
 @pytest.mark.asyncio
-async def test_send_command_does_not_log_shell_command_when_disabled(
-    real_sdk_container,
-) -> None:  # noqa
+async def test_send_command_does_not_log_shell_command_when_disabled(real_sdk_container) -> None:  # noqa
     fake_container = make_fake_container()
     mock_result = ExecResultExtended(0, "log output".encode(), "ID", mock.MagicMock())
     real_sdk_container._SDKContainer__container = fake_container
@@ -215,9 +209,7 @@ async def test_send_command_does_not_log_shell_command_when_disabled(
             ".exec_run_in_container"
         ),
         return_value=mock_result,
-    ), mock.patch.object(
-        real_sdk_container, "logger"
-    ) as mock_logger:
+    ), mock.patch.object(real_sdk_container, "logger") as mock_logger:
         real_sdk_container.send_command(
             "--help", prefix="cmd-prefix", enable_container_logs=False
         )

--- a/test_collections/matter/sdk_tests/support/tests/test_sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/tests/test_sdk_container.py
@@ -177,16 +177,9 @@ async def test_send_command_logs_shell_command_when_enabled(
 ) -> None:  # noqa
     fake_container = make_fake_container()
     mock_result = ExecResultExtended(0, "log output".encode(), "ID", mock.MagicMock())
+    real_sdk_container._SDKContainer__container = fake_container
 
-    with mock.patch.object(
-        target=real_sdk_container, attribute="is_running", return_value=False
-    ), mock.patch.object(
-        target=container_manager, attribute="get_container", return_value=None
-    ), mock.patch.object(
-        target=container_manager,
-        attribute="create_container",
-        return_value=fake_container,
-    ), mock.patch(
+    with mock.patch(
         target=(
             "test_collections.matter.sdk_tests.support.sdk_container"
             ".exec_run_in_container"
@@ -195,8 +188,6 @@ async def test_send_command_logs_shell_command_when_enabled(
     ), mock.patch.object(
         real_sdk_container, "logger"
     ) as mock_logger:
-        await real_sdk_container.start()
-
         real_sdk_container.send_command(
             "--help", prefix="cmd-prefix", enable_container_logs=True
         )
@@ -216,16 +207,9 @@ async def test_send_command_does_not_log_shell_command_when_disabled(
 ) -> None:  # noqa
     fake_container = make_fake_container()
     mock_result = ExecResultExtended(0, "log output".encode(), "ID", mock.MagicMock())
+    real_sdk_container._SDKContainer__container = fake_container
 
-    with mock.patch.object(
-        target=real_sdk_container, attribute="is_running", return_value=False
-    ), mock.patch.object(
-        target=container_manager, attribute="get_container", return_value=None
-    ), mock.patch.object(
-        target=container_manager,
-        attribute="create_container",
-        return_value=fake_container,
-    ), mock.patch(
+    with mock.patch(
         target=(
             "test_collections.matter.sdk_tests.support.sdk_container"
             ".exec_run_in_container"
@@ -234,8 +218,6 @@ async def test_send_command_does_not_log_shell_command_when_disabled(
     ), mock.patch.object(
         real_sdk_container, "logger"
     ) as mock_logger:
-        await real_sdk_container.start()
-
         real_sdk_container.send_command(
             "--help", prefix="cmd-prefix", enable_container_logs=False
         )

--- a/test_collections/matter/sdk_tests/support/tests/utils/utils.py
+++ b/test_collections/matter/sdk_tests/support/tests/utils/utils.py
@@ -48,6 +48,7 @@ default_matter_config_with_th_config: dict[str, Any] = {
     "th_config": {
         "prompt_timeout_seconds": 120,
         "enable_realtime_python_test_logs": True,
+        "enable_container_logs": True,
     },
 }
 

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_chip_suite.py
@@ -211,6 +211,7 @@ async def test_pair_with_dut_thread_with_external_config_success() -> None:
     mock_gen_code.assert_called_once_with(
         discriminator="3840",
         setup_pin_code="20202021",
+        enable_container_logs=False,
     )
     mock_pairing_thread.assert_called_once_with(
         hex_dataset="0e080000000000010000000300001335060004001fffe002"
@@ -288,6 +289,7 @@ async def test_pair_with_dut_thread_with_auto_config_success() -> None:
     mock_gen_code.assert_called_once_with(
         discriminator="3840",
         setup_pin_code="20202021",
+        enable_container_logs=False,
     )
     mock_pairing_thread.assert_called_once_with(
         hex_dataset="c0ffee123456",
@@ -422,3 +424,67 @@ async def test_pair_with_dut_thread_pairing_fails() -> None:
 
     assert result is False
     mock_pairing_thread.assert_called_once()
+
+
+def _config_dict_with_th_config(th_config: dict) -> dict:
+    return {
+        "network": {
+            "fabric_id": "0",
+            "thread": {
+                "operational_dataset_hex": "0e080000000000010000000300001335060004001ff"
+                "fe00208fedcba9876543210070800000000000000050800000000000000030d4f70656"
+                "e54687265616444656d6f01021234041011223344556677889900aabbccddeeff000c0"
+                "402a0f7f8",
+                "ba_host": "127.0.0.1",
+                "ba_port": 5684,
+            },
+            "wifi": {"ssid": "testharness", "password": "wifi-password"},
+        },
+        "dut_config": {
+            "pairing_mode": "thread-meshcop",
+            "setup_code": "20202021",
+            "discriminator": "3840",
+            "chip_use_paa_certs": False,
+            "trace_log": True,
+        },
+        "test_parameters": None,
+        "th_config": th_config,
+    }
+
+
+@pytest.mark.parametrize(
+    "th_config_value, env_value, expected",
+    [
+        (True, False, True),  # config override True beats env False
+        (False, True, False),  # config override False beats env True
+        (None, True, True),  # unset config defers to env True
+        (None, False, False),  # unset config defers to env False
+    ],
+)
+def test_container_logs_enabled_matrix(th_config_value, env_value, expected) -> None:
+    test_suite = ChipSuite(TestSuiteExecution())
+    config_dict = _config_dict_with_th_config(
+        {"enable_container_logs": th_config_value}
+    )
+    test_suite._ChipSuite__config_matter = TestEnvironmentConfigMatter(**config_dict)
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.yaml_tests.models.chip_suite"
+        ".settings"
+    ) as mock_settings:
+        mock_settings.ENABLE_CONTAINER_LOGS = env_value
+        assert test_suite._container_logs_enabled() is expected
+
+
+def test_container_logs_enabled_defers_to_env_when_th_config_absent() -> None:
+    test_suite = ChipSuite(TestSuiteExecution())
+    config_dict = _config_dict_with_th_config({})
+    del config_dict["th_config"]
+    test_suite._ChipSuite__config_matter = TestEnvironmentConfigMatter(**config_dict)
+
+    with mock.patch(
+        "test_collections.matter.sdk_tests.support.yaml_tests.models.chip_suite"
+        ".settings"
+    ) as mock_settings:
+        mock_settings.ENABLE_CONTAINER_LOGS = True
+        assert test_suite._container_logs_enabled() is True

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_chip_suite.py
@@ -204,7 +204,11 @@ async def test_pair_with_dut_thread_with_external_config_success() -> None:
         target=test_suite.runner,
         attribute="pairing_thread",
         return_value=True,
-    ) as mock_pairing_thread:
+    ) as mock_pairing_thread, mock.patch(
+        "test_collections.matter.sdk_tests.support.yaml_tests.models.chip_suite"
+        ".settings.ENABLE_CONTAINER_LOGS",
+        False,
+    ):
         result = await test_suite._ChipSuite__pair_with_dut_thread()
 
     assert result is True
@@ -280,7 +284,11 @@ async def test_pair_with_dut_thread_with_auto_config_success() -> None:
         target=test_suite.runner,
         attribute="pairing_thread",
         return_value=True,
-    ) as mock_pairing_thread:
+    ) as mock_pairing_thread, mock.patch(
+        "test_collections.matter.sdk_tests.support.yaml_tests.models.chip_suite"
+        ".settings.ENABLE_CONTAINER_LOGS",
+        False,
+    ):
         result = await test_suite._ChipSuite__pair_with_dut_thread()
 
     assert result is True

--- a/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/tests/yaml_tests/test_matter_yaml_runner.py
@@ -51,7 +51,7 @@ async def test_setup() -> None:
     ), mock.patch.object(target=chip_server, attribute="start") as mock_start:
         await runner.setup(server_type, False)
 
-    mock_start.assert_awaited_once_with(server_type, False)
+    mock_start.assert_awaited_once_with(server_type, False, None)
     assert runner._MatterYAMLRunner__test_harness_runner is not None
 
     # clean up:
@@ -71,7 +71,7 @@ async def test_setup_using_paa_certs() -> None:
     ), mock.patch.object(target=chip_server, attribute="start") as mock_start:
         await runner.setup(server_type, use_paa_certs=True)
 
-    mock_start.assert_awaited_once_with(server_type, True)
+    mock_start.assert_awaited_once_with(server_type, True, None)
     assert runner._MatterYAMLRunner__test_harness_runner is not None
 
     # clean up:

--- a/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/matter_yaml_runner.py
@@ -109,7 +109,10 @@ class MatterYAMLRunner(metaclass=Singleton):
         )
 
     async def setup(
-        self, server_type: ChipServerType, use_paa_certs: bool = False
+        self,
+        server_type: ChipServerType,
+        use_paa_certs: bool = False,
+        enable_container_logs: Optional[bool] = None,
     ) -> None:
         self.__pics_file_created = False
 
@@ -117,11 +120,13 @@ class MatterYAMLRunner(metaclass=Singleton):
         web_socket_config.server_address = self.__get_gateway_ip()
         self.__test_harness_runner = WebSocketRunner(config=web_socket_config)
 
-        self.__chip_tool_log = await self.chip_server.start(server_type, use_paa_certs)
+        self.__chip_tool_log = await self.chip_server.start(
+            server_type, use_paa_certs, enable_container_logs
+        )
 
-    async def stop(self) -> None:
+    async def stop(self, enable_container_logs: Optional[bool] = None) -> None:
         await self.stop_runner()
-        await self.chip_server.stop()
+        await self.chip_server.stop(enable_container_logs)
 
     def __get_gateway_ip(self) -> str:
         """

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -74,7 +74,10 @@ class ChipSuite(TestSuite, UserPromptSupport):
         The project's th_config.enable_container_logs, when explicitly set,
         overrides the instance-wide ENABLE_CONTAINER_LOGS env var.
         """
-        th_config = self.config_matter.th_config
+        try:
+            th_config = self.config_matter.th_config
+        except Exception:
+            th_config = None
         override = th_config.enable_container_logs if th_config else None
         if override is not None:
             return bool(override)

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -16,6 +16,7 @@
 from typing import Optional
 
 from app.constants.shared_constants import DutPairingModeEnum
+from app.core.config import settings
 from app.models import TestSuiteExecution
 from app.test_engine.logger import test_engine_logger as logger
 from app.test_engine.models import TestSuite
@@ -67,16 +68,36 @@ class ChipSuite(TestSuite, UserPromptSupport):
 
         return self.__config_matter  # type: ignore
 
+    def _container_logs_enabled(self) -> bool:
+        """Whether container-operation logging is enabled.
+
+        The project's th_config.enable_container_logs, when explicitly set,
+        overrides the instance-wide ENABLE_CONTAINER_LOGS env var.
+        """
+        th_config = self.config_matter.th_config
+        override = th_config.enable_container_logs if th_config else None
+        if override is not None:
+            return bool(override)
+        return settings.ENABLE_CONTAINER_LOGS
+
     async def setup(self) -> None:
         logger.info("Setting up SDK container")
-        await self.sdk_container.start()
+        await self.sdk_container.start(
+            enable_container_logs=self._container_logs_enabled()
+        )
 
         # pcscd is required for NFC reader access regardless of pairing mode
-        self.sdk_container.send_command("--disable-polkit", prefix="pcscd")
+        self.sdk_container.send_command(
+            "--disable-polkit",
+            prefix="pcscd",
+            enable_container_logs=self._container_logs_enabled(),
+        )
 
         logger.info("Setting up test runner")
         await self.runner.setup(
-            self.server_type, self.config_matter.dut_config.chip_use_paa_certs
+            self.server_type,
+            self.config_matter.dut_config.chip_use_paa_certs,
+            enable_container_logs=self._container_logs_enabled(),
         )
 
         if len(self.pics.clusters) > 0:
@@ -248,6 +269,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
         payload = self.runner.chip_server.generate_manual_pairing_code_with_chip_tool(
             discriminator=self.config_matter.dut_config.discriminator or "",
             setup_pin_code=self.config_matter.dut_config.setup_code or "",
+            enable_container_logs=self._container_logs_enabled(),
         )
 
         return await self.runner.pairing_thread(
@@ -283,10 +305,12 @@ class ChipSuite(TestSuite, UserPromptSupport):
                 await self.__prompt_user_to_perform_decommission()
 
         logger.info("Stopping test runner")
-        await self.runner.stop()
+        await self.runner.stop(enable_container_logs=self._container_logs_enabled())
 
         logger.info("Stopping SDK container")
-        self.sdk_container.destroy()
+        self.sdk_container.destroy(
+            enable_container_logs=self._container_logs_enabled()
+        )
 
         if self.border_router is not None:
             logger.info("Stopping border router container")

--- a/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
+++ b/test_collections/matter/sdk_tests/support/yaml_tests/models/chip_suite.py
@@ -311,9 +311,7 @@ class ChipSuite(TestSuite, UserPromptSupport):
         await self.runner.stop(enable_container_logs=self._container_logs_enabled())
 
         logger.info("Stopping SDK container")
-        self.sdk_container.destroy(
-            enable_container_logs=self._container_logs_enabled()
-        )
+        self.sdk_container.destroy(enable_container_logs=self._container_logs_enabled())
 
         if self.border_router is not None:
             logger.info("Stopping border router container")


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/1091
Depends on: https://github.com/project-chip/matter-test-scripts/pull/805
---

### Description
Extends the th_config pattern (introduced in #1038 for prompt timeout and real-time Python logs) to **ENABLE_CONTAINER_LOGS**, so container-operation debug logging can be toggled per-project without editing .env/restarting the backend, while keeping the env var as the instance-wide fallback default.

Unlike the other two th_config flags, this one is checked inside singleton infra classes (**ContainerManager**, **SDKContainer**) with no project-config access — so the override is resolved by .config-aware callers and threaded down as an explicit parameter through the whole call chain: **ChipSuite**/**PythonTestCase**/**PythonTestSuite**/**PayloadParsingTestBaseClass** → **ChipServer**/**MatterYAMLRunner** → **SDKContainer** → **ContainerManager**.
Callers with no config access (otbr_manager.py, test-discovery utilities) are untouched — they keep the env-var-only default.

### Changed
- `schemas/test_environment_config.py`: THConfig.enable_container_logs: Optional[bool] = None; added `get_th_config_value()` helper that tolerates th_config being a plain dict (production shape) or a pydantic object (some test doubles fake .config via Model.__dict__, which doesn't recursively convert nested models).
- `container_manager/container_manager.py`: new resolve_container_logs_enabled(); enable_container_logs param threaded through create_container/destroy/copy_file_from_container/copy_file_to_container.
- sdk_container.py, chip/chip_server.py, yaml_tests/matter_yaml_runner.py: same param threaded through start/stop/send_command/copy_file_*/generate_manual_pairing_code_with_chip_tool/restart.
- **ChipSuite**, **PythonTestCase**, **PythonTestSuite**, **PayloadParsingTestBaseClass** (nested submodule): each gets a `_container_logs_enabled()` resolver, plus a `_safe_config()` guard so it falls back to the env var instead of raising when .config itself is unavailable (e.g. test doubles with no wired-up project chain).
- default_project.config: added th_config.enable_container_logs example.
- Full new unit test coverage for `resolve_container_logs_enabled()` and the emit/suppress behavior of every touched method (previously zero coverage existed for ENABLE_CONTAINER_LOGS at all).
