### PR TITLE
Add wpa_supplicant mount for CNET tests in SDKContainer

### DIFF
--- a/test_collections/matter/sdk_tests/support/sdk_container.py
+++ b/test_collections/matter/sdk_tests/support/sdk_container.py
@@ -47,6 +47,10 @@ DOCKER_PAA_CERTS_PATH = "/paa-root-certs"
 LOCAL_CREDENTIALS_DEVELOPMENT_PATH = Path("/var/credentials/development")
 DOCKER_CREDENTIALS_DEVELOPMENT_PATH = "/credentials/development"
 
+# wpa_supplicant mount (required for CNET tests to manage Wi-Fi networks)
+LOCAL_WPA_SUPPLICANT_PATH = Path("/var/run/wpa_supplicant")
+DOCKER_WPA_SUPPLICANT_PATH = "/var/run/wpa_supplicant"
+
 # Python Testing Folder
 LOCAL_TEST_COLLECTIONS_PATH = (
     "/home/ubuntu/certification-tool/backend/test_collections/matter"
@@ -106,6 +110,10 @@ class SDKContainer(metaclass=Singleton):
             LOCAL_CREDENTIALS_DEVELOPMENT_PATH: {
                 "bind": DOCKER_CREDENTIALS_DEVELOPMENT_PATH,
                 "mode": "ro",
+            },
+            LOCAL_WPA_SUPPLICANT_PATH: {
+                "bind": DOCKER_WPA_SUPPLICANT_PATH,
+                "mode": "rw",
             },
             LOCAL_PYTHON_TESTING_PATH: {
                 "bind": DOCKER_PYTHON_TESTING_PATH,


### PR DESCRIPTION
## Summary

  Adds a `/var/run/wpa_supplicant` volume mount to the `chip-cert-bins` (SDK)
  container that the Test Harness starts automatically, so CNET (Network
  Commissioning cluster) test cases can manage Wi-Fi networks on the host
  without requiring testers to start the container manually with an extra `-v`
  flag.

  ## Background

  CNET Wi-Fi network commissioning tests talk to the host's `wpa_supplicant`
  over its control socket. `SDKContainer.run_parameters["volumes"]` (used by
  `container_manager.create_container(...)` when the TH engine/UI boots the
  container) already mounts `/var/run/dbus/system_bus_socket`, PAA certs,
  credentials, and the python_testing tree — but not `/var/run/wpa_supplicant`.
  Without it, CNET tests run through the automated TH engine can't reach
  `wpa_supplicant`, forcing manual `docker run ... -v 
  /var/run/wpa_supplicant:/var/run/wpa_supplicant ...` workarounds outside the 
  TH.

  ## Changes

  - `test_collections/matter/sdk_tests/support/sdk_container.py`:
    - Added `LOCAL_WPA_SUPPLICANT_PATH` / `DOCKER_WPA_SUPPLICANT_PATH` constants
  (`/var/run/wpa_supplicant`), following the existing mount-constant pattern.
    - Added the corresponding entry to `SDKContainer.run_parameters["volumes"]`
  (`mode: rw`, matching the D-Bus socket mount).

  ## Test plan

  - [ ] Start the SDK container via the TH engine and confirm
  `/var/run/wpa_supplicant` is bind-mounted (`docker inspect <container> | grep
  wpa_supplicant`).
  - [ ] Run a CNET test case through the TH and confirm it can add/update/remove
  Wi-Fi networks without the manual volume workaround.